### PR TITLE
fix: UC002 ResidentNote architecture - add Manager layer

### DIFF
--- a/src/Core/DependencyInjection.cs
+++ b/src/Core/DependencyInjection.cs
@@ -14,7 +14,7 @@ public static class DependencyInjection
     public static IServiceCollection AddCore(this IServiceCollection services)
     {
         _ = services.AddScoped<IResidentService, ResidentService>();
-        //_ = services.AddScoped<IResidentNoteService, ResidentNoteService>();
+        _ = services.AddScoped<IResidentNoteService, ResidentNoteService>();
         //_ = services.AddScoped<IMedicineRecordService, MedicineRecordService>(); // This service is currently not implemented, so it's commented out to avoid confusion.
         // _ = services.AddScoped<IPainkillerRecordService, PainkillerRecordService>(); // This service is currently not implemented, so it's commented out to avoid confusion.
         _ = services.AddScoped<IAccountService, AccountService>();

--- a/src/Core/Interfaces/Managers/IResidentNoteManager.cs
+++ b/src/Core/Interfaces/Managers/IResidentNoteManager.cs
@@ -2,33 +2,24 @@
 //  No warranty, explicit or implicit, provided.
 
 using Core.DTOs;
-using Core.Interfaces.Managers;
-using Core.Interfaces.Services;
 
-namespace Core.Services;
+namespace Core.Interfaces.Managers;
 
 /// <summary>
-/// Provides business logic operations for managing resident notes.
+/// Defines a contract for communicating with the ResidentNote API endpoints over HTTP.
 /// </summary>
 /// <remarks>
-/// Delegates all data access to <see cref="IResidentNoteManager"/> in Infrastructure,
-/// ensuring Core never depends on Infrastructure or data access concerns directly —
-/// following Clean Architecture and the Dependency Inversion Principle.
+/// Implemented in Infrastructure. Separates HTTP communication concerns from business logic in Core,
+/// following Clean Architecture — Core defines the contract, Infrastructure fulfils it.
 /// </remarks>
 /// <example>
 /// <code>
-/// // Registered in Core DependencyInjection:
-/// services.AddScoped&lt;IResidentNoteService, ResidentNoteService&gt;();
+/// // Registered in Infrastructure DependencyInjection:
+/// services.AddScoped&lt;IResidentNoteManager, ResidentNoteManager&gt;();
 /// </code>
 /// </example>
-public class ResidentNoteService(IResidentNoteManager residentNoteManager) : IResidentNoteService
+public interface IResidentNoteManager
 {
-    #region Fields
-
-    private readonly IResidentNoteManager _residentNoteManager = residentNoteManager;
-
-    #endregion
-
     #region Methods
 
     /// <summary>
@@ -37,10 +28,7 @@ public class ResidentNoteService(IResidentNoteManager residentNoteManager) : IRe
     /// <param name="residentId">A unique identifier for the resident.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>An enumerable collection of <see cref="ResidentNoteDto"/> for the specified resident.</returns>
-    public async Task<IEnumerable<ResidentNoteDto>> GetAllByResidentIdAsync(Guid residentId, CancellationToken cancellationToken = default)
-    {
-        return await _residentNoteManager.GetAllByResidentIdAsync(residentId, cancellationToken);
-    }
+    Task<IEnumerable<ResidentNoteDto>> GetAllByResidentIdAsync(Guid residentId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Adds a new note for a resident.
@@ -49,10 +37,7 @@ public class ResidentNoteService(IResidentNoteManager residentNoteManager) : IRe
     /// <param name="noteText">A string containing the note text.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns><see langword="true"/> if the note was added successfully; otherwise, <see langword="false"/>.</returns>
-    public async Task<bool> AddAsync(Guid residentId, string noteText, CancellationToken cancellationToken = default)
-    {
-        return await _residentNoteManager.AddAsync(residentId, noteText, cancellationToken);
-    }
+    Task<bool> AddAsync(Guid residentId, string noteText, CancellationToken cancellationToken);
 
     /// <summary>
     /// Updates the text of an existing note.
@@ -61,10 +46,7 @@ public class ResidentNoteService(IResidentNoteManager residentNoteManager) : IRe
     /// <param name="newText">A string containing the new note text.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns><see langword="true"/> if the note was updated successfully; otherwise, <see langword="false"/>.</returns>
-    public async Task<bool> UpdateAsync(Guid noteId, string newText, CancellationToken cancellationToken = default)
-    {
-        return await _residentNoteManager.UpdateAsync(noteId, newText, cancellationToken);
-    }
+    Task<bool> UpdateAsync(Guid noteId, string newText, CancellationToken cancellationToken);
 
     /// <summary>
     /// Deletes a note by its unique identifier.
@@ -72,10 +54,7 @@ public class ResidentNoteService(IResidentNoteManager residentNoteManager) : IRe
     /// <param name="noteId">A unique identifier for the note to delete.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns><see langword="true"/> if the note was deleted successfully; otherwise, <see langword="false"/>.</returns>
-    public async Task<bool> DeleteAsync(Guid noteId, CancellationToken cancellationToken = default)
-    {
-        return await _residentNoteManager.DeleteAsync(noteId, cancellationToken);
-    }
+    Task<bool> DeleteAsync(Guid noteId, CancellationToken cancellationToken);
 
     #endregion
 }

--- a/src/Core/Mappers/ResidentNoteMapper.cs
+++ b/src/Core/Mappers/ResidentNoteMapper.cs
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+
+using Domain.Entities;
+
+namespace Core.Mappers;
+
+/// <summary>
+/// Provides mapping operations between <see cref="ResidentNote"/> domain entities and <see cref="ResidentNoteDto"/> data transfer objects.
+/// </summary>
+/// <remarks>
+/// Keeps mapping logic centralised in Core so neither the service nor the manager
+/// needs to know how fields are translated — follows Single Responsibility Principle.
+/// </remarks>
+public static class ResidentNoteMapper
+{
+    #region Methods
+
+    /// <summary>
+    /// Maps a <see cref="ResidentNote"/> entity to a <see cref="ResidentNoteDto"/>.
+    /// </summary>
+    /// <param name="entity">The <see cref="ResidentNote"/> entity to map.</param>
+    /// <returns>A <see cref="ResidentNoteDto"/> populated from the entity.</returns>
+    /// <exception cref="ArgumentNullException">The <paramref name="entity"/> parameter is <see langword="null"/>.</exception>
+    public static ResidentNoteDto ToDto(ResidentNote entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return new ResidentNoteDto
+        {
+            Id = entity.Id,
+            Note = entity.Note,
+            Timestamp = entity.EditedAt,
+            Initials = string.Empty
+        };
+    }
+
+    /// <summary>
+    /// Maps an enumerable collection of <see cref="ResidentNote"/> entities to <see cref="ResidentNoteDto"/> objects.
+    /// </summary>
+    /// <param name="entities">The collection of <see cref="ResidentNote"/> entities to map.</param>
+    /// <returns>An enumerable collection of <see cref="ResidentNoteDto"/> objects.</returns>
+    /// <exception cref="ArgumentNullException">The <paramref name="entities"/> parameter is <see langword="null"/>.</exception>
+    public static IEnumerable<ResidentNoteDto> ToDtos(IEnumerable<ResidentNote> entities)
+    {
+        ArgumentNullException.ThrowIfNull(entities);
+
+        return entities.Select(ToDto);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="ResidentNote"/> entity from a resident identifier and note text.
+    /// </summary>
+    /// <param name="residentId">A unique identifier for the resident.</param>
+    /// <param name="noteText">A string containing the note text.</param>
+    /// <returns>A new <see cref="ResidentNote"/> entity ready for persistence.</returns>
+    public static ResidentNote ToNewEntity(Guid residentId, string noteText)
+    {
+        return new ResidentNote
+        {
+            Id = Guid.NewGuid(),
+            ResidentId = residentId,
+            Note = noteText,
+            EditedAt = DateTime.UtcNow
+        };
+    }
+
+    #endregion
+}

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -38,7 +38,7 @@ public static class DependencyInjection
         _ = services.AddScoped<IResidentManager, ResidentManager>();
         _ = services.AddScoped<IAccountManager, AccountManager>();
         _ = services.AddScoped<IPhoneAssignmentManager, PhoneAssignmentManager>();
-        // _ = services.AddHttpClient<IResidentNoteManager, ResidentNoteManager>(); // TODO: Implement ResidentNoteManager
+        _ = services.AddScoped<IResidentNoteManager, ResidentNoteManager>();
         // _ = services.AddHttpClient<IPainkillerRecordManager, PainkillerRecordManager>(); // TODO: Implement PainkillerRecordManager
         // _ = services.AddHttpClient<IMedicineRecordManager, MedicineRecordManager>(); // TODO: Implement MedicineRecordManager
         //_ = services.AddScoped<AccountService>();

--- a/src/Infrastructure/Managers/ResidentNoteManager.cs
+++ b/src/Infrastructure/Managers/ResidentNoteManager.cs
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+//  No warranty, explicit or implicit, provided.
+
+using System.Net.Http.Json;
+
+using Core.DTOs;
+using Core.Interfaces.Managers;
+
+namespace Infrastructure.Managers;
+
+/// <summary>
+/// Provides operations for managing resident notes by communicating with the backend API over HTTP.
+/// </summary>
+/// <remarks>
+/// Implements <see cref="IResidentNoteManager"/> using <see cref="HttpClient"/> to call the WebApi.
+/// Keeps all HTTP communication out of Core — Core only knows the interface contract.
+/// </remarks>
+/// <example>
+/// <code>
+/// // Registered in Infrastructure DependencyInjection:
+/// services.AddScoped&lt;IResidentNoteManager, ResidentNoteManager&gt;();
+/// </code>
+/// </example>
+public class ResidentNoteManager : IResidentNoteManager
+{
+    #region Fields
+
+    private readonly HttpClient _httpClient;
+
+    #endregion
+
+    #region Constructors
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResidentNoteManager"/> class.
+    /// </summary>
+    /// <param name="httpClientFactory">The factory used to create the named <see cref="HttpClient"/> for the API.</param>
+    /// <exception cref="InvalidOperationException">The named HttpClient 'SlottetApi' could not be created.</exception>
+    public ResidentNoteManager(IHttpClientFactory httpClientFactory)
+    {
+        // Named client ensures correct BaseAddress and shared configuration across managers
+        _httpClient = httpClientFactory.CreateClient("SlottetApi")
+            ?? throw new InvalidOperationException("Failed to create HttpClient.");
+    }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Retrieves all notes for a specific resident.
+    /// </summary>
+    /// <param name="residentId">A unique identifier for the resident.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>An enumerable collection of <see cref="ResidentNoteDto"/> for the specified resident.</returns>
+    public async Task<IEnumerable<ResidentNoteDto>> GetAllByResidentIdAsync(Guid residentId, CancellationToken cancellationToken)
+    {
+        return await _httpClient.GetFromJsonAsync<IEnumerable<ResidentNoteDto>>(
+            $"residentnote/{residentId}", cancellationToken) ?? [];
+    }
+
+    /// <summary>
+    /// Adds a new note for a resident.
+    /// </summary>
+    /// <param name="residentId">A unique identifier for the resident.</param>
+    /// <param name="noteText">A string containing the note text.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns><see langword="true"/> if the note was added successfully; otherwise, <see langword="false"/>.</returns>
+    public async Task<bool> AddAsync(Guid residentId, string noteText, CancellationToken cancellationToken)
+    {
+        AddResidentNoteDto dto = new()
+        {
+            ResidentId = residentId,
+            NoteText = noteText
+        };
+
+        HttpResponseMessage response = await _httpClient.PostAsJsonAsync("residentnote", dto, cancellationToken);
+
+        return response.IsSuccessStatusCode;
+    }
+
+    /// <summary>
+    /// Updates the text of an existing note.
+    /// </summary>
+    /// <param name="noteId">A unique identifier for the note to update.</param>
+    /// <param name="newText">A string containing the new note text.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns><see langword="true"/> if the note was updated successfully; otherwise, <see langword="false"/>.</returns>
+    public async Task<bool> UpdateAsync(Guid noteId, string newText, CancellationToken cancellationToken)
+    {
+        EditResidentNoteDto dto = new()
+        {
+            ResidentNoteId = noteId,
+            NewNoteText = newText
+        };
+
+        HttpResponseMessage response = await _httpClient.PutAsJsonAsync($"residentnote/{noteId}", dto, cancellationToken);
+
+        return response.IsSuccessStatusCode;
+    }
+
+    /// <summary>
+    /// Deletes a note by its unique identifier.
+    /// </summary>
+    /// <param name="noteId">A unique identifier for the note to delete.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns><see langword="true"/> if the note was deleted successfully; otherwise, <see langword="false"/>.</returns>
+    public async Task<bool> DeleteAsync(Guid noteId, CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = await _httpClient.DeleteAsync($"residentnote/{noteId}", cancellationToken);
+
+        return response.IsSuccessStatusCode;
+    }
+
+    #endregion
+}

--- a/tests/Core.Tests/Services/ResidentNoteServiceTests.cs
+++ b/tests/Core.Tests/Services/ResidentNoteServiceTests.cs
@@ -1,11 +1,9 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 
 using Core.DTOs;
-using Core.Interfaces.Repositories;
+using Core.Interfaces.Managers;
 using Core.Services;
-
-using Domain.Entities;
 
 using Moq;
 
@@ -13,28 +11,39 @@ namespace Core.Tests.Services;
 
 public class ResidentNoteServiceTests
 {
+    #region Fields
 
-    private readonly Mock<IResidentNoteRepository> _mockRepo;
+    private readonly Mock<IResidentNoteManager> _mockManager;
     private readonly ResidentNoteService _service;
+
+    #endregion
+
+    #region Constructors
 
     public ResidentNoteServiceTests()
     {
-        _mockRepo = new Mock<IResidentNoteRepository>();
-        _service = new ResidentNoteService(_mockRepo.Object);
+        _mockManager = new Mock<IResidentNoteManager>();
+        _service = new ResidentNoteService(_mockManager.Object);
     }
+
+    #endregion
+
+    #region Methods
 
     [Fact]
     public async Task GetAllByResidentIdAsync_ReturnsNotesForResident()
     {
         // Arrange
         Guid residentId = Guid.NewGuid();
-        List<ResidentNote> notes =
+        List<ResidentNoteDto> notes =
         [
-            new ResidentNote { Id = Guid.NewGuid(), ResidentId = residentId, Note = "Note 1" },
-            new ResidentNote { Id = Guid.NewGuid(), ResidentId = residentId, Note = "Note 2" }
+            new ResidentNoteDto { Id = Guid.NewGuid(), Note = "Note 1" },
+            new ResidentNoteDto { Id = Guid.NewGuid(), Note = "Note 2" }
         ];
-        _ = _mockRepo.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
-          .ReturnsAsync(notes);
+        _ = _mockManager
+            .Setup(m => m.GetAllByResidentIdAsync(residentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(notes);
+
         // Act
         IEnumerable<ResidentNoteDto> result = await _service.GetAllByResidentIdAsync(residentId, TestContext.Current.CancellationToken);
 
@@ -48,68 +57,51 @@ public class ResidentNoteServiceTests
     {
         // Arrange
         Guid residentId = Guid.NewGuid();
-        _ = _mockRepo.Setup(r => r.AddAsync(It.IsAny<ResidentNote>(), It.IsAny<CancellationToken>()))
-         .ReturnsAsync(new ResidentNote());
+        _ = _mockManager
+            .Setup(m => m.AddAsync(residentId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         // Act
         bool result = await _service.AddAsync(residentId, "New Note", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
+        _mockManager.Verify(m => m.AddAsync(residentId, "New Note", It.IsAny<CancellationToken>()), Times.Once);
     }
+
     [Fact]
     public async Task UpdateAsync_ReturnsTrueWhenNoteUpdated()
     {
-        //ARRANGE:
-        // 1. Create residentId and noteId
-        Guid residentId = Guid.NewGuid();
+        // Arrange
         Guid noteId = Guid.NewGuid();
+        _ = _mockManager
+            .Setup(m => m.UpdateAsync(noteId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
-        // 2. Create an existing note
-        ResidentNote existingNote = new() { Id = noteId, ResidentId = residentId, Note = "Old text" };
+        // Act
+        bool result = await _service.UpdateAsync(noteId, "Updated text", TestContext.Current.CancellationToken);
 
-        // 3. Mock GetByIdAsync - repository finds the note
-        _ = _mockRepo.Setup(r => r.GetByIdAsync(noteId, It.IsAny<CancellationToken>()))
-                 .ReturnsAsync(existingNote);
-
-        // 4. Mock UpdateAsync - repository updates the note
-        _ = _mockRepo.Setup(r => r.UpdateAsync(It.IsAny<ResidentNote>(), It.IsAny<CancellationToken>()))
-                 .Returns(Task.CompletedTask);
-
-        // ACT:
-        bool result = await _service.UpdateAsync(noteId, "New text", TestContext.Current.CancellationToken);
-
-        //ASSERT:
+        // Assert
         Assert.True(result);
-        // Verify that UpdateAsync was called exactly once
-        _mockRepo.Verify(r => r.UpdateAsync(It.IsAny<ResidentNote>(), It.IsAny<CancellationToken>()), Times.Once);
-
+        _mockManager.Verify(m => m.UpdateAsync(noteId, "Updated text", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task DeleteAsync_ReturnsTrueWhenNoteDeleted()
     {
         // Arrange
-        Guid residentId = Guid.NewGuid();
         Guid noteId = Guid.NewGuid();
-        ResidentNote existingNote = new() { Id = noteId, ResidentId = residentId, Note = "Note to delete" };
-
-        // Mock GetByIdAsync - repository finds the note
-        _ = _mockRepo.Setup(r => r.GetByIdAsync(noteId, It.IsAny<CancellationToken>()))
-                 .ReturnsAsync(existingNote);
-
-        // Mock DeleteAsync - repository deletes the note
-        _ = _mockRepo.Setup(r => r.DeleteAsync(It.IsAny<ResidentNote>(), It.IsAny<CancellationToken>()))
-                 .Returns(Task.CompletedTask);
+        _ = _mockManager
+            .Setup(m => m.DeleteAsync(noteId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         // Act
         bool result = await _service.DeleteAsync(noteId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        // Verify that DeleteAsync was called exactly once
-        _mockRepo.Verify(r => r.DeleteAsync(It.IsAny<ResidentNote>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockManager.Verify(m => m.DeleteAsync(noteId, It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    #endregion
 }
-
-


### PR DESCRIPTION
- Add IResidentNoteManager interface (Core/Interfaces/Managers)
- Add ResidentNoteMapper (Core/Mappers)
- Add ResidentNoteManager (Infrastructure/Managers) using HttpClient
- Fix ResidentNoteService: replace IResidentNoteRepository with IResidentNoteManager
- Enable DI registrations in Core and Infrastructure
- Update ResidentNoteServiceTests: mock IResidentNoteManager instead of IResidentNoteRepository

Fixes Clean Architecture violation where Core.Services accessed Infrastructure.Data repository directly instead of going through Infrastructure Manager via HttpClient to WebApi.


Closes #50