### PR TITLE
fix: UC005 wire PhoneAssignment view to repository for issue #184

### DIFF
--- a/src/Core/Interfaces/Repositories/IPhoneAssignmentRepository.cs
+++ b/src/Core/Interfaces/Repositories/IPhoneAssignmentRepository.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Team6. All rights reserved.
 // No warranty, explicit or implicit, provided.
 
+using Core.DTOs;
+
 using Domain.Entities;
 
 namespace Core.Interfaces.Repositories;
@@ -17,4 +19,12 @@ public interface IPhoneAssignmentRepository : IRepository<PhoneAssignment>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A collection of phone assignments for the given shift.</returns>
     Task<IEnumerable<PhoneAssignment>> GetByShiftTypeAsync(string shiftType, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Retrieves phone assignments with caregiver name from the view for the given shift.
+    /// </summary>
+    /// <param name="shiftType">The shift type (Day, Evening, Night).</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A collection of phone assignment DTOs including caregiver name.</returns>
+    Task<IEnumerable<PhoneAssignmentDto>> GetDtoByShiftTypeAsync(string shiftType, CancellationToken cancellationToken);
 }

--- a/src/Infrastructure.Data/Repositories/PhoneAssignmentRepository.cs
+++ b/src/Infrastructure.Data/Repositories/PhoneAssignmentRepository.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Team6. All rights reserved.
 // No warranty, explicit or implicit, provided.
 
+using Core.DTOs;
 using Core.Interfaces.Repositories;
 
 using Domain.Entities;
@@ -25,6 +26,22 @@ public class PhoneAssignmentRepository(AppDbContext dbContext)
     {
         return await _dbContext.PhoneAssignments
             .Where(p => p.ShiftType == shiftType)
+            .ToListAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<PhoneAssignmentDto>> GetDtoByShiftTypeAsync(
+        string shiftType, CancellationToken cancellationToken)
+    {
+        // Use the vwPhoneAssignment view to get phone assignments with caregiver name
+        return await _dbContext.PhoneAssignmentView
+            .Where(p => p.ShiftType == shiftType)
+            .Select(p => new PhoneAssignmentDto
+            {
+                PhoneNumber = p.PhoneNumber,
+                ShiftType = p.ShiftType,
+                AssignedStaffName = p.CaregiverName
+            })
             .ToListAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
Closes #184

## Changes
- Added GetDtoByShiftTypeAsync to IPhoneAssignmentRepository (Core)
- Implemented GetDtoByShiftTypeAsync in PhoneAssignmentRepository using vwPhoneAssignment view
- Maps PhoneAssignmentView → PhoneAssignmentDto (CaregiverName → AssignedStaffName)
- SQL view is now wired up and used in repository layer