### PR TITLE
feat: add full notes UI for UC-002 resident notes in ResidentCard

### DIFF
--- a/src/WebUI/WebUI/Components/Residents/ResidentCard.razor
+++ b/src/WebUI/WebUI/Components/Residents/ResidentCard.razor
@@ -1,72 +1,127 @@
 @*UC001 - Resident card shown for a quick status overview - stick to GDPR rules!*@
 @*UC001 Task - Low Fi prototype for first iteration of resident card*@
+@*UC002 - Full notes management added*@
 
 @using Domain.Entities
 @using Domain.Enums
 
-
 <section class="dashboard-grid container-fluid min-vh-100 d-flex align-items-center">
-    <div class="row g-3 row-cols-1 row-cols-md-4">
-    
+  <div class="row g-3 row-cols-1 row-cols-md-4">
+
     <div class="col">
 
-        <article class="card h-100">
-                    <header class="card-header @GetTrafficLightClass(Resident.TrafficLightStatus) flex-fill">
-                        <h5 class="card-title">@Resident.Initials</h5>
-                        <span class="badge bg-success position-absolute top-0 end-0 m-0 px-4 col-auto">PN-Tid: 02:34:16</span>
-                    </header>
-          <section class="card-body">
+      <article class="card h-100">
+        <header class="card-header @GetTrafficLightClass(Resident.TrafficLightStatus) flex-fill">
+          <h5 class="card-title">@Resident.Initials</h5>
+          <span class="badge bg-success position-absolute top-0 end-0 m-0 px-4 col-auto">PN-Tid: 02:34:16</span>
+        </header>
+        <section class="card-body">
 
-      
-                        
-                          <div class="col">
-                            <table class="table">
-                                <thead>
-                                  <tr>
-                                    <th scope="col">aktivitet </th>
-                                    <th scope="col">personer</th>
-                                    <th scope="col">beløb</th>
-                                  </tr>
-                                    
-                                </thead>
-                                <tbody>
-                                    <tr scope="row">
-                                      <td>Handle</td>
-                                      <td>👤</td>
-                                      <td>300kr</td>
-                                    </tr>
-                                    <tr>
-                                        <th scope="row">Info</th>
-                                        <td colspan="2" >Eget kort</td>
+          <div class="col">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th scope="col">aktivitet </th>
+                  <th scope="col">personer</th>
+                  <th scope="col">beløb</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr scope="row">
+                  <td>Handle</td>
+                  <td>👤</td>
+                  <td>300kr</td>
+                </tr>
+                <tr>
+                  <th scope="row">Info</th>
+                  <td colspan="2">Eget kort</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
 
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-
-                            <div class="row">
-                                @{
-                                    var latestNote = Resident.Notes
-                                    .OrderByDescending(n => n.EditedAt)
-                                    .FirstOrDefault();
-                                }
-
-                                @if (latestNote is null)
-                                {
-                                    <p><em>Ingen note endnu</em></p>
-                                }
-                                else
-                                {
-                                    <p>@latestNote.Note</p>
-                                }
-                            </div>
-
-         
-                </section>
-</article>
+          @* UC002 - Notes section *@
+          <div class="row mt-2">
+            <div class="d-flex justify-content-between align-items-center mb-1">
+              <strong class="small">Noter</strong>
+              <button class="btn btn-sm btn-outline-primary" @onclick="ToggleAddForm">+ Tilføj</button>
             </div>
 
-        
+            @* Feedback message *@
+            @if (!string.IsNullOrEmpty(_feedbackMessage))
+            {
+              <div class="alert @_feedbackClass py-1 px-2 small mb-1" role="alert">
+                @_feedbackMessage
+              </div>
+            }
+
+            @* Add note form *@
+            @if (_showAddForm)
+            {
+              <div class="mb-2">
+                <textarea class="form-control form-control-sm mb-1" rows="2" placeholder="Skriv note her..."
+                          @bind="_newNoteText"></textarea>
+                <div class="d-flex gap-1">
+                  <button class="btn btn-sm btn-primary" @onclick="AddNote">Gem</button>
+                  <button class="btn btn-sm btn-secondary" @onclick="ToggleAddForm">Annullér</button>
+                </div>
+              </div>
+            }
+
+            @* Notes list *@
+            @if (!Resident.Notes.Any())
+            {
+              <p class="small fst-italic text-muted">Ingen noter endnu</p>
+            }
+            else
+            {
+              <ul class="list-group list-group-flush">
+                @foreach (ResidentNote note in Resident.Notes.OrderByDescending(n => n.EditedAt))
+                {
+                  <li class="list-group-item px-0 py-1">
+                    @if (_editingNoteId == note.Id)
+                    {
+                      <textarea class="form-control form-control-sm mb-1" rows="2" @bind="_editNoteText"></textarea>
+                      <div class="d-flex gap-1">
+                        <button class="btn btn-sm btn-primary" @onclick="() => SaveEdit(note.Id)">Gem</button>
+                        <button class="btn btn-sm btn-secondary" @onclick="CancelEdit">Annullér</button>
+                      </div>
+                    }
+                    else
+                    {
+                      <p class="mb-0 small">@note.Note</p>
+                      <div class="d-flex justify-content-between align-items-center">
+                        <small class="text-muted">@note.EditedAt.ToString("HH:mm dd-MM-yyyy")</small>
+                        <div class="d-flex gap-1">
+                          <button class="btn btn-sm btn-outline-secondary py-0"
+                                  @onclick="() => StartEdit(note)">Rediger</button>
+                          <button class="btn btn-sm btn-outline-danger py-0"
+                                  @onclick="() => ConfirmDelete(note.Id)">Slet</button>
+                        </div>
+                      </div>
+                    }
+                  </li>
+                }
+              </ul>
+            }
+
+            @* Delete confirmation *@
+            @if (_confirmDeleteId.HasValue)
+            {
+              <div class="alert alert-warning py-1 px-2 mt-2 small">
+                <p class="mb-1">Er du sikker på du vil slette denne note?</p>
+                <div class="d-flex gap-1">
+                  <button class="btn btn-sm btn-danger" @onclick="DeleteNote">Slet</button>
+                  <button class="btn btn-sm btn-secondary" @onclick="CancelDelete">Annullér</button>
+                </div>
+              </div>
+            }
+          </div>
+
+        </section>
+      </article>
     </div>
+
+  </div>
 </section>
 @* Code moved to ResidentCard.razor.cs (partial class) *@

--- a/src/WebUI/WebUI/Components/Residents/ResidentCard.razor.cs
+++ b/src/WebUI/WebUI/Components/Residents/ResidentCard.razor.cs
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
-//  No warranty, explicit or implicit, provided.
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
 
+using Core.Interfaces.Services;
 
 using Domain.Entities;
 using Domain.Enums;
@@ -11,8 +12,167 @@ namespace WebUI.Components.Residents;
 
 public partial class ResidentCard : ComponentBase
 {
+    #region Parameters
+
     [Parameter]
     public Resident Resident { get; set; } = default!;
+
+    #endregion
+
+    #region Injected Services
+
+    [Inject]
+    private IResidentNoteService ResidentNoteService { get; set; } = default!;
+
+    #endregion
+
+    #region Fields
+
+    private bool _showAddForm;
+    private string _newNoteText = string.Empty;
+    private Guid? _editingNoteId;
+    private string _editNoteText = string.Empty;
+    private Guid? _confirmDeleteId;
+    private string _feedbackMessage = string.Empty;
+    private string _feedbackClass = string.Empty;
+
+    #endregion
+
+    #region Lifecycle
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadNotes();
+    }
+
+    #endregion
+
+    #region Methods
+
+    private async Task LoadNotes()
+    {
+        IEnumerable<Core.DTOs.ResidentNoteDto> notes = await ResidentNoteService
+            .GetAllByResidentIdAsync(Resident.Id, CancellationToken.None);
+
+        Resident.Notes = notes.Select(n => new ResidentNote
+        {
+            Id = n.Id,
+            Note = n.Note,
+            EditedAt = n.Timestamp,
+            ResidentId = Resident.Id
+        }).ToList();
+    }
+
+    private void ToggleAddForm()
+    {
+        _showAddForm = !_showAddForm;
+        _newNoteText = string.Empty;
+        ClearFeedback();
+    }
+
+    private async Task AddNote()
+    {
+        if (string.IsNullOrWhiteSpace(_newNoteText))
+        {
+            return;
+        }
+
+        bool success = await ResidentNoteService.AddAsync(
+            Resident.Id, _newNoteText, CancellationToken.None);
+
+        if (success)
+        {
+            _showAddForm = false;
+            _newNoteText = string.Empty;
+            SetFeedback("Note gemt.", "alert-success");
+            await LoadNotes();
+        }
+        else
+        {
+            SetFeedback("Note kunne ikke gemmes.", "alert-danger");
+        }
+    }
+
+    private void StartEdit(ResidentNote note)
+    {
+        _editingNoteId = note.Id;
+        _editNoteText = note.Note;
+        ClearFeedback();
+    }
+
+    private void CancelEdit()
+    {
+        _editingNoteId = null;
+        _editNoteText = string.Empty;
+    }
+
+    private async Task SaveEdit(Guid noteId)
+    {
+        if (string.IsNullOrWhiteSpace(_editNoteText))
+        {
+            return;
+        }
+
+        bool success = await ResidentNoteService.UpdateAsync(
+            noteId, _editNoteText, CancellationToken.None);
+
+        if (success)
+        {
+            _editingNoteId = null;
+            _editNoteText = string.Empty;
+            SetFeedback("Note opdateret.", "alert-success");
+            await LoadNotes();
+        }
+        else
+        {
+            SetFeedback("Note kunne ikke opdateres.", "alert-danger");
+        }
+    }
+
+    private void ConfirmDelete(Guid noteId)
+    {
+        _confirmDeleteId = noteId;
+        ClearFeedback();
+    }
+
+    private void CancelDelete()
+    {
+        _confirmDeleteId = null;
+    }
+
+    private async Task DeleteNote()
+    {
+        if (_confirmDeleteId is null)
+        {
+            return;
+        }
+
+        bool success = await ResidentNoteService.DeleteAsync(
+            _confirmDeleteId.Value, CancellationToken.None);
+
+        if (success)
+        {
+            _confirmDeleteId = null;
+            SetFeedback("Note slettet.", "alert-success");
+            await LoadNotes();
+        }
+        else
+        {
+            SetFeedback("Note kunne ikke slettes.", "alert-danger");
+        }
+    }
+
+    private void SetFeedback(string message, string cssClass)
+    {
+        _feedbackMessage = message;
+        _feedbackClass = cssClass;
+    }
+
+    private void ClearFeedback()
+    {
+        _feedbackMessage = string.Empty;
+        _feedbackClass = string.Empty;
+    }
 
     private static string GetTrafficLightClass(TrafficLightStatus? trafficLight)
     {
@@ -24,4 +184,6 @@ public partial class ResidentCard : ComponentBase
             _ => "resident-default"
         };
     }
+
+    #endregion
 }


### PR DESCRIPTION
Closes #293

Implements full UC-002 resident notes UI inside ResidentCard component:

- Show all notes ordered by EditedAt (newest first)
- Add note with text area and save/cancel buttons
- Edit note inline with pre-filled text
- Delete note with confirmation prompt
- Show EditedAt timestamp (HH:mm dd-MM-yyyy) on each note
- Success/error feedback messages

References: uc-002.wireframe.md