### PR TITLE
test: UC005 add PhoneAssignmentServiceTests for issue #188

### DIFF
--- a/tests/Core.Tests/Services/PhoneAssignmentServiceTests.cs
+++ b/tests/Core.Tests/Services/PhoneAssignmentServiceTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+using Core.Interfaces.Managers;
+using Core.Services;
+
+using Moq;
+
+namespace Core.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="PhoneAssignmentService"/>.
+/// </summary>
+public class PhoneAssignmentServiceTests
+{
+    #region Fields
+
+    private readonly Mock<IPhoneAssignmentManager> _phoneAssignmentManagerMock;
+    private readonly PhoneAssignmentService _service;
+
+    #endregion
+
+    #region Constructor
+
+    public PhoneAssignmentServiceTests()
+    {
+        _phoneAssignmentManagerMock = new Mock<IPhoneAssignmentManager>();
+        _service = new PhoneAssignmentService(_phoneAssignmentManagerMock.Object);
+    }
+
+    #endregion
+
+    #region GetCurrentPhoneAssignmentsForActiveShift
+
+    [Fact]
+    public async Task GetCurrentPhoneAssignmentsForActiveShift_ValidRequest_CallsManagerOnce()
+    {
+        // Arrange
+        CancellationToken cancellationToken = CancellationToken.None;
+
+        _ = _phoneAssignmentManagerMock
+            .Setup(m => m.GetCurrentPhoneAssignmentsForActiveShift(cancellationToken))
+            .ReturnsAsync([]);
+
+        // Act
+        _ = await _service.GetCurrentPhoneAssignmentsForActiveShift(cancellationToken);
+
+        // Assert
+        _phoneAssignmentManagerMock.Verify(
+            m => m.GetCurrentPhoneAssignmentsForActiveShift(cancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCurrentPhoneAssignmentsForActiveShift_ValidRequest_ReturnsManagerResult()
+    {
+        // Arrange
+        CancellationToken cancellationToken = CancellationToken.None;
+
+        IEnumerable<PhoneAssignmentDto> expected =
+        [
+            new PhoneAssignmentDto { PhoneNumber = "41522", ShiftType = "Day" },
+            new PhoneAssignmentDto { PhoneNumber = "41523", ShiftType = "Day" }
+        ];
+
+        _ = _phoneAssignmentManagerMock
+            .Setup(m => m.GetCurrentPhoneAssignmentsForActiveShift(cancellationToken))
+            .ReturnsAsync(expected);
+
+        // Act
+        IEnumerable<PhoneAssignmentDto> result =
+            await _service.GetCurrentPhoneAssignmentsForActiveShift(cancellationToken);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task GetCurrentPhoneAssignmentsForActiveShift_EmptyResult_ReturnsEmptyCollection()
+    {
+        // Arrange
+        CancellationToken cancellationToken = CancellationToken.None;
+
+        _ = _phoneAssignmentManagerMock
+            .Setup(m => m.GetCurrentPhoneAssignmentsForActiveShift(cancellationToken))
+            .ReturnsAsync([]);
+
+        // Act
+        IEnumerable<PhoneAssignmentDto> result =
+            await _service.GetCurrentPhoneAssignmentsForActiveShift(cancellationToken);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetCurrentPhoneAssignmentsForActiveShift_CancellationRequested_PropagatesCancellationToken()
+    {
+        // Arrange
+        CancellationToken cancellationToken = new CancellationToken(canceled: true);
+
+        _ = _phoneAssignmentManagerMock
+            .Setup(m => m.GetCurrentPhoneAssignmentsForActiveShift(cancellationToken))
+            .ThrowsAsync(new OperationCanceledException(cancellationToken));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _service.GetCurrentPhoneAssignmentsForActiveShift(cancellationToken));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Changes
- Added `PhoneAssignmentServiceTests.cs` in `tests/Core.Tests/Services/`

## Tests added
- `GetCurrentPhoneAssignmentsForActiveShift_ValidRequest_CallsManagerOnce`
- `GetCurrentPhoneAssignmentsForActiveShift_ValidRequest_ReturnsManagerResult`
- `GetCurrentPhoneAssignmentsForActiveShift_EmptyResult_ReturnsEmptyCollection`
- `GetCurrentPhoneAssignmentsForActiveShift_CancellationRequested_PropagatesCancellationToken`

## Test results
39 passed, 0 failed

Closes #188