### PR TITLE
fix: UC005 PhoneList Clean Architecture - add IPhoneAssignmentService…

### DIFF
--- a/src/Api/Controllers/PhoneAssignmentsController.cs
+++ b/src/Api/Controllers/PhoneAssignmentsController.cs
@@ -2,7 +2,7 @@
 // No warranty, explicit or implicit, provided.
 
 using Core.DTOs;
-using Core.Interfaces.Managers;
+using Core.Interfaces.Services;
 
 using Microsoft.AspNetCore.Mvc;
 
@@ -13,21 +13,30 @@ namespace Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("[controller]")]
-public class PhoneAssignmentsController(IPhoneAssignmentManager phoneAssignmentManager) : ControllerBase
+public class PhoneAssignmentsController(IPhoneAssignmentService phoneAssignmentService) : ControllerBase
 {
-    private readonly IPhoneAssignmentManager _phoneAssignmentManager = phoneAssignmentManager;
+    #region Fields
+
+    private readonly IPhoneAssignmentService _phoneAssignmentService = phoneAssignmentService;
+
+    #endregion
+
+    #region Endpoints
 
     /// <summary>
     /// Retrieves all phone assignments for the active shift.
     /// </summary>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    /// <returns>A collection of phone assignments for the active shift.</returns>
+    /// <returns>A collection of <see cref="PhoneAssignmentDto"/> for the active shift.</returns>
     [HttpGet("active-shift")]
     public async Task<ActionResult<IEnumerable<PhoneAssignmentDto>>> GetCurrentPhoneAssignmentsForActiveShift(
         CancellationToken cancellationToken)
     {
-        IEnumerable<PhoneAssignmentDto> result = await _phoneAssignmentManager
-            .GetCurrentPhoneAssignmentsForActiveShift(cancellationToken);
+        IEnumerable<PhoneAssignmentDto> result =
+            await _phoneAssignmentService.GetCurrentPhoneAssignmentsForActiveShiftAsync(cancellationToken);
+
         return Ok(result);
     }
+
+    #endregion
 }

--- a/src/Core/DependencyInjection.cs
+++ b/src/Core/DependencyInjection.cs
@@ -1,6 +1,5 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
-//  No warranty, explicit or implicit, provided.
-
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
 
 using Core.Interfaces.Services;
 using Core.Services;
@@ -15,9 +14,9 @@ public static class DependencyInjection
     {
         _ = services.AddScoped<IResidentService, ResidentService>();
         _ = services.AddScoped<IResidentNoteService, ResidentNoteService>();
-        //_ = services.AddScoped<IMedicineRecordService, MedicineRecordService>(); // This service is currently not implemented, so it's commented out to avoid confusion.
-        // _ = services.AddScoped<IPainkillerRecordService, PainkillerRecordService>(); // This service is currently not implemented, so it's commented out to avoid confusion.
+        _ = services.AddScoped<IPhoneAssignmentService, PhoneAssignmentService>();
         _ = services.AddScoped<IAccountService, AccountService>();
+
         return services;
     }
 }

--- a/src/Core/Interfaces/Services/IPhoneAssignmentService.cs
+++ b/src/Core/Interfaces/Services/IPhoneAssignmentService.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+
+namespace Core.Interfaces.Services;
+
+/// <summary>
+/// Defines a contract for managing phone assignments on the dashboard.
+/// </summary>
+/// <remarks>
+/// Provides methods for retrieving phone assignments for the active shift.
+/// Implemented by <see cref="Core.Services.PhoneAssignmentService"/>.
+/// Core defines the contract; Infrastructure fulfils it via <see cref="Core.Interfaces.Managers.IPhoneAssignmentManager"/>.
+/// </remarks>
+public interface IPhoneAssignmentService
+{
+    /// <summary>
+    /// Gets the current phone assignments for the active shift.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A collection of <see cref="PhoneAssignmentDto"/> for the active shift.</returns>
+    Task<IEnumerable<PhoneAssignmentDto>> GetCurrentPhoneAssignmentsForActiveShiftAsync(CancellationToken cancellationToken);
+}

--- a/src/Core/Mappers/PhoneAssignmentMapper.cs
+++ b/src/Core/Mappers/PhoneAssignmentMapper.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+
+using Domain.Entities;
+
+namespace Core.Mappers;
+
+/// <summary>
+/// Provides mapping methods between <see cref="PhoneAssignment"/> domain entities and <see cref="PhoneAssignmentDto"/> data transfer objects.
+/// </summary>
+/// <remarks>
+/// Centralises all entity-to-DTO conversion for phone assignments in Core,
+/// ensuring domain entities are never exposed directly across layer boundaries.
+/// </remarks>
+public static class PhoneAssignmentMapper
+{
+    /// <summary>
+    /// Maps a <see cref="PhoneAssignment"/> entity to a <see cref="PhoneAssignmentDto"/>.
+    /// </summary>
+    /// <param name="entity">The phone assignment entity to map.</param>
+    /// <returns>A <see cref="PhoneAssignmentDto"/> representing the entity.</returns>
+    public static PhoneAssignmentDto ToDto(PhoneAssignment entity)
+    {
+        return new PhoneAssignmentDto
+        {
+            PhoneNumber = entity.PhoneNumber,
+            ShiftType = entity.ShiftType
+        };
+    }
+
+    /// <summary>
+    /// Maps a collection of <see cref="PhoneAssignment"/> entities to <see cref="PhoneAssignmentDto"/> objects.
+    /// </summary>
+    /// <param name="entities">The collection of phone assignment entities to map.</param>
+    /// <returns>A collection of <see cref="PhoneAssignmentDto"/> objects.</returns>
+    public static IEnumerable<PhoneAssignmentDto> ToDtos(IEnumerable<PhoneAssignment> entities)
+    {
+        return entities.Select(ToDto);
+    }
+}

--- a/src/Core/Services/PhoneAssignmentService.cs
+++ b/src/Core/Services/PhoneAssignmentService.cs
@@ -1,25 +1,39 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
-//  No warranty, explicit or implicit, provided.
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
 
 using Core.DTOs;
 using Core.Interfaces.Managers;
+using Core.Interfaces.Services;
 
 namespace Core.Services;
 
 /// <summary>
-/// Service for managing phone assignments on the dashboard.
+/// Provides business logic operations for managing phone assignments on the dashboard.
 /// </summary>
-public class PhoneAssignmentService(IPhoneAssignmentManager phoneAssignmentManager)
+/// <remarks>
+/// Delegates all data access to <see cref="IPhoneAssignmentManager"/> in Infrastructure,
+/// ensuring Core never depends on Infrastructure or data access concerns directly —
+/// following Clean Architecture and the Dependency Inversion Principle.
+/// </remarks>
+public class PhoneAssignmentService(IPhoneAssignmentManager phoneAssignmentManager) : IPhoneAssignmentService
 {
+    #region Fields
+
     private readonly IPhoneAssignmentManager _phoneAssignmentManager = phoneAssignmentManager;
+
+    #endregion
+
+    #region Methods
 
     /// <summary>
     /// Gets the current phone assignments for the active shift.
     /// </summary>
-    /// <param name="cancellationToken">Token to cancel the operation.</param>
-    /// <returns>A collection of phone assignments for the active shift.</returns>
-    public async Task<IEnumerable<PhoneAssignmentDto>> GetCurrentPhoneAssignmentsForActiveShift(CancellationToken cancellationToken)
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A collection of <see cref="PhoneAssignmentDto"/> for the active shift.</returns>
+    public async Task<IEnumerable<PhoneAssignmentDto>> GetCurrentPhoneAssignmentsForActiveShiftAsync(CancellationToken cancellationToken)
     {
         return await _phoneAssignmentManager.GetCurrentPhoneAssignmentsForActiveShift(cancellationToken);
     }
+
+    #endregion
 }

--- a/tests/WebApi.Tests/CustomWebApplicationFactory.cs
+++ b/tests/WebApi.Tests/CustomWebApplicationFactory.cs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Team6. All rights reserved.
 // No warranty, explicit or implicit, provided.
 
-using Core.Interfaces.Managers;
+using Core.Interfaces.Services;
 
 using Infrastructure.Data.Persistent;
 
@@ -34,7 +34,7 @@ public class CustomWebApplicationFactory<TStartup> : WebApplicationFactory<TStar
 
         _ = builder.ConfigureServices(services =>
         {
-            _ = services.AddScoped<IPhoneAssignmentManager, MockPhoneAssignmentManager>();
+            _ = services.AddScoped<IPhoneAssignmentService, MockPhoneAssignmentService>();
 
             ServiceDescriptor? descriptor = services.SingleOrDefault(
                 d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));

--- a/tests/WebApi.Tests/Mocks/MockPhoneAssignmentService.cs
+++ b/tests/WebApi.Tests/Mocks/MockPhoneAssignmentService.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+using Core.Interfaces.Services;
+
+namespace WebApi.Tests.Mocks;
+
+public class MockPhoneAssignmentService : IPhoneAssignmentService
+{
+    public Task<IEnumerable<PhoneAssignmentDto>> GetCurrentPhoneAssignmentsForActiveShiftAsync(
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IEnumerable<PhoneAssignmentDto>>([]);
+    }
+}


### PR DESCRIPTION
## Problem
PhoneList (UC005) did not follow the same Clean Architecture pattern. The controller injected IPhoneAssignmentManager directly, bypassing the service layer.

## Changes
- Added `IPhoneAssignmentService` interface in `Core/Interfaces/Services/`
- Updated `PhoneAssignmentService` to implement `IPhoneAssignmentService`
- Added `PhoneAssignmentMapper` in `Core/Mappers/`
- Updated `PhoneAssignmentsController` to inject `IPhoneAssignmentService` instead of `IPhoneAssignmentManager`
- Registered `IPhoneAssignmentService` in `Core/DependencyInjection.cs`
- Added `MockPhoneAssignmentService` in `WebApi.Tests/Mocks/`
- Updated `CustomWebApplicationFactory` to use `MockPhoneAssignmentService`

## Flow after fix
**WebUI:** WebUI → IPhoneAssignmentService → PhoneAssignmentService → IPhoneAssignmentManager → PhoneAssignmentManager → HTTP → WebApi

**WebApi:** Controller → IPhoneAssignmentService → PhoneAssignmentService → IPhoneAssignmentManager → IPhoneAssignmentRepository → DB

## Tests
35 passed, 0 failed