### PR TITLE
Add UC-007 use case for authenticate to access data

### DIFF
--- a/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.usecase.da.md
+++ b/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.usecase.da.md
@@ -1,0 +1,132 @@
+# Use Case: Authenticate to access data
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-007 |
+| crossReference | BC<br/>REQ-F-005<br/>REQ-U-005<br/>REQ-DC-001<br/>REQ-R-003 |
+| Title          | Authenticate to access data |
+| Author         | Team 6 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-09 | Initial     | Team 6 |
+
+## Use Case Description (Danish)
+
+## Brugerhistorie
+Som medarbejder vil jeg kunne logge ind med e-mail og adgangskode, før jeg kan tilgå data i drifttavlen, så borgerrelaterede oplysninger kun kan ses, når jeg er korrekt autentificeret.
+
+### Kort Use Case
+**Titel**: Autentificér for at få adgang til data
+**Succesforløb**:
+Medarbejderen åbner login-siden, indtaster gyldige legitimationsoplysninger, og systemet autentificerer brugeren. Systemet returnerer et access token (JWT) og et refresh token, klienten gemmer dem, og den autentificerede medarbejder kan derefter tilgå data i drifttavlen via autentificerede forespørgsler.
+
+### Casual Use Case
+**Titel**: Autentificér for at få adgang til data
+**Scope**: Slottets Drifttavlen (Autentificering)
+**Niveau**: Brugermål
+**Aktører**:
+- Medarbejder
+- Autentificeret medarbejder
+- System
+
+**Hovedforløb**:
+1: Medarbejderen åbner login-siden.
+2: Medarbejderen indtaster e-mail og adgangskode og sender.
+3: Systemet validerer legitimationsoplysninger og brugerens adgang (rolle/rettigheder).
+4: Systemet udsteder et access token (JWT) og et refresh token.
+5: Klienten gemmer tokens og navigerer til drifttavlen.
+6: Den autentificerede medarbejder tilgår drifttavlens data.
+
+**Hovedudvidelser**:
+2a: Ugyldige legitimationsoplysninger.
+    1: Systemet viser en fejlbesked og udsteder ingen token.
+4a: Netværks- eller serverfejl under login.
+    1: Systemet viser en fejl og giver mulighed for at prøve igen.
+6a: Access token er udløbet.
+    1: Klienten fornyer access token ved hjælp af refresh token.
+    2: Systemet udsteder et nyt access token og forespørgslen forsøges igen.
+6b: Refresh token er udløbet eller tilbagekaldt.
+    1: Systemet afviser fornyelses-forespørgslen.
+    2: Klienten rydder tokens og sender brugeren tilbage til login.
+
+**Resumé**: Personalet skal autentificere sig før adgang til drifttavlens data; tokens muliggør fortsat adgang uden at gå på kompromis med datasikkerheden.
+
+### Fuldt Udfoldet Use Case
+**Titel**: Autentificér for at få adgang til data
+**Scope**: Slottets Drifttavlen (Autentificering)
+**Niveau**: Brugermål
+**Aktører**:
+- Medarbejder
+- Autentificeret medarbejder
+- System
+
+**Relaterede Krav**:
+- [REQ-F-005] Adgangskontrol og login (hurtigt login, minimumskrav til kodeord, initialer/e-mail som brugernavn).
+- [REQ-U-005] Hurtig og nem login-proces.
+- [REQ-DC-001] GDPR-overholdelse og sikker håndtering af persondata.
+- [REQ-R-003] Audit-log for alle ændringer og brugerhandlinger.
+
+**Forudsætninger**:
+- Systemet er i drift.
+- Identity API er tilgængelig.
+- Medarbejderen har en brugerkonto.
+- Brugeren er ikke allerede autentificeret (eller skal logge ind igen pga. udløbet session).
+
+**Hovedforløb**:
+1. Medarbejderen åbner login-siden.
+2. Medarbejderen indtaster e-mail og adgangskode og sender.
+3. Systemet validerer legitimationsoplysninger.
+4. Systemet udsteder et access token (JWT) og et refresh token og returnerer dem til klienten.
+5. Klienten gemmer tokens og navigerer til drifttavlen.
+6. Den autentificerede medarbejder forespørger på data til drifttavlen.
+7. Systemet autoriserer forespørgslen og returnerer data til autentificerede brugere.
+
+**Udvidelser**:
+    a: På ethvert tidspunkt, hvis en netværks- eller serverfejl opstår, viser systemet en fejl og giver mulighed for at prøve igen.
+    b: På ethvert tidspunkt, hvis brugeren ikke er autentificeret, afviser systemet adgang til beskyttede data og sender brugeren til login.
+    3a: Legitimationsoplysninger er ugyldige.
+        1: Systemet afviser login og viser en generisk fejl (ingen token udstedes).
+    3b: Brugeren er autentificeret, men har ikke de nødvendige rettigheder.
+        1: Systemet afviser login eller nægter adgang og viser en autorisationsfejl.
+    6a: Access token er udløbet.
+        1: Klienten anmoder automatisk om et nyt access token (via `POST /Account/Refresh`, fx gennem `JwtRefreshMiddleware`).
+        2: Systemet validerer refresh token og udsteder et nyt access token.
+        3: Klienten forsøger den oprindelige forespørgsel igen.
+    6b: Refresh token er udløbet eller tilbagekaldt.
+        1: Systemet afviser fornyelses-forespørgslen.
+        2: Klienten rydder gemte tokens og sender brugeren til login.
+
+**Efterbetingelser**:
+- Ved succes er brugeren autentificeret og kan tilgå drifttavlens data, mens access token er gyldigt.
+- Ved fejl gemmes der ikke et access token, og der returneres ingen beskyttede data.
+
+## Vedligeholdelse
+- Opdater version og ændringslog ved større ændringer.
+- Gennemgå regelmæssigt use cases for nøjagtighed og relevans.
+- Gennemgå og godkend use cases med relevante interessenter før accept.
+
+## Implementation Notes
+- Identity-endpoints (AccountController): `POST /Account/Register`, `POST /Account/Login`, `POST /Account/Refresh`, `POST /Account/Logout`, `DELETE /Account/{userId}`, `POST /Account/GetUserIdByEmail`.
+- Frontend login-side: `src/WebUI/WebUI.Client/Components/Pages/Login.razor`.
+- Login-endpoint: `POST /Account/Login` i `src/Api/Controllers/Identity/AccountController.cs`.
+- Token storage: `src/WebUI/WebUI.Client/Services/TokenStorageService.cs`.
+
+## Terms Translation
+| English          | Danish |
+|------------------|--------|
+| Authenticate     | Autentificere |
+| Authentication   | Autentificering |
+| Authorization    | Autorisation |
+| Login            | Login |
+| Credentials      | Legitimationsoplysninger |
+| Access token     | Access token |
+| Refresh token    | Refresh token |
+| Token expired    | Token udløbet |
+| JWT              | JWT |
+| Dashboard data   | Drifttavlens data |
+| Retry            | Prøv igen |
+| Network error    | Netværksfejl |
+| Permission       | Rettighed |

--- a/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.usecase.md
+++ b/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.usecase.md
@@ -1,0 +1,115 @@
+# Use Case: Authenticate to access data
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-007 |
+| crossReference | BC<br/>REQ-F-005<br/>REQ-U-005<br/>REQ-DC-001<br/>REQ-R-003 |
+| Title          | Authenticate to access data |
+| Author         | Team 6 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-09 | Initial     | Team 6 |
+
+## Use Case Description
+
+## User story
+As a staff member, I want to authenticate with my email and password before I can access dashboard data, so I can only view Resident-related information when I am properly logged in.
+
+### Brief Use Case
+**Title**: Authenticate to access data
+**Success Flow**:
+The staff member opens the login page, enters valid credentials, and the system authenticates the user. The system returns an access token (JWT) and a refresh token, the client stores them, and the authenticated staff member can access dashboard data through authenticated requests.
+
+### Casual Use Case
+**Title**: Authenticate to access data
+**Scope**: Slottets Drifttavlen (Authentication)
+**Level**: User Goal
+**Actors**:
+- Staff Member
+- Authenticated Staff Member
+- System
+
+**Main Flow**:
+1: Staff Member opens the login page.
+2: Staff Member enters email and password and submits.
+3: System validates credentials and user access (role/permissions).
+4: System issues an access token (JWT) and refresh token.
+5: Client stores tokens and navigates to the Dashboard.
+6: Authenticated Staff Member accesses dashboard data.
+
+**Main Extensions**:
+2a: Invalid credentials.
+    1: System shows an error message and issues no token.
+4a: Network or server error during login.
+    1: System shows an error and offers retry.
+6a: Access token is expired.
+    1: Client refreshes the access token using the refresh token.
+    2: System issues a new access token and the request is retried.
+6b: Refresh token is expired or revoked.
+    1: System denies the refresh request.
+    2: Client clears tokens and redirects to login.
+
+**Summary**: Staff must authenticate before accessing dashboard data; tokens support continued access while keeping data protected.
+
+### Fully Dressed Use Case
+**Title**: Authenticate to access data
+**Scope**: Slottets Drifttavlen (Authentication)
+**Level**: User Goal
+**Actors**:
+- Staff Member
+- Authenticated Staff Member
+- System
+
+**Related Requirements**:
+- [REQ-F-005] Access control and login (quick login, minimum password requirements, initials/email as username).
+- [REQ-U-005] Quick and easy login process.
+- [REQ-DC-001] GDPR compliance and secure handling of personal data.
+- [REQ-R-003] Audit log for all changes and user actions.
+
+**Preconditions**:
+- System is operational.
+- Identity API is available.
+- Staff Member has a user account.
+- User is not currently authenticated (or must re-authenticate due to expired session).
+
+**Main Flow**:
+1. Staff Member opens the login page.
+2. Staff Member enters email and password and submits.
+3. System validates the credentials.
+4. System issues an access token (JWT) and refresh token and returns them to the client.
+5. Client stores tokens and navigates to the Dashboard.
+6. Authenticated Staff Member requests dashboard data.
+7. System authorizes the request and returns data for authenticated users.
+
+**Extensions**:
+    a: At any time, if a network or server error occurs, system shows an error and offers retry.
+    b: At any time, if the user is not authenticated, system denies access to protected data and redirects the user to login.
+    3a: Credentials are invalid.
+        1: System rejects the login and shows a generic error (no token is issued).
+    3b: User is authenticated but does not have the required permissions.
+        1: System rejects the login or denies access and shows an authorization error.
+    6a: Access token is expired.
+        1: Client automatically requests a new access token (via `POST /Account/Refresh`, e.g., through `JwtRefreshMiddleware`).
+        2: System validates the refresh token and issues a new access token.
+        3: Client retries the original request.
+    6b: Refresh token is expired or revoked.
+        1: System rejects the refresh request.
+        2: Client clears stored tokens and redirects to login.
+
+**Postconditions**:
+- On success, the staff member is authenticated and can access dashboard data while the access token is valid.
+- On failure, no access token is stored and no protected data is returned.
+
+## Maintenance
+- Update the version and change log for major changes.
+- Regularly review use cases for accuracy and relevance.
+- Review and approve use cases with relevant stakeholders before acceptance.
+
+## Implementation Notes
+- Identity endpoints (AccountController): `POST /Account/Register`, `POST /Account/Login`, `POST /Account/Refresh`, `POST /Account/Logout`, `DELETE /Account/{userId}`, `POST /Account/GetUserIdByEmail`.
+- Frontend login page: `src/WebUI/WebUI.Client/Components/Pages/Login.razor`.
+- Login endpoint: `POST /Account/Login` in `src/Api/Controllers/Identity/AccountController.cs`.
+- Token storage: `src/WebUI/WebUI.Client/Services/TokenStorageService.cs`.


### PR DESCRIPTION
## Summary

Adds UC-007 use case (English + Danish) for the existing JWT authentication flow.

## Files

- `uc-007.usecase.md`
- `uc-007.usecase.da.md`

## Coverage

User story, Brief, Casual, Fully Dressed. Main flow + extensions for invalid credentials, network errors, token expiry, refresh token revocation. Cross-refs: BC, REQ-F-005, REQ-U-005, REQ-DC-001, REQ-R-003.

## Closes

Closes #208