### PR TITLE
fix: add missing blank lines between headers and body in api.http for…

### DIFF
--- a/src/Api/Api.http
+++ b/src/Api/Api.http
@@ -14,6 +14,7 @@ Content-Type: application/json
 POST {{Api_HostAddress}}/Account/login
 Accept: application/json
 Content-Type: application/json
+
 {
     "email": "testuser@example.com",
     "password": "Password123!"
@@ -23,7 +24,8 @@ Content-Type: application/json
 POST {{Api_HostAddress}}/Account/refresh
 Accept: application/json
 Content-Type: application/json
+
 {
-    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI4YmQwMTdmZi02MjEyLTQ1OWMtOGFjNC05ZTJiYzkyNjgyOTAiLCJleHAiOjE3NzY2NzA5MTEsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3QiLCJhdWQiOiJiWmN1cmpWeURKQ20yJUtId3dSY2R1SU95amVLeVIyMiJ9.My1ZXl2S5StgPNpSBdw3o1KDoE-2RjrL9mJm5cFDLgo",
-    "refreshToken": "dp4h2GA5PegKTI2cWyCAQ8zvhu7dQXo+36otqfX1ZcoeiahHsmiGMjnitNPeE5nB3W/o1HTi/CXTE4T6Mqle8g=="
+    "accessToken": "PASTE_ACCESS_TOKEN_HERE",
+    "refreshToken": "PASTE_REFRESH_TOKEN_HERE"
 }


### PR DESCRIPTION
Adds missing blank lines between HTTP headers and JSON body in api.http for Login and Refresh requests, ensuring compatibility with both VS Code REST Client and Visual Studio 2026 Enterprise.

VS Code REST Client was tolerant of the missing blank lines, but Visual Studio strictly follows RFC 7230 which requires the empty line as separator between headers and body.

Tested all three endpoints (Register, Login, Refresh) — all return expected responses.