### PR TITLE
Fix dotnet test: restore --solution flag required by this SDK version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build
         run: dotnet build --no-restore Slottet.CareManagement.sln
       - name: Test
-        run: dotnet test Slottet.CareManagement.sln --no-build --verbosity normal --collect:"XPlat Code Coverage"
+        run: dotnet test --solution Slottet.CareManagement.sln --no-build --verbosity normal --collect:"XPlat Code Coverage"
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The SDK rejects a solution file as a positional argument and requires it to be passed via --solution. Revert the positional-arg change while keeping --collect:"XPlat Code Coverage" that was added for coverage.