### PR TITLE
test(uc-002): add UI tests for NotesSection and ResidentNotesList com…

### DIFF
--- a/tests/WebUI.Tests/Components/Residents/NotesSectionTests.cs
+++ b/tests/WebUI.Tests/Components/Residents/NotesSectionTests.cs
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+//  No warranty, explicit or implicit, provided.
+
+using AngleSharp.Dom;
+
+using Bunit;
+
+using Core.Interfaces.Services;
+
+using Domain.Entities;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+
+using NotesSectionComponent = WebUI.Client.Components.Residents.NotesSection;
+
+namespace WebUI.Tests.Components.Residents;
+
+/// <summary>
+/// Unit tests for the NotesSection Blazor component.
+/// </summary>
+public class NotesSectionTests : Bunit.TestContext
+{
+    #region Fields
+
+    private readonly Mock<IResidentNoteService> _residentNoteServiceMock;
+    private readonly Resident _resident;
+
+    #endregion
+
+    #region Constructor
+
+    public NotesSectionTests()
+    {
+        _residentNoteServiceMock = new Mock<IResidentNoteService>();
+
+        _ = Services.AddScoped<IResidentNoteService>(_ => _residentNoteServiceMock.Object);
+
+        _ = _residentNoteServiceMock
+            .Setup(s => s.GetAllByResidentIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _resident = new Resident
+        {
+            Id = Guid.NewGuid(),
+            Initials = "AB",
+            Notes = []
+        };
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private IRenderedComponent<NotesSectionComponent> RenderWithNotes(List<ResidentNote>? notes = null)
+    {
+        return RenderComponent<NotesSectionComponent>(parameters => parameters
+            .Add(p => p.Resident, _resident)
+            .Add(p => p.Notes, notes ?? []));
+    }
+
+    private static void ClickButtonByText(IRenderedComponent<NotesSectionComponent> cut, string text)
+    {
+        cut.FindAll("button").First(b => b.TextContent.Contains(text)).Click();
+    }
+
+    #endregion
+
+    #region Render Tests
+
+    [Fact]
+    public void Render_WithNoNotes_RendersAddButton()
+    {
+        IRenderedComponent<NotesSectionComponent> cut = RenderWithNotes();
+
+        Assert.Contains("Tilf", cut.Markup);
+    }
+
+    [Fact]
+    public void Render_WithNotes_RendersNoteContent()
+    {
+        List<ResidentNote> notes =
+        [
+            new ResidentNote
+            {
+                Id = Guid.NewGuid(),
+                Note = "Test note content",
+                ResidentId = _resident.Id,
+                EditedAt = DateTime.UtcNow
+            }
+        ];
+
+        IRenderedComponent<NotesSectionComponent> cut = RenderWithNotes(notes);
+
+        Assert.Contains("Test note content", cut.Markup);
+    }
+
+    #endregion
+
+    #region Toggle Form Tests
+
+    [Fact]
+    public void ToggleAddForm_OnFirstClick_ShowsTextarea()
+    {
+        IRenderedComponent<NotesSectionComponent> cut = RenderWithNotes();
+
+        cut.Find("button.btn-outline-primary").Click();
+
+        Assert.NotNull(cut.Find("textarea"));
+    }
+
+    [Fact]
+    public void ToggleAddForm_OnSecondClick_HidesTextarea()
+    {
+        IRenderedComponent<NotesSectionComponent> cut = RenderWithNotes();
+
+        cut.Find("button.btn-outline-primary").Click();
+        cut.Find("button.btn-outline-primary").Click();
+
+        Assert.Empty(cut.FindAll("textarea"));
+    }
+
+    #endregion
+
+    #region Add Note Tests
+
+    [Fact]
+    public void AddNote_WithValidText_CallsServiceAddAsync()
+    {
+        _ = _residentNoteServiceMock
+            .Setup(s => s.AddAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        IRenderedComponent<NotesSectionComponent> cut = RenderWithNotes();
+
+        cut.Find("button.btn-outline-primary").Click();
+        cut.Find("textarea").Change("My new note");
+        ClickButtonByText(cut, "Gem");
+
+        _residentNoteServiceMock.Verify(
+            s => s.AddAsync(_resident.Id, "My new note", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void AddNote_WithWhitespaceText_DoesNotCallService()
+    {
+        IRenderedComponent<NotesSectionComponent> cut = RenderWithNotes();
+
+        cut.Find("button.btn-outline-primary").Click();
+        cut.Find("textarea").Change("   ");
+        ClickButtonByText(cut, "Gem");
+
+        _residentNoteServiceMock.Verify(
+            s => s.AddAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void AddNote_WhenServiceReturnsTrue_ShowsSuccessFeedback()
+    {
+        _ = _residentNoteServiceMock
+            .Setup(s => s.AddAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        IRenderedComponent<NotesSectionComponent> cut = RenderWithNotes();
+
+        cut.Find("button.btn-outline-primary").Click();
+        cut.Find("textarea").Change("Successful note");
+        ClickButtonByText(cut, "Gem");
+
+        Assert.Contains("alert-success", cut.Markup);
+    }
+
+    [Fact]
+    public void AddNote_WhenServiceReturnsFalse_ShowsErrorFeedback()
+    {
+        _ = _residentNoteServiceMock
+            .Setup(s => s.AddAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        IRenderedComponent<NotesSectionComponent> cut = RenderWithNotes();
+
+        cut.Find("button.btn-outline-primary").Click();
+        cut.Find("textarea").Change("Failing note");
+        ClickButtonByText(cut, "Gem");
+
+        Assert.Contains("alert-danger", cut.Markup);
+    }
+
+    #endregion
+
+    #region Cancel Add Form Tests
+
+    [Fact]
+    public void CancelAddForm_HidesTextarea()
+    {
+        IRenderedComponent<NotesSectionComponent> cut = RenderWithNotes();
+
+        cut.Find("button.btn-outline-primary").Click();
+        ClickButtonByText(cut, "Annull");
+
+        Assert.Empty(cut.FindAll("textarea"));
+    }
+
+    #endregion
+}

--- a/tests/WebUI.Tests/Components/Residents/ResidentNotesListTests.cs
+++ b/tests/WebUI.Tests/Components/Residents/ResidentNotesListTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+//  No warranty, explicit or implicit, provided.
+
+using Bunit;
+
+using Domain.Entities;
+
+using ResidentNotesListComponent = WebUI.Client.Components.Residents.ResidentNotesList;
+
+namespace WebUI.Tests.Components.Residents;
+
+/// <summary>
+/// Unit tests for the ResidentNotesList Blazor component.
+/// </summary>
+public class ResidentNotesListTests : Bunit.TestContext
+{
+    #region Render Tests
+
+    [Fact]
+    public void Render_WithNullNotes_RendersEmptyMessage()
+    {
+        IRenderedComponent<ResidentNotesListComponent> cut = RenderComponent<ResidentNotesListComponent>(parameters => parameters
+            .Add(p => p.Notes, null));
+
+        Assert.Contains("Ingen noter", cut.Markup);
+    }
+
+    [Fact]
+    public void Render_WithEmptyNotes_RendersEmptyMessage()
+    {
+        IRenderedComponent<ResidentNotesListComponent> cut = RenderComponent<ResidentNotesListComponent>(parameters => parameters
+            .Add(p => p.Notes, []));
+
+        Assert.Contains("Ingen noter", cut.Markup);
+    }
+
+    [Fact]
+    public void Render_WithNotes_RendersNoteText()
+    {
+        List<ResidentNote> notes =
+        [
+            new ResidentNote
+            {
+                Id = Guid.NewGuid(),
+                Note = "First note text",
+                EditedAt = DateTime.UtcNow
+            }
+        ];
+
+        IRenderedComponent<ResidentNotesListComponent> cut = RenderComponent<ResidentNotesListComponent>(parameters => parameters
+            .Add(p => p.Notes, notes));
+
+        Assert.Contains("First note text", cut.Markup);
+    }
+
+    [Fact]
+    public void Render_WithMultipleNotes_RendersInDescendingOrder()
+    {
+        DateTime older = new(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc);
+        DateTime newer = new(2026, 5, 4, 10, 0, 0, DateTimeKind.Utc);
+
+        List<ResidentNote> notes =
+        [
+            new ResidentNote
+            {
+                Id = Guid.NewGuid(),
+                Note = "Older note",
+                EditedAt = older
+            },
+            new ResidentNote
+            {
+                Id = Guid.NewGuid(),
+                Note = "Newer note",
+                EditedAt = newer
+            }
+        ];
+
+        IRenderedComponent<ResidentNotesListComponent> cut = RenderComponent<ResidentNotesListComponent>(parameters => parameters
+            .Add(p => p.Notes, notes));
+
+        int newerIndex = cut.Markup.IndexOf("Newer note");
+        int olderIndex = cut.Markup.IndexOf("Older note");
+
+        Assert.True(newerIndex < olderIndex, "Newer note should appear before older note in markup.");
+    }
+
+    [Fact]
+    public void Render_InEditMode_RendersTextarea()
+    {
+        Guid noteId = Guid.NewGuid();
+
+        List<ResidentNote> notes =
+        [
+            new ResidentNote
+            {
+                Id = noteId,
+                Note = "Editable note",
+                EditedAt = DateTime.UtcNow
+            }
+        ];
+
+        IRenderedComponent<ResidentNotesListComponent> cut = RenderComponent<ResidentNotesListComponent>(parameters => parameters
+            .Add(p => p.Notes, notes)
+            .Add(p => p.EditingNoteId, noteId)
+            .Add(p => p.EditNoteText, "Editing this"));
+
+        Assert.NotNull(cut.Find("textarea"));
+    }
+
+    [Fact]
+    public void Render_NotInEditMode_DoesNotRenderTextarea()
+    {
+        List<ResidentNote> notes =
+        [
+            new ResidentNote
+            {
+                Id = Guid.NewGuid(),
+                Note = "View only note",
+                EditedAt = DateTime.UtcNow
+            }
+        ];
+
+        IRenderedComponent<ResidentNotesListComponent> cut = RenderComponent<ResidentNotesListComponent>(parameters => parameters
+            .Add(p => p.Notes, notes)
+            .Add(p => p.EditingNoteId, null));
+
+        Assert.Empty(cut.FindAll("textarea"));
+    }
+
+    #endregion
+
+    #region Event Tests
+
+    [Fact]
+    public void ClickEditButton_RaisesOnStartEditEvent()
+    {
+        ResidentNote noteToEdit = new()
+        {
+            Id = Guid.NewGuid(),
+            Note = "Edit me",
+            EditedAt = DateTime.UtcNow
+        };
+
+        ResidentNote? receivedNote = null;
+
+        IRenderedComponent<ResidentNotesListComponent> cut = RenderComponent<ResidentNotesListComponent>(parameters => parameters
+            .Add(p => p.Notes, [noteToEdit])
+            .Add(p => p.OnStartEdit, n => receivedNote = n));
+
+        cut.FindAll("button").First(b => b.TextContent.Contains("Rediger")).Click();
+
+        Assert.NotNull(receivedNote);
+        Assert.Equal(noteToEdit.Id, receivedNote!.Id);
+    }
+
+    [Fact]
+    public void ClickDeleteButton_RaisesOnConfirmDeleteEvent()
+    {
+        Guid noteId = Guid.NewGuid();
+
+        ResidentNote noteToDelete = new()
+        {
+            Id = noteId,
+            Note = "Delete me",
+            EditedAt = DateTime.UtcNow
+        };
+
+        Guid? receivedId = null;
+
+        IRenderedComponent<ResidentNotesListComponent> cut = RenderComponent<ResidentNotesListComponent>(parameters => parameters
+            .Add(p => p.Notes, [noteToDelete])
+            .Add(p => p.OnConfirmDelete, id => receivedId = id));
+
+        cut.FindAll("button").First(b => b.TextContent.Contains("Slet")).Click();
+
+        Assert.Equal(noteId, receivedId);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## UC-002 Dashboard ResidentNote — UI Tests

Added bUnit + Moq unit tests for the two ResidentNote UI components.

### NotesSection (9 tests)
- Render with no notes / with notes
- Toggle add form (open/close)
- Cancel add form
- Add note: valid text, whitespace, success feedback, error feedback

### ResidentNotesList (8 tests)
- Render: null/empty notes shows empty message
- Render: notes shown with text
- Render: descending order by EditedAt
- Render: edit mode shows textarea
- Render: view mode does not show textarea
- Event bubbling: OnStartEdit, OnConfirmDelete

### Test infrastructure
- `Bunit.TestContext` base class (matches existing ResidentCardTests pattern)
- `Mock<IResidentNoteService>` for service isolation
- AAA pattern (Arrange/Act/Assert)

### Coverage
17 new tests, all passing in Docker test stage.

Closes #54