### PR TITLE
docs: UC002 - sync SD and DCD with implemented architecture

### DIFF
--- a/docs/use-cases/uc-002-dashBoard-residentNote/uc-002.dcd.0001.md
+++ b/docs/use-cases/uc-002-dashBoard-residentNote/uc-002.dcd.0001.md
@@ -3,81 +3,148 @@
 ## Metadata
 | Key               | Value                             |
 |-------------------|-----------------------------------|
-| Id                | DCD-002                        |
-| crossReference    | SD-002                         |
+| Id                | DCD-002                           |
+| crossReference    | SD-002                            |
 
 ## Version Log
-| Version | Date       | Description                        | Author     |
-|---------|------------|------------------------------------|------------|
-| 0001    | 2026-03-06 | Initial                            | Team 6     |
+| Version | Date       | Description                                         | Author |
+|---------|------------|-----------------------------------------------------|--------|
+| 0001    | 2026-03-06 | Initial                                             | Team 6 |
+| 0002    | 2026-04-26 | Add IResidentNoteManager and ResidentNoteManager layer; fix ResidentNoteService dependency | Team 6 |
 
 ## Domain Class Diagram
+
+### Domain Layer
 ```mermaid
-%% UC-002 ResidentNote Domain Class Diagram
 classDiagram
   namespace Domain {
     class Resident {
-      +ResidentId: Guid
-      +Name: string
-      ~GetNotes(): List<ResidentNote>
+      +Id: Guid
+      +Initials: string
+      +Notes: List~ResidentNote~
     }
     class ResidentNote {
-      +ResidentNoteId: Guid
+      +Id: Guid
       +ResidentId: Guid
-      +NoteText: string
-      +CreatedAt: DateTime
+      +Note: string
       +EditedAt: DateTime
     }
   }
+  Resident "1" --> "0..*" ResidentNote : has
+```
+
+### Application Layer
+```mermaid
+classDiagram
   namespace Core.DTOs {
+    class ResidentNoteDto {
+      +Id: Guid
+      +Note: string
+      +Timestamp: DateTime
+      +Initials: string
+    }
     class AddResidentNoteDto {
-      +residentId: Guid
-      +ResidentNote: string
+      +ResidentId: Guid
+      +NoteText: string
     }
     class EditResidentNoteDto {
-      +residentId: Guid
-      +residentNoteId: Guid
-      +newText: string
+      +ResidentId: Guid
+      +ResidentNoteId: Guid
+      +NewNoteText: string
+    }
+  }
+  namespace Core.Mappers {
+    class ResidentNoteMapper {
+      +ToDto(entity: ResidentNote) ResidentNoteDto$
+      +ToDtos(entities: IEnumerable~ResidentNote~) IEnumerable~ResidentNoteDto~$
+      +ToNewEntity(residentId: Guid, noteText: string) ResidentNote$
+    }
+  }
+  namespace Core.Interfaces.Services {
+    class IResidentNoteService {
+      <<interface>>
+      +GetAllByResidentIdAsync(residentId: Guid, ct: CancellationToken) Task~IEnumerable~ResidentNoteDto~~
+      +AddAsync(residentId: Guid, noteText: string, ct: CancellationToken) Task~bool~
+      +UpdateAsync(noteId: Guid, newText: string, ct: CancellationToken) Task~bool~
+      +DeleteAsync(noteId: Guid, ct: CancellationToken) Task~bool~
+    }
+  }
+  namespace Core.Interfaces.Managers {
+    class IResidentNoteManager {
+      <<interface>>
+      +GetAllByResidentIdAsync(residentId: Guid, ct: CancellationToken) Task~IEnumerable~ResidentNoteDto~~
+      +AddAsync(residentId: Guid, noteText: string, ct: CancellationToken) Task~bool~
+      +UpdateAsync(noteId: Guid, newText: string, ct: CancellationToken) Task~bool~
+      +DeleteAsync(noteId: Guid, ct: CancellationToken) Task~bool~
     }
   }
   namespace Core.Services {
     class ResidentNoteService {
-      +getResidentNotesForResident(residentId): List<ResidentNote>
-      +addResidentNote(dto: AddResidentNoteDto): bool
-      +editResidentNote(dto: EditResidentNoteDto): bool
-      +deleteResidentNote(residentId, residentNoteId): bool
+      -_residentNoteManager: IResidentNoteManager
+      +GetAllByResidentIdAsync(residentId: Guid, ct: CancellationToken) Task~IEnumerable~ResidentNoteDto~~
+      +AddAsync(residentId: Guid, noteText: string, ct: CancellationToken) Task~bool~
+      +UpdateAsync(noteId: Guid, newText: string, ct: CancellationToken) Task~bool~
+      +DeleteAsync(noteId: Guid, ct: CancellationToken) Task~bool~
     }
   }
-  namespace WebApi {
-    class ResidentNoteController {
-        +getResidentNotes(residentId): List<ResidentNote>
-        +addResidentNote(residentId, noteText): bool
-        +editResidentNote(residentId, residentNoteId, newText): bool
-        +deleteResidentNote(residentId, residentNoteId): bool
-    }
-  }
-  namespace Infrastructure.Repositories {
-    class IResidentNoteRepository {
-    <<interface>>
-    }
-  }
-  Resident "1" --> "*" ResidentNote : has
-  ResidentNoteController ..> ResidentNoteService : uses
-  ResidentNoteService ..> AddResidentNoteDto : uses
-  ResidentNoteService ..> EditResidentNoteDto : uses
-  ResidentNoteService ..> ResidentNoteController : depends
-  ResidentNoteController ..> IResidentNoteRepository : depends
-  IResidentNoteRepository "*" --> "*" ResidentNote : manages
+  ResidentNoteService ..|> IResidentNoteService : implements
+  ResidentNoteService --> IResidentNoteManager : uses
+  ResidentNoteMapper --> ResidentNoteDto : produces
 ```
 
-**Notes:**
-- If class names change from previous artifacts, update `/docs/glosery.md` accordingly.
-- DTOs (`AddResidentNoteDto`, `EditResidentNoteDto`) are used to decouple UI and domain models.
-- Data returned from repository is mapped to DTOs before being sent to WebUI.
-- All data transformations are explicit and documented.
-- See sequence diagram for interaction details.
-- See solutions DCD for repository and interface details.
+### Infrastructure Layer
+```mermaid
+classDiagram
+  namespace Infrastructure.Managers {
+    class ResidentNoteManager {
+      -_httpClient: HttpClient
+      +GetAllByResidentIdAsync(residentId: Guid, ct: CancellationToken) Task~IEnumerable~ResidentNoteDto~~
+      +AddAsync(residentId: Guid, noteText: string, ct: CancellationToken) Task~bool~
+      +UpdateAsync(noteId: Guid, newText: string, ct: CancellationToken) Task~bool~
+      +DeleteAsync(noteId: Guid, ct: CancellationToken) Task~bool~
+    }
+  }
+  namespace Infrastructure.Data.Repositories {
+    class ResidentNoteRepository {
+    }
+  }
+  namespace Core.Interfaces.Managers {
+    class IResidentNoteManager {
+      <<interface>>
+    }
+  }
+  namespace Core.Interfaces.Repositories {
+    class IResidentNoteRepository {
+      <<interface>>
+    }
+  }
+  ResidentNoteManager ..|> IResidentNoteManager : implements
+  ResidentNoteRepository ..|> IResidentNoteRepository : implements
+```
 
----
+### WebUI Layer
+```mermaid
+classDiagram
+  namespace WebUI.Components.Residents {
+    class ResidentCard {
+      -ResidentNoteService: IResidentNoteService
+      +LoadNotes() Task
+      +AddNote() Task
+      +SaveEdit(noteId: Guid) Task
+      +DeleteNote() Task
+    }
+  }
+  namespace Core.Interfaces.Services {
+    class IResidentNoteService {
+      <<interface>>
+    }
+  }
+  ResidentCard --> IResidentNoteService : injects
+```
 
-If class names change from previous artifacts, update `/docs/glosery.md` accordingly.
+## Notes
+- ResidentNoteService (Core) delegates all data access to IResidentNoteManager — never to repositories directly.
+- ResidentNoteManager (Infrastructure) communicates with the WebApi over HTTP using HttpClient.
+- The WebApi controller (ResidentNoteController) accesses data via IResidentNoteRepository in Infrastructure.Data.
+- DTOs are used for all cross-layer data transfer — domain entities are never exposed directly.
+- ResidentNoteMapper centralises all entity-to-DTO mapping in Core.

--- a/docs/use-cases/uc-002-dashBoard-residentNote/uc-002.sd.0004.md
+++ b/docs/use-cases/uc-002-dashBoard-residentNote/uc-002.sd.0004.md
@@ -1,155 +1,104 @@
-
 # UC-002 Dashboard ResidentNote Sequence Diagram
 
 ## Metadata
-| Key            | Value           |
-|----------------|-----------------|
-| Id             | UC-002.SD       |
-| crossReference | UC-002.SSD UC-002.OC |
+| Key            | Value                    |
+|----------------|--------------------------|
+| Id             | UC-002.SD                |
+| crossReference | UC-002.SSD UC-002.OC UC-002.DCD |
 
 ## Version Log
-| Version | Date       | Description                        | Author |
-|---------|------------|------------------------------------|--------|
-| 0003    | 2026-03-07 | Update: use WebApi for CRUD        | Team 6 |
-| 0004    | 2026-03-24 | Change to WebApi→Infrastructure Data Access diagram | Team 6 |
+| Version | Date       | Description                                              | Author |
+|---------|------------|----------------------------------------------------------|--------|
+| 0001    | 2026-03-06 | Initial                                                  | Team 6 |
+| 0002    | 2026-03-07 | Add edit and delete flows                                | Team 6 |
+| 0003    | 2026-03-07 | Update: use WebApi for CRUD                              | Team 6 |
+| 0004    | 2026-03-24 | Change to WebApi→Infrastructure Data Access diagram      | Team 6 |
+| 0005    | 2026-04-26 | Sync with implementation: add IResidentNoteManager layer | Team 6 |
 
 ## Sequence Diagram
-
 
 ### Presentation Layer → Application Layer
 ```mermaid
 sequenceDiagram
     actor Employee as Actor
-    participant WebUI as WebUI
-    participant ResidentNoteService as ResidentNoteService
+    participant WebUI as ResidentCard (WebUI)
+    participant ResidentNoteService as ResidentNoteService (Core)
 
     Employee->>+WebUI: selectResident(residentId)
-    WebUI->>+ResidentNoteService: GetResidentNotes(residentId)
-    ResidentNoteService-->>-WebUI: ResidentNotesDto[]
-    WebUI-->>-Employee: showResidentNotes(ResidentNotesDto[])
+    WebUI->>+ResidentNoteService: GetAllByResidentIdAsync(residentId)
+    ResidentNoteService-->>-WebUI: IEnumerable~ResidentNoteDto~
+    WebUI-->>-Employee: showResidentNotes(ResidentNoteDto[])
 
     Employee->>+WebUI: addResidentNote(residentId, noteText)
-    WebUI->>+ResidentNoteService: AddResidentNote(residentId, noteText)
-    ResidentNoteService-->>-WebUI: confirmResidentNoteAdded()
+    WebUI->>+ResidentNoteService: AddAsync(residentId, noteText)
+    ResidentNoteService-->>-WebUI: true
     WebUI-->>-Employee: confirmResidentNoteAdded()
 
-    Employee->>+WebUI: editResidentNote(residentId, residentNoteId, newText)
-    WebUI->>+ResidentNoteService: EditResidentNote(residentId, residentNoteId, newText)
-    ResidentNoteService-->>-WebUI: confirmResidentNoteEdited()
+    Employee->>+WebUI: editResidentNote(noteId, newText)
+    WebUI->>+ResidentNoteService: UpdateAsync(noteId, newText)
+    ResidentNoteService-->>-WebUI: true
     WebUI-->>-Employee: confirmResidentNoteEdited()
 
-    Employee->>+WebUI: deleteResidentNote(residentId, residentNoteId)
-    WebUI->>+ResidentNoteService: DeleteResidentNote(residentId, residentNoteId)
-    ResidentNoteService-->>-WebUI: confirmResidentNoteDeleted()
+    Employee->>+WebUI: deleteResidentNote(noteId)
+    WebUI->>+ResidentNoteService: DeleteAsync(noteId)
+    ResidentNoteService-->>-WebUI: true
     WebUI-->>-Employee: confirmResidentNoteDeleted()
 ```
 
+### Application Layer → Infrastructure Layer (External Interfaces)
+```mermaid
+sequenceDiagram
+    participant ResidentNoteService as ResidentNoteService (Core)
+    participant ResidentNoteManager as ResidentNoteManager (Infrastructure)
+
+    ResidentNoteService->>+ResidentNoteManager: GetAllByResidentIdAsync(residentId)
+    ResidentNoteManager-->>-ResidentNoteService: IEnumerable~ResidentNoteDto~
+
+    ResidentNoteService->>+ResidentNoteManager: AddAsync(residentId, noteText)
+    ResidentNoteManager-->>-ResidentNoteService: bool
+
+    ResidentNoteService->>+ResidentNoteManager: UpdateAsync(noteId, newText)
+    ResidentNoteManager-->>-ResidentNoteService: bool
+
+    ResidentNoteService->>+ResidentNoteManager: DeleteAsync(noteId)
+    ResidentNoteManager-->>-ResidentNoteService: bool
+```
 
 ### WebApi Layer → Infrastructure Layer (Data Access)
 ```mermaid
 sequenceDiagram
-    %% WebApi Layer
-    participant ResidentNoteApiController as ResidentNoteApiController
+    participant ResidentNoteManager as ResidentNoteManager (Infrastructure)
+    participant WebApi as ResidentNoteController (WebApi)
+    participant Repository as ResidentNoteRepository (Infrastructure.Data)
 
-    %% Infrastructure - Data Access
-    participant ResidentNoteManager as ResidentNoteManager
-    participant Repository as ResidentNoteRepository
+    ResidentNoteManager->>+WebApi: GET /residentnote/{residentId}
+    WebApi->>+Repository: GetAllAsync()
+    Repository-->>-WebApi: IEnumerable~ResidentNote~
+    WebApi-->>-ResidentNoteManager: ResidentNoteDto[]
 
-    ResidentNoteApiController->>+ResidentNoteManager: GetResidentNotes(residentId)
-    ResidentNoteManager->>+Repository: FetchResidentNotes(residentId)
-    Repository-->>-ResidentNoteManager: ResidentNotes
-    ResidentNoteManager-->>-ResidentNoteApiController: ResidentNotesDto[]
+    ResidentNoteManager->>+WebApi: POST /residentnote (AddResidentNoteDto)
+    WebApi->>+Repository: AddAsync(ResidentNote)
+    Repository-->>-WebApi: ResidentNote
+    WebApi-->>-ResidentNoteManager: 200 OK
 
-    ResidentNoteApiController->>+ResidentNoteManager: AddResidentNote(AddResidentNoteDto)
-    ResidentNoteManager->>+Repository: SaveResidentNote(residentId, noteText)
-    alt addResidentNote success
-        Repository-->>ResidentNoteManager: ResidentNoteSaved
-        ResidentNoteManager-->>ResidentNoteApiController: ResidentNoteSaved
-    else addResidentNote error
-        Repository-->>ResidentNoteManager: error
-        ResidentNoteManager-->>ResidentNoteApiController: error
-    end
+    ResidentNoteManager->>+WebApi: PUT /residentnote/{noteId} (EditResidentNoteDto)
+    WebApi->>+Repository: GetByIdAsync(noteId)
+    Repository-->>WebApi: ResidentNote
+    WebApi->>+Repository: UpdateAsync(ResidentNote)
+    Repository-->>-WebApi: void
+    WebApi-->>-ResidentNoteManager: 200 OK
 
-    ResidentNoteApiController->>+ResidentNoteManager: EditResidentNote(EditResidentNoteDto)
-    ResidentNoteManager->>+Repository: UpdateResidentNote(residentId, residentNoteId, newText)
-    alt editResidentNote success
-        Repository-->>ResidentNoteManager: ResidentNoteUpdated
-        ResidentNoteManager-->>ResidentNoteApiController: ResidentNoteUpdated
-    else editResidentNote error
-        Repository-->>ResidentNoteManager: error
-        ResidentNoteManager-->>ResidentNoteApiController: error
-    end
-
-    ResidentNoteApiController->>+ResidentNoteManager: DeleteResidentNote(residentId, residentNoteId)
-    ResidentNoteManager->>+Repository: DeleteResidentNote(residentId, residentNoteId)
-    alt deleteResidentNote success
-        Repository-->>ResidentNoteManager: ResidentNoteDeleted
-        ResidentNoteManager-->>ResidentNoteApiController: ResidentNoteDeleted
-    else deleteResidentNote error
-        Repository-->>ResidentNoteManager: error
-        ResidentNoteManager-->>ResidentNoteApiController: error
-    end
+    ResidentNoteManager->>+WebApi: DELETE /residentnote/{noteId}
+    WebApi->>+Repository: GetByIdAsync(noteId)
+    Repository-->>WebApi: ResidentNote
+    WebApi->>+Repository: DeleteAsync(ResidentNote)
+    Repository-->>-WebApi: void
+    WebApi-->>-ResidentNoteManager: 200 OK
 ```
 
-
-### Application Layer → Infrastructure Layer (WebAPI)
-```mermaid
-sequenceDiagram
-    participant ResidentNoteService as ResidentNoteService
-    participant ResidentNoteManager as ResidentNoteManager
-    participant WebApi as WebApi
-
-    ResidentNoteService->>+ResidentNoteManager: GetResidentNotes(residentId)
-    ResidentNoteManager->>+WebApi: GET /api/residents/{residentId}/notes
-    WebApi-->>-ResidentNoteManager: JSON response with ResidentNotes
-    ResidentNoteManager-->>-ResidentNoteService: ResidentNotesDto[]
-
-    ResidentNoteService->>+ResidentNoteManager: AddResidentNote(AddResidentNoteDto)
-    ResidentNoteManager->>+WebApi: POST /api/residents/{residentId}/notes
-    alt addResidentNote success
-        WebApi-->>ResidentNoteManager: 201 Created with ResidentNote details
-        ResidentNoteManager-->>ResidentNoteService: ResidentNoteSaved
-    else addResidentNote error
-        WebApi-->>ResidentNoteManager: 400 Bad Request or 500 Internal Server Error
-        ResidentNoteManager-->>ResidentNoteService: error
-    end
-
-    ResidentNoteService->>+ResidentNoteManager: EditResidentNote(EditResidentNoteDto)
-    ResidentNoteManager->>+WebApi: PUT /api/residents/{residentId}/notes/{residentNoteId}
-    alt editResidentNote success
-        WebApi-->>ResidentNoteManager: 200 OK with ResidentNote details
-        ResidentNoteManager-->>ResidentNoteService: ResidentNoteUpdated
-    else editResidentNote error
-        WebApi-->>ResidentNoteManager: 400 Bad Request or 500 Internal Server Error
-        ResidentNoteManager-->>ResidentNoteService: error
-    end
-
-    ResidentNoteService->>+ResidentNoteManager: DeleteResidentNote(residentId, residentNoteId)
-    ResidentNoteManager->>+WebApi: DELETE /api/residents/{residentId}/notes/{residentNoteId}
-    alt deleteResidentNote success
-        WebApi-->>ResidentNoteManager: 200 OK with ResidentNote details
-        ResidentNoteManager-->>ResidentNoteService: ResidentNoteDeleted
-    else deleteResidentNote error
-        WebApi-->>ResidentNoteManager: 400 Bad Request or 500 Internal Server Error
-        ResidentNoteManager-->>ResidentNoteService: error
-    end
-```
-
----
-
-
-**Notes:**
-- The WebUI never calls the controller or data access directly; it always calls the Application layer (Service/Handler), which orchestrates all business logic and data access.
-- Data Transfer Objects (DTOs) are used between layers to decouple UI and domain models.
-- Example: `AddResidentNote(residentId, noteText)` in WebUI is transformed into an `AddResidentNoteDto` when sent to the Application layer, which then passes it to the WebApi.
-- Data returned from the database is mapped to DTOs before being sent to the WebUI.
-- All data transformations are explicit and documented in the implementation.
-
-**DTO Example:**
-```csharp
-public class AddResidentNoteDto
-{
-    public int ResidentId { get; set; }
-    public string ResidentNote { get; set; }
-}
-```
+## Notes
+- WebUI (ResidentCard) never calls the API directly — always via IResidentNoteService.
+- ResidentNoteService (Core) delegates all HTTP communication to IResidentNoteManager (Core interface), implemented by ResidentNoteManager in Infrastructure.
+- ResidentNoteManager uses HttpClient with the named client 'SlottetApi' to call WebApi endpoints.
+- ResidentNoteController (WebApi) accesses data via IResidentNoteRepository — never via services.
+- DTOs are used for all cross-layer data transfer. Domain entities are never exposed outside Infrastructure.Data.


### PR DESCRIPTION
- Update uc-002.sd.0004.md to version 0005: add IResidentNoteManager layer between ResidentNoteService and WebApi. Add three-layer diagram (Presentation→Application, Application→Infrastructure, WebApi→Data).
- Update uc-002.dcd.0001.md to version 0002: add IResidentNoteManager, ResidentNoteManager, ResidentNoteMapper and WebUI layer. Remove incorrect direct dependency ResidentNoteService→IResidentNoteRepository.

## Problem
The SD (uc-002.sd.0004.md) and DCD (uc-002.dcd.0001.md) were out of sync
with the implemented architecture. The DCD incorrectly showed
ResidentNoteService depending directly on IResidentNoteRepository,
bypassing the Manager layer.

## Changes
- **uc-002.sd.0004.md → version 0005**: Added three-layer sequence diagram
  structure (Presentation→Application, Application→Infrastructure,
  WebApi→Data Access). The IResidentNoteManager layer between
  ResidentNoteService and WebApi is now explicit.
- **uc-002.dcd.0001.md → version 0002**: Added IResidentNoteManager,
  ResidentNoteManager, ResidentNoteMapper and WebUI layer. Removed
  incorrect direct dependency ResidentNoteService→IResidentNoteRepository.

## Traceability
Both artifacts now correctly reflect the architecture implemented in
PR fix/uc002-residentnote-architecture (see related PR).


Closes #293