### PR TITLE
Remove --collect flag incompatible with xunit v3 native runner

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,10 +53,4 @@ jobs:
       - name: Build
         run: dotnet build --no-restore Slottet.CareManagement.sln
       - name: Test
-        run: dotnet test --solution Slottet.CareManagement.sln --no-build --verbosity normal --collect:"XPlat Code Coverage"
-      - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-reports
-          path: "**/TestResults/**/coverage.cobertura.xml"
-          if-no-files-found: warn
+        run: dotnet test --solution Slottet.CareManagement.sln --no-build --verbosity normal


### PR DESCRIPTION
xunit v3 compiles tests as self-executing assemblies and runs them natively, bypassing the VSTest protocol. --collect:"XPlat Code Coverage" is a VSTest data collector option; xunit v3 passes it as a raw CLI arg to the test DLL which rejects it with "Unknown option '--collect'".

Coverage with xunit v3 requires a separate approach (dotnet-coverage global tool or coverlet.msbuild in each test project) and will be addressed in a dedicated PR.