### PR TITLE
UC003: Implemented medicine status ERD, repository, handler. 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,9 +4,11 @@
     <PackageVersion Include="DotNetEnv" Version="3.1.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.23" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.23" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.25" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" Version="2.1.0" />

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -7,10 +7,12 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
-    <ProjectReference Include="..\Core\Core.csproj" /> 
+    <ProjectReference Include="..\Core\Core.csproj" />
+    <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" /> 
   </ItemGroup>
   
 </Project>

--- a/src/Api/Controllers/MedicineController.cs
+++ b/src/Api/Controllers/MedicineController.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+using Core.Handlers;
+using Core.DTOs;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Controllers;
+
+
+[ApiController]
+[Route("api/[controller]")]
+public class MedicineController : Controller
+{
+    private readonly MedicineStatusHandler _handler;
+
+    public MedicineController(MedicineStatusHandler handler)
+    {
+        _handler = handler;
+    }
+
+    // GET: api/medicine/{residentId}
+    [HttpGet("{residentId}")]
+    public async Task<ActionResult<MedicineStatusDto>> GetMedicineStatus(Guid residentId)
+    {
+        var result = await _handler.GetMedicineStatusAsync(residentId);
+
+        if (result == null)
+            return NotFound();
+
+        return Ok(result);
+    }
+
+    // GET: api/medicine/painkiller/{residentId}
+    [HttpGet("painkiller/{residentId}")]
+    public async Task<ActionResult<PainkillerStatusDto>> GetPainkillerStatus(Guid residentId)
+    {
+        var result = await _handler.GetPainkillerStatusAsync(residentId);
+        return Ok(result);
+    }
+
+
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,6 +1,13 @@
 // Copyright (c) 2026 Team6. All rights reserved. 
 //  No warranty, explicit or implicit, provided.
 
+using Core.Handlers;
+using Core.Interfaces;
+using Core.Interfaces.Repositories;
+using Infrastructure.Persistents;
+using Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+
 
 // For SwaggerGen extension methods
 
@@ -11,6 +18,16 @@ public class Program
     public static void Main(string[] args)
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+
+        //  Adds DbContext
+        builder.Services.AddDbContext<AppDbContext>(options =>
+            options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+        //Adds repository and handler
+        builder.Services.AddScoped<IMedicineRepository, MedicineRepository>();
+        builder.Services.AddScoped<MedicineStatusHandler>();
+
 
         // Add services to the container.
 

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 

--- a/src/Core/DTOs/MedicineStatusDto.cs
+++ b/src/Core/DTOs/MedicineStatusDto.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Core.DTOs;
+
+public class MedicineStatusDto
+{
+
+    public string ResidentId { get; set; } = string.Empty;
+    public string[] Medicine { get; set; } = Array.Empty<string>();
+    public DateTime[] Timestamps { get; set; } = Array.Empty<DateTime>();
+    public bool[] Given { get; set; } = Array.Empty<bool>();
+
+}

--- a/src/Core/DTOs/PainkillerStatusDto.cs
+++ b/src/Core/DTOs/PainkillerStatusDto.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Core.DTOs;
+
+public class PainkillerStatusDto
+{
+
+    public Guid ResidentId { get; set; }
+    public string[] Types { get; set; } = Array.Empty<string>();
+    public DateTime NextAllowedTime { get; set; }
+}

--- a/src/Core/Handlers/MedicineStatusHandler.cs
+++ b/src/Core/Handlers/MedicineStatusHandler.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Core.DTOs;
+using Microsoft.EntityFrameworkCore;
+using Core.Interfaces.Repositories;
+
+namespace Core.Handlers;
+
+/// <summary>
+/// Handles retrieval of medicine and painkiller status for a resident.
+/// This class acts as a thin abstraction layer over <see cref="IMedicineRepository"/>.
+/// </summary>
+/// <remarks>
+/// This handler does not contain business logic. It simply forwards calls to the repository.
+/// It exists to decouple higher-level services from direct repository access.
+/// </remarks>
+
+public class MedicineStatusHandler
+{
+
+    //Repository used to fetch medicine-related data
+    private readonly IMedicineRepository _repository;
+
+    //Repository implementation used to retrieve medicine and painkiller status data
+    public MedicineStatusHandler(IMedicineRepository repository)
+    {
+           _repository = repository;
+    }
+
+
+    /// Retrieves the medicine status for a specific resident by delegating to the repository.
+    /// A task that represents the asynchronous operation. 
+    /// The task result contains the <see cref="MedicineStatusDto"/> for the resident.
+    /// </returns>
+    public Task<MedicineStatusDto> GetMedicineStatusAsync(Guid residentId, CancellationToken cancellationToken = default) =>
+    
+         _repository.GetMedicineStatusAsync(residentId, cancellationToken);
+
+
+    
+    // Retrieves the painkiller status for a specific resident.
+    /// A task that represents the asynchronous operation. 
+    /// The task result contains the <see cref="PainkillerStatusDto"/> for the resident
+    public Task<PainkillerStatusDto> GetPainkillerStatusAsync(Guid residentId, CancellationToken cancellationToken = default) =>
+
+        _repository.GetPainkillerStatusAsync(residentId, cancellationToken);
+
+
+
+}

--- a/src/Core/Interfaces/Repositories/IMedicineRepository.cs
+++ b/src/Core/Interfaces/Repositories/IMedicineRepository.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Core.DTOs;
+
+namespace Core.Interfaces.Repositories;
+
+
+/// <summary>
+/// Core only knows about this interface.
+/// EF Core or DbContext lives in Infrastructure.
+/// </summary>
+/// 
+
+public interface IMedicineRepository
+{
+    Task<MedicineStatusDto> GetMedicineStatusAsync(Guid residentId, CancellationToken cancellationToken = default);
+    Task<PainkillerStatusDto> GetPainkillerStatusAsync(Guid residentId, CancellationToken cancellationToken = default);
+
+}

--- a/src/Infrastructure/Database/Entities/MedicineAdministrationEntity.cs
+++ b/src/Infrastructure/Database/Entities/MedicineAdministrationEntity.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+
+namespace Infrastructure.Database.Entities;
+
+/// <summary>
+/// Represents a medicine administration in the database.
+/// Each record indicates whether a specific medicine was given
+/// to a resident at a specific time.
+/// </summary>
+
+public class MedicineAdministrationEntity
+{
+    // Primary key medicine administration record
+    [Key]
+    public Guid Id { get; set; }
+
+
+    // Foreign key to the resident who received the medicine
+    [Required]
+    public Guid ResidentId { get; set; }
+
+
+    // Navigation property to the related resident entity
+    [ForeignKey(nameof(ResidentId))]
+    public virtual ResidentEntity Resident { get; set; } = null!;
+
+  
+    // Name of the medicine administered.
+    [Required]
+    [MaxLength(100)]
+    public string MedicineName { get; set; } = string.Empty;
+
+    
+    //Timestamp indicating when the medicine should be or was given.
+    [Required]
+    public DateTime Timestamp { get; set; }
+
+   
+    // Indicates whether the medicine was given (true) or not (false).
+    [Required]
+    public bool Given { get; set; }
+
+}

--- a/src/Infrastructure/Database/Entities/PainkillerAdministrationEntity.cs
+++ b/src/Infrastructure/Database/Entities/PainkillerAdministrationEntity.cs
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Infrastructure.Database.Entities;
+
+/// <summary>
+/// Represents a painkiller administration in the database.
+/// Each record tracks painkiller given to a resident,
+/// and the time when the next dose is allowed.
+/// </summary>
+
+public class PainkillerAdministrationEntity
+{
+    // Primary key for the painkiller administration record
+    [Key]
+    public Guid Id { get; set; }
+
+    // Foreign key referencing the resident.
+    [Required]
+    public Guid ResidentId { get; set; }
+
+   
+    // Navigation property to the related resident.
+    [ForeignKey(nameof(ResidentId))]
+    public virtual ResidentEntity Resident { get; set; } = null!;
+
+    
+    // What type of painkiller administered
+    [Required]
+    [MaxLength(100)]
+    public string Type { get; set; } = string.Empty;
+
+    
+    /// Times when the painkiller was administered.
+    [Required]
+    public DateTime GivenAt { get; set; }
+
+    
+    // The next time this resident is allowed to receive this painkiller.
+    [Required]
+    public DateTime NextAllowedTime { get; set; }
+
+}

--- a/src/Infrastructure/Database/Entities/ResidentEntity.cs
+++ b/src/Infrastructure/Database/Entities/ResidentEntity.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Infrastructure.Database.Entities;
+
+public class ResidentEntity
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    [Required]
+    [MaxLength(2)]
+    public string Initials { get; set; } = string.Empty;
+
+    // Store enum as int. TrafficLight is stored as an integer in the database to represent enum values.
+    public int? TrafficLight { get; set; }
+
+
+    // Navigation properties
+    /// <summary>
+    /// Collection of medicine and painkillers administrations for this resident.
+    /// One resident can have many medicine records.
+    /// </summary>
+
+    public virtual ICollection<MedicineAdministrationEntity> Medicines { get; set; } = new List<MedicineAdministrationEntity>();
+
+    public virtual ICollection<PainkillerAdministrationEntity> Painkillers { get; set; } = new List<PainkillerAdministrationEntity>();
+
+
+}

--- a/src/Infrastructure/Persistents/AppDbContext.cs
+++ b/src/Infrastructure/Persistents/AppDbContext.cs
@@ -2,6 +2,7 @@
 //  No warranty, explicit or implicit, provided.
 
 using Microsoft.EntityFrameworkCore;
+using Infrastructure.Database.Entities;
 
 namespace Infrastructure.Persistents;
 
@@ -10,10 +11,36 @@ public partial class AppDbContext(DbContextOptions<AppDbContext> options) : DbCo
     public DbSet<Domain.Entities.Resident> Residents { get; set; }
     public DbSet<Domain.Entities.ResidentNote> ResidentNotes { get; set; }
 
+    public DbSet<Infrastructure.Database.Entities.ResidentEntity> ResidentEntities { get; set; }
+    public DbSet<Infrastructure.Database.Entities.MedicineAdministrationEntity> MedicineAdministrationEntities { get; set; }
+    public DbSet<Infrastructure.Database.Entities.PainkillerAdministrationEntity> PainkillerAdministrationEntities { get; set; }
+
+
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
         _ = modelBuilder.ApplyConfiguration(new Configurations.ResidentConfiguration());
         _ = modelBuilder.ApplyConfiguration(new Configurations.ResidentNoteConfiguration());
+
+
+        // Configure ResidentEntity → MedicineAdministration
+        modelBuilder.Entity<ResidentEntity>()
+            .HasMany(r => r.Medicines)
+            .WithOne(m => m.Resident)
+            .HasForeignKey(m => m.ResidentId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Configure ResidentEntity → PainkillerAdministration
+        modelBuilder.Entity<ResidentEntity>()
+            .HasMany(r => r.Painkillers)
+            .WithOne(p => p.Resident)
+            .HasForeignKey(p => p.ResidentId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        //enum values as string instead of int TrafficLight
+        modelBuilder.Entity<ResidentEntity>()
+            .Property(r => r.TrafficLight)
+            .HasConversion<string>();
     }
 }

--- a/src/Infrastructure/Repositories/MedicineRepository.cs
+++ b/src/Infrastructure/Repositories/MedicineRepository.cs
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Core.DTOs;
+using Core.Interfaces;
+using Core.Interfaces.Repositories;
+
+using Infrastructure.Database.Entities;
+using Infrastructure.Persistents;
+using Microsoft.EntityFrameworkCore;
+
+
+namespace Infrastructure.Repositories;
+
+/// <summary>
+/// EF Core implementation of IMedicineRepository.
+/// Uses AppDbContext to access the database.
+/// </summary>
+
+public class MedicineRepository : IMedicineRepository
+{
+    // EF Core database context used to query the database
+    private readonly AppDbContext _context;
+
+
+    //Constructor that injects the AppDbContext
+    public MedicineRepository(AppDbContext context)
+    {
+
+        _context = context;
+    }
+
+
+    // Retrieves all medicine administration records for a specific resident
+    /// <returns>
+    /// MedicineStatusDto containing medicine names, timestamps, and given status
+    /// </returns>
+
+    public async Task<MedicineStatusDto> GetMedicineStatusAsync(Guid residentId, CancellationToken ct = default)
+    {
+        var medicines = await _context.MedicineAdministrationEntities
+            .Where(m => m.ResidentId == residentId)
+            .OrderBy(m => m.Timestamp)
+            .ToListAsync(ct);
+
+        return new MedicineStatusDto
+        {
+            ResidentId = residentId.ToString(),
+            Medicine = medicines.Select(m => m.MedicineName).ToArray(),
+            Timestamps = medicines.Select(m => m.Timestamp).ToArray(),
+            Given = medicines.Select(m => m.Given).ToArray()
+        };
+    }
+
+
+    //Retrieves painkiller administration data for the last 24 hours
+    /// <returns>
+    /// PainkillerStatusDto with types and next allowed time
+    /// </returns>
+    public async Task<PainkillerStatusDto> GetPainkillerStatusAsync(Guid residentId, CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var pks = await _context.PainkillerAdministrationEntities
+            .Where(p => p.ResidentId == residentId && p.GivenAt >= now.AddHours(-24))
+            .OrderByDescending(p => p.GivenAt)
+            .ToListAsync(ct);
+
+
+        //calculates the next allowed time based on previous administrations
+        return new PainkillerStatusDto
+        {
+            ResidentId = residentId,
+            Types = pks.Select(p => p.Type).ToArray(),
+            NextAllowedTime = pks.Any() ? pks.Max(p => p.NextAllowedTime) : now
+        };
+    }
+
+
+
+}

--- a/src/WebUI/WebUI/WebUI.csproj
+++ b/src/WebUI/WebUI/WebUI.csproj
@@ -12,10 +12,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="../../../.env">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>  
+  
   
 </Project>

--- a/tests/WebApi.Tests/WebApi.Tests.csproj
+++ b/tests/WebApi.Tests/WebApi.Tests.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />


### PR DESCRIPTION
Hej har nu arbejdet meget med UC003 medecin status ERD. skulle gerne have ResidentEntity, MedicineAdministrationEntity og PainkillerAdministrationEntity  tilføjet til infrastrukturlaget og DbContext-relationer er konfigureret. Har også  
MedicineRepository (EF Core)  implementeret til at forespørge på medicin- og smertestillende.
MedicineStatusHandler er implementeret til at returnere:
MedicineStatusDto
PainkillerStatusDto

MedicineController er tilføjet med:
GET /api/medicine/{residentId} → returnerer medicinstatus for resident.
GET /api/medicine/painkiller/{residentId} → returnerer smertestillende status for resident.

Har ikke lavet en unit test men har tjekket  Swagger. tror jeg har arbejdet med det for sent ud på aftenen haha, så er måske emn fejl eller 2. så kig det endeligst godt ignnem inden aprove og som altid meget gerne skrive. Mvh William 
