### PR TITLE
feat(uc-002): update ResidentNote table, add vwResidentNote view, con…

### DIFF
--- a/src/Domain/Entities/ResidentNote.cs
+++ b/src/Domain/Entities/ResidentNote.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 
 using System.ComponentModel.DataAnnotations;
@@ -12,8 +12,12 @@ public class ResidentNote : IEntity
 {
     [Key]
     public Guid Id { get; set; }
+
     [Required]
     public string Note { get; set; } = string.Empty;
+
+    [Required]
+    public DateTime CreatedAt { get; set; }
 
     [Required]
     public DateTime EditedAt { get; set; }

--- a/src/Infrastructure.Data/Persistent/AppDbContext.cs
+++ b/src/Infrastructure.Data/Persistent/AppDbContext.cs
@@ -39,6 +39,7 @@ public partial class AppDbContext(DbContextOptions<AppDbContext> options) : Iden
         _ = modelBuilder.ApplyConfiguration(new Configurations.ResidentNoteConfiguration());
         _ = modelBuilder.ApplyConfiguration(new Configurations.MedicineRecordConfiguration());
         _ = modelBuilder.ApplyConfiguration(new Configurations.PainkillerRecordConfiguration());
+        _ = modelBuilder.ApplyConfiguration(new Configurations.AuditLogConfiguration());
 
         _ = modelBuilder.Entity<MedicineStatusView>()
             .HasNoKey()
@@ -47,6 +48,10 @@ public partial class AppDbContext(DbContextOptions<AppDbContext> options) : Iden
         _ = modelBuilder.Entity<PainkillerStatusView>()
             .HasNoKey()
             .ToView("painkillerstatusview");
+
+        _ = modelBuilder.Entity<ResidentNoteView>()
+            .HasNoKey()
+            .ToView("vwResidentNote");
 
         _ = modelBuilder.Entity<PhoneAssignmentView>()
             .HasNoKey()

--- a/src/Infrastructure.Data/Persistent/Configurations/AuditLogConfiguration.cs
+++ b/src/Infrastructure.Data/Persistent/Configurations/AuditLogConfiguration.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+//  No warranty, explicit or implicit, provided.
+
+using Domain.Entities;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Data.Persistent.Configurations;
+
+/// <summary>
+/// Provides Entity Framework Core configuration for the <see cref="AuditLog"/> entity.
+/// </summary>
+/// <remarks>
+/// Pins string column lengths so MySQL does not fall back to <c>longtext</c>, and
+/// adds indexes on the columns most often used to filter audit queries
+/// (entity name, timestamp, changed-by user).
+/// </remarks>
+public class AuditLogConfiguration : IEntityTypeConfiguration<AuditLog>
+{
+    #region Constants
+
+    private const int EntityNameMaxLength = 100;
+    private const int ChangeTypeMaxLength = 20;
+    private const int ChangedByMaxLength = 100;
+    private const int DescriptionMaxLength = 1000;
+
+    #endregion
+
+    #region Methods
+
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<AuditLog> builder)
+    {
+        _ = builder.HasKey(a => a.Id);
+
+        _ = builder.Property(a => a.EntityName)
+            .IsRequired()
+            .HasMaxLength(EntityNameMaxLength);
+
+        _ = builder.Property(a => a.ChangeType)
+            .IsRequired()
+            .HasMaxLength(ChangeTypeMaxLength);
+
+        _ = builder.Property(a => a.ChangedBy)
+            .HasMaxLength(ChangedByMaxLength);
+
+        _ = builder.Property(a => a.Timestamp)
+            .IsRequired();
+
+        _ = builder.Property(a => a.Description)
+            .IsRequired()
+            .HasMaxLength(DescriptionMaxLength);
+
+        _ = builder.HasIndex(a => a.EntityName)
+            .HasDatabaseName("IX_AuditLogs_EntityName");
+
+        _ = builder.HasIndex(a => a.Timestamp)
+            .HasDatabaseName("IX_AuditLogs_Timestamp");
+
+        _ = builder.HasIndex(a => a.ChangedBy)
+            .HasDatabaseName("IX_AuditLogs_ChangedBy");
+    }
+
+    #endregion
+}

--- a/src/Infrastructure.Data/Persistent/Configurations/ResidentNoteConfiguration.cs
+++ b/src/Infrastructure.Data/Persistent/Configurations/ResidentNoteConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 
 using Domain.Entities;
@@ -8,29 +8,65 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Infrastructure.Data.Persistent.Configurations;
 
+/// <summary>
+/// Provides Entity Framework Core configuration for the <see cref="ResidentNote"/> entity.
+/// </summary>
+/// <remarks>
+/// Configures column lengths, required fields and an index on <c>ResidentId</c> to support
+/// efficient lookups of notes for a single resident (UC-002 Dashboard ResidentNote).
+/// </remarks>
 public class ResidentNoteConfiguration : IEntityTypeConfiguration<ResidentNote>
 {
+    #region Constants
+
+    private const int NoteMaxLength = 2000;
+    private static readonly DateTime SeedTimestamp = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    #endregion
+
+    #region Methods
+
+    /// <inheritdoc />
     public void Configure(EntityTypeBuilder<ResidentNote> builder)
     {
+        _ = builder.Property(n => n.Note)
+            .IsRequired()
+            .HasMaxLength(NoteMaxLength);
+
+        _ = builder.Property(n => n.CreatedAt)
+            .IsRequired();
+
+        _ = builder.Property(n => n.EditedAt)
+            .IsRequired();
+
+        _ = builder.HasIndex(n => n.ResidentId)
+            .HasDatabaseName("IX_ResidentNotes_ResidentId");
+
         SeedingData(builder);
     }
 
+    /// <summary>
+    /// Seeds initial <see cref="ResidentNote"/> rows used for development and integration tests.
+    /// </summary>
+    /// <param name="builder">The entity type builder.</param>
     public static void SeedingData(EntityTypeBuilder<ResidentNote> builder)
     {
         _ = builder.HasData(
-        new ResidentNote { Id = Guid.Parse("F5A6B7C8-9012-3456-7890-ABCDEF012345"), ResidentId = Guid.Parse("694B9796-DC5A-4A68-BAFB-0A59595E8FB3"), Note = "Resident A's note.", EditedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
-        new ResidentNote { Id = Guid.Parse("A6B7C8D9-0123-4567-8901-BCDEF0123456"), ResidentId = Guid.Parse("A1B2C3D4-E5F6-7890-1234-56789ABCDEF0"), Note = "Resident B's note.", EditedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
-        new ResidentNote { Id = Guid.Parse("B7C8D9E0-1234-5678-9012-CDEF01234567"), ResidentId = Guid.Parse("C2D3E4F5-6789-0123-4567-89ABCDEF0123"), Note = "Resident C's note.", EditedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
-        new ResidentNote { Id = Guid.Parse("C8D9E0F1-2345-6789-0123-DEF012345678"), ResidentId = Guid.Parse("D3E4F5A6-7890-1234-5678-9ABCDEF01234"), Note = "Resident D's note.", EditedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
-        new ResidentNote { Id = Guid.Parse("D9E0F1A2-3456-7890-1234-EF0123456789"), ResidentId = Guid.Parse("E4F5A6B7-8901-2345-6789-ABCDEF012345"), Note = "Resident E's note.", EditedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
-        new ResidentNote { Id = Guid.Parse("E0F1A2B3-4567-8901-2345-F0123456789A"), ResidentId = Guid.Parse("F5A6B7C8-9012-3456-789A-BCDEF0123456"), Note = "Resident F's note.", EditedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
-        new ResidentNote { Id = Guid.Parse("F1A2B3C4-5678-9012-3456-0123456789AB"), ResidentId = Guid.Parse("A6B7C8D9-0123-4567-89AB-CDEF01234567"), Note = "Resident GA's note.", EditedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
-        new ResidentNote { Id = Guid.Parse("A2B3C4D5-6789-0123-4567-123456789ABC"), ResidentId = Guid.Parse("B7C8D9E0-1234-5678-9ABC-DEF012345678"), Note = "Resident H's note.", EditedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
-        new ResidentNote { Id = Guid.Parse("B3C4D5E6-7890-1234-5678-23456789ABCD"), ResidentId = Guid.Parse("C8D9E0F1-2345-6789-ABCD-EF0123456789"), Note = "Resident I's note.", EditedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
-        new ResidentNote { Id = Guid.Parse("C4D5E6F7-8901-2345-6789-3456789ABCDE"), ResidentId = Guid.Parse("D9E0F1A2-3456-789A-BCDE-F01234567890"), Note = "Resident J's note.", EditedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
-        new ResidentNote { Id = Guid.Parse("D5E6F7A8-9012-3456-7890-456789ABCDE0"), ResidentId = Guid.Parse("E0F1A2B3-4567-89AB-CDEF-012345678901"), Note = "Resident K's note.", EditedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
-        new ResidentNote { Id = Guid.Parse("E6F7A8B9-0123-4567-8901-56789ABCDE01"), ResidentId = Guid.Parse("F1A2B3C4-5678-9ABC-DEF0-123456789012"), Note = "Resident GB's note.", EditedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
-        new ResidentNote { Id = Guid.Parse("F7A8B9C0-1234-5678-9012-6789ABCDE012"), ResidentId = Guid.Parse("F1A2B3C4-5678-9ABC-DEF0-123456789012"), Note = "Resident GB's note 2.", EditedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
+            new ResidentNote { Id = Guid.Parse("F5A6B7C8-9012-3456-7890-ABCDEF012345"), ResidentId = Guid.Parse("694B9796-DC5A-4A68-BAFB-0A59595E8FB3"), Note = "Resident A's note.", CreatedAt = SeedTimestamp, EditedAt = SeedTimestamp },
+            new ResidentNote { Id = Guid.Parse("A6B7C8D9-0123-4567-8901-BCDEF0123456"), ResidentId = Guid.Parse("A1B2C3D4-E5F6-7890-1234-56789ABCDEF0"), Note = "Resident B's note.", CreatedAt = SeedTimestamp, EditedAt = SeedTimestamp },
+            new ResidentNote { Id = Guid.Parse("B7C8D9E0-1234-5678-9012-CDEF01234567"), ResidentId = Guid.Parse("C2D3E4F5-6789-0123-4567-89ABCDEF0123"), Note = "Resident C's note.", CreatedAt = SeedTimestamp, EditedAt = SeedTimestamp },
+            new ResidentNote { Id = Guid.Parse("C8D9E0F1-2345-6789-0123-DEF012345678"), ResidentId = Guid.Parse("D3E4F5A6-7890-1234-5678-9ABCDEF01234"), Note = "Resident D's note.", CreatedAt = SeedTimestamp, EditedAt = SeedTimestamp },
+            new ResidentNote { Id = Guid.Parse("D9E0F1A2-3456-7890-1234-EF0123456789"), ResidentId = Guid.Parse("E4F5A6B7-8901-2345-6789-ABCDEF012345"), Note = "Resident E's note.", CreatedAt = SeedTimestamp, EditedAt = SeedTimestamp },
+            new ResidentNote { Id = Guid.Parse("E0F1A2B3-4567-8901-2345-F0123456789A"), ResidentId = Guid.Parse("F5A6B7C8-9012-3456-789A-BCDEF0123456"), Note = "Resident F's note.", CreatedAt = SeedTimestamp, EditedAt = SeedTimestamp },
+            new ResidentNote { Id = Guid.Parse("F1A2B3C4-5678-9012-3456-0123456789AB"), ResidentId = Guid.Parse("A6B7C8D9-0123-4567-89AB-CDEF01234567"), Note = "Resident GA's note.", CreatedAt = SeedTimestamp, EditedAt = SeedTimestamp },
+            new ResidentNote { Id = Guid.Parse("A2B3C4D5-6789-0123-4567-123456789ABC"), ResidentId = Guid.Parse("B7C8D9E0-1234-5678-9ABC-DEF012345678"), Note = "Resident H's note.", CreatedAt = SeedTimestamp, EditedAt = SeedTimestamp },
+            new ResidentNote { Id = Guid.Parse("B3C4D5E6-7890-1234-5678-23456789ABCD"), ResidentId = Guid.Parse("C8D9E0F1-2345-6789-ABCD-EF0123456789"), Note = "Resident I's note.", CreatedAt = SeedTimestamp, EditedAt = SeedTimestamp },
+            new ResidentNote { Id = Guid.Parse("C4D5E6F7-8901-2345-6789-3456789ABCDE"), ResidentId = Guid.Parse("D9E0F1A2-3456-789A-BCDE-F01234567890"), Note = "Resident J's note.", CreatedAt = SeedTimestamp, EditedAt = SeedTimestamp },
+            new ResidentNote { Id = Guid.Parse("D5E6F7A8-9012-3456-7890-456789ABCDE0"), ResidentId = Guid.Parse("E0F1A2B3-4567-89AB-CDEF-012345678901"), Note = "Resident K's note.", CreatedAt = SeedTimestamp, EditedAt = SeedTimestamp },
+            new ResidentNote { Id = Guid.Parse("E6F7A8B9-0123-4567-8901-56789ABCDE01"), ResidentId = Guid.Parse("F1A2B3C4-5678-9ABC-DEF0-123456789012"), Note = "Resident GB's note.", CreatedAt = SeedTimestamp, EditedAt = SeedTimestamp },
+            new ResidentNote { Id = Guid.Parse("F7A8B9C0-1234-5678-9012-6789ABCDE012"), ResidentId = Guid.Parse("F1A2B3C4-5678-9ABC-DEF0-123456789012"), Note = "Resident GB's note 2.", CreatedAt = SeedTimestamp, EditedAt = SeedTimestamp }
         );
     }
+
+    #endregion
 }

--- a/src/Infrastructure.Data/Persistent/Views/ResidentNoteView.cs
+++ b/src/Infrastructure.Data/Persistent/Views/ResidentNoteView.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+namespace Infrastructure.Data.Persistent.Views;
+
+/// <summary>
+/// Read model for the <c>vwResidentNote</c> database view.
+/// Represents a resident note joined with the resident's initials.
+/// </summary>
+/// <remarks>
+/// This is not a domain entity — it is a read-only projection used by the API
+/// to return notes with display data (initials) without an extra join in code.
+/// </remarks>
+public sealed class ResidentNoteView
+{
+    public Guid Id { get; init; }
+    public string Note { get; init; } = string.Empty;
+    public DateTime CreatedAt { get; init; }
+    public DateTime EditedAt { get; init; }
+    public Guid ResidentId { get; init; }
+    public string Initials { get; init; } = string.Empty;
+}

--- a/src/Infrastructure.Data/SQL/DDL/Views/vwResidentNote.sql
+++ b/src/Infrastructure.Data/SQL/DDL/Views/vwResidentNote.sql
@@ -1,0 +1,23 @@
+-- ============================================================
+-- View: vwResidentNote
+-- Description: Provides a read-optimized view of resident notes
+--              joined with the resident's initials so the API
+--              can return notes with display data in a single query.
+--              Used by the Dashboard ResidentNote feature.
+-- CrossReference: UC-002.ERD UC-002.DCD
+-- Author: Team 6
+-- Date: 2026-05-03
+-- Version: 0001
+-- ============================================================
+
+CREATE OR REPLACE VIEW vwResidentNote AS
+    -- Join ResidentNotes with Residents to resolve ResidentId to Initials
+    SELECT
+        rn.Id           AS Id,
+        rn.Note         AS Note,
+        rn.CreatedAt    AS CreatedAt,
+        rn.EditedAt     AS EditedAt,
+        rn.ResidentId   AS ResidentId,
+        r.Initials      AS Initials
+    FROM ResidentNotes rn
+    INNER JOIN Residents r ON rn.ResidentId = r.Id;


### PR DESCRIPTION
## UC-002 Dashboard ResidentNote — Code + SQL (Issue #134)

### Changes
- **Update tables**: Added `CreatedAt` to `ResidentNote` entity (matches ERD-002).
  Configured `ResidentNote` with MaxLength on `Note`, required fields, and an index on `ResidentId`.
- **Create View**: Added `vwResidentNote` SQL DDL that joins `ResidentNotes` with `Residents`
  to expose `Initials` for the API. Added matching `ResidentNoteView` C# read model
  registered in `AppDbContext` with `HasNoKey()`.
- **Update Audit Log**: Added `AuditLogConfiguration` with MaxLength on string columns
  and indexes on `EntityName`, `Timestamp`, `ChangedBy` for efficient audit queries.

### Notes
- Migration not generated locally — please advise on team migration flow.
- All 66 tests pass via Docker test stage.

Refs #134