### PR TITLE
Refactor ResidentService: move HttpClient to Infrastructure. 

### DIFF
--- a/src/Core/Interfaces/ApiClients/IResidentApiClient.cs
+++ b/src/Core/Interfaces/ApiClients/IResidentApiClient.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Domain.Entities;
+
+
+namespace Core.Interfaces.ApiClients;
+
+public interface IResidentApiClient
+{
+    Task<Resident?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Resident>> GetAllAsync(CancellationToken cancellationToken = default);
+
+}

--- a/src/Core/Services/ResidentService.cs
+++ b/src/Core/Services/ResidentService.cs
@@ -1,9 +1,9 @@
 // Copyright (c) 2026 Team6. All rights reserved. 
 //  No warranty, explicit or implicit, provided.
 
-using Core.Interfaces.Repositories;
 
-using System.Net.Http.Json;
+using Core.Interfaces.ApiClients;
+using Core.Interfaces.Repositories;
 
 using Domain.Entities;
 
@@ -22,7 +22,8 @@ namespace Core.Services;
 public class ResidentService
 {
     private readonly IResidentRepository _residentRepository;
-    private readonly HttpClient _httpClient;
+    private readonly IResidentApiClient _residentApiClient;
+
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ResidentService"/> class.
@@ -31,10 +32,11 @@ public class ResidentService
     ///  The dependency injection system now provides: a ResidentRepository and an HttpClient to the ResidentService.
     /// The service can now make HTTP requests to an API.
     /// 
-    public ResidentService(IResidentRepository residentRepository, HttpClient httpClient)
+    public ResidentService(IResidentRepository residentRepository, IResidentApiClient residentApiClient)
     {
         _residentRepository = residentRepository;
-        _httpClient = httpClient;
+        _residentApiClient = residentApiClient;
+        
     }
 
 
@@ -50,13 +52,16 @@ public class ResidentService
     /// <remarks>
     /// This method is now refactored to use an API instead of directly accessing the repository.
     /// </remarks>
-    public async Task<Resident?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    
+    public Task<Resident?> GetByIdAsync(Guid id,CancellationToken cancellationToken = default)
     {
-        return await _httpClient.GetFromJsonAsync<Resident>(
-            $"api/residents/{id}",
-            cancellationToken
-        );
+        return _residentApiClient.GetByIdAsync(id, cancellationToken);
+
     }
+
+
+
+
 
 
     /// <summary>
@@ -73,17 +78,7 @@ public class ResidentService
     /// The JSON response from the API is automatically deserialized into a collection of
     /// <see cref="Resident"/> objects.
     /// </remarks>
-    public async Task<IEnumerable<Resident>> GetAllAsync(CancellationToken cancellationToken = default)
-    {
-        var residents = await _httpClient.GetFromJsonAsync<IEnumerable<Resident>>(
-            "api/residents",
-            cancellationToken
-        );
-
-        //null-coalescing operator.If residents is null, return an empty list instead.
-        return residents ?? new List<Resident>();
-
-    }
+    
 
 
 

--- a/src/Infrastructure/Services/ResidentApiClient.cs
+++ b/src/Infrastructure/Services/ResidentApiClient.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net.Http.Json;
+using Domain.Entities;
+using Core.Interfaces.ApiClients;
+namespace Infrastructure.Services;
+
+using System.Net.Http.Json;
+
+using Core.Interfaces; 
+
+using Domain.Entities;
+
+public class ResidentApiClient : IResidentApiClient
+{
+    private readonly HttpClient _httpClient;
+
+    public ResidentApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public Task<Resident?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        return _httpClient.GetFromJsonAsync<Resident>(
+            $"api/residents/{id}",ct);
+    }
+
+    public async Task<IEnumerable<Resident>> GetAllAsync(CancellationToken ct = default)
+    {
+        var residents = await _httpClient.GetFromJsonAsync<IEnumerable<Resident>>(
+            "api/residents",ct);
+
+        return residents ?? new List<Resident>();
+    }
+}

--- a/src/WebUI/WebUI/Program.cs
+++ b/src/WebUI/WebUI/Program.cs
@@ -1,7 +1,11 @@
 // Copyright (c) 2026 Team6. All rights reserved. 
 //  No warranty, explicit or implicit, provided.
 
+using Core.Interfaces.ApiClients;
+using Core.Services;
+
 using Infrastructure;
+using Infrastructure.Services;
 
 using WebUI.Components;
 
@@ -42,6 +46,10 @@ public class Program
             .AddInteractiveWebAssemblyComponents();
 
         _ = builder.Services.AddInfrastructure();
+
+        //Add ResidentService and API client 
+        builder.Services.AddHttpClient<IResidentApiClient, ResidentApiClient>();
+        builder.Services.AddScoped<ResidentService>();
 
         WebApplication app = builder.Build();
 


### PR DESCRIPTION
hej Micheal gjorde mig opmærksom på at jeg havde skrevet httpclkient kode delene et forkert sted. har nu fjernet al direkte HttpClient-brug fra ResidentService og Introduceret IResidentApiClient i Core/Interfaces/ApiClients, håber det er korretk nu og beklager for fejl, men bliv endelig hved med at give mig feedback. værdsætter det. 