### PR TITLE
fix(uc-007): refine usecase actors and scope (v0002)

### DIFF
--- a/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.usecase.da.md
+++ b/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.usecase.da.md
@@ -4,7 +4,7 @@
 | Key            | Value |
 |----------------|-------|
 | Id             | UC-007 |
-| crossReference | BC<br/>REQ-F-005<br/>REQ-U-005<br/>REQ-DC-001<br/>REQ-R-003 |
+| crossReference | BC<br/>UC-004<br/>REQ-F-005<br/>REQ-U-005<br/>REQ-DC-001<br/>REQ-R-003 |
 | Title          | Authenticate to access data |
 | Author         | Team 6 |
 
@@ -12,121 +12,115 @@
 | Version | Date       | Description | Author |
 |---------|------------|-------------|--------|
 | 0001    | 2026-05-09 | Initial     | Team 6 |
+| 0002    | 2026-05-10 | Add Time Event actor, re-scope to data access (login flow owned by UC-004), add audit trail postcondition | Team 6 |
 
-## Use Case Description (Danish)
+## Use Case Description
 
-## Brugerhistorie
-Som medarbejder vil jeg kunne logge ind med e-mail og adgangskode, før jeg kan tilgå data i drifttavlen, så borgerrelaterede oplysninger kun kan ses, når jeg er korrekt autentificeret.
+## User story
+Som autentificeret medarbejder vil jeg have, at alle forespørgsler på Dashboard-data — inklusive periodiske auto-refresh forespørgsler udløst af klientens Time Event — altid autoriseres af et gyldigt token, så borgerrelaterede oplysninger kun udleveres til en korrekt autentificeret session.
 
-### Kort Use Case
-**Titel**: Autentificér for at få adgang til data
-**Succesforløb**:
-Medarbejderen åbner login-siden, indtaster gyldige legitimationsoplysninger, og systemet autentificerer brugeren. Systemet returnerer et access token (JWT) og et refresh token, klienten gemmer dem, og den autentificerede medarbejder kan derefter tilgå data i drifttavlen via autentificerede forespørgsler.
+### Brief Use Case
+**Title**: Authenticate to access data
+**Success Flow**:
+Den autentificerede medarbejder åbner Dashboard, og klienten forespørger Dashboard-data fra Resource API ved at bruge et access token (JWT), som er gemt på klienten. Resource API validerer `[Authorize]` på beskyttede endpoints og returnerer kun Dashboard-data, når tokenet er gyldigt. Dashboardets Time Event udløser periodiske (60-sekunders) auto-refresh forespørgsler, som følger samme autentificerede forespørgselssti.
 
 ### Casual Use Case
-**Titel**: Autentificér for at få adgang til data
-**Scope**: Slottets Drifttavlen (Autentificering)
-**Niveau**: Brugermål
-**Aktører**:
-- Medarbejder
-- Autentificeret medarbejder
-- System
+**Title**: Authenticate to access data
+**Scope**: Slottets Drifttavlen (Autorisation af adgang til Dashboard-data)
+**Level**: User Goal
+**Actors**:
+- Authenticated Staff Member
+- Time Event (system actor — Dashboard 60-second auto-refresh trigger)
+- Resource API (validates [Authorize] on protected endpoints)
+- Identity API (validates and refreshes tokens)
 
-**Hovedforløb**:
-1: Medarbejderen åbner login-siden.
-2: Medarbejderen indtaster e-mail og adgangskode og sender.
-3: Systemet validerer legitimationsoplysninger og brugerens adgang (rolle/rettigheder).
-4: Systemet udsteder et access token (JWT) og et refresh token.
-5: Klienten gemmer tokens og navigerer til drifttavlen.
-6: Den autentificerede medarbejder tilgår drifttavlens data.
+**Main Flow**:
+1: Den autentificerede medarbejder åbner Dashboard.
+2: Klienten læser gemte tokens fra TokenStorageService.
+3: Klienten forespørger Dashboard-data fra Resource API ved at bruge `Authorization: Bearer <JWT>`.
+4: Resource API validerer `[Authorize]` og returnerer Dashboard-data.
+5: Klienten viser Dashboard-data.
+6: Time Event udløses hver 60. sekund, og klienten gentager trin 3–5 for at auto-refresh Dashboard.
 
-**Hovedudvidelser**:
-2a: Ugyldige legitimationsoplysninger.
-    1: Systemet viser en fejlbesked og udsteder ingen token.
-4a: Netværks- eller serverfejl under login.
-    1: Systemet viser en fejl og giver mulighed for at prøve igen.
-6a: Access token er udløbet.
-    1: Klienten fornyer access token ved hjælp af refresh token.
-    2: Systemet udsteder et nyt access token og forespørgslen forsøges igen.
-6b: Refresh token er udløbet eller tilbagekaldt.
-    1: Systemet afviser fornyelses-forespørgslen.
-    2: Klienten rydder tokens og sender brugeren tilbage til login.
+**Main Extensions**:
+3a: Access token mangler.
+    1: Resource API svarer `401 Unauthorized`.
+    2: Klienten sender brugeren videre via RedirectToLogin.
+3b: Access token er udløbet.
+    1: JwtRefreshMiddleware kalder `POST /Account/Refresh` på Identity API ved at bruge refresh token.
+    2: Klienten gentager trin 3 med et nyt access token.
+3c: Refresh token er udløbet eller tilbagekaldt.
+    1: Identity API afviser `POST /Account/Refresh`.
+    2: Klienten rydder tokens i TokenStorageService og sender brugeren videre via RedirectToLogin.
+4a: Brugeren mangler rettigheder.
+    1: Resource API svarer `403 Forbidden`.
+    2: Klienten viser en autorisationsfejl.
+5a: Netværks- eller serverfejl.
+    1: Klienten viser en fejl og giver mulighed for at prøve igen.
 
-**Resumé**: Personalet skal autentificere sig før adgang til drifttavlens data; tokens muliggør fortsat adgang uden at gå på kompromis med datasikkerheden.
+**Summary**: Dashboard-data returneres kun til autentificerede sessioner; tokens autoriserer både brugerinitierede forespørgsler og Time Event auto-refresh forespørgsler.
 
-### Fuldt Udfoldet Use Case
-**Titel**: Autentificér for at få adgang til data
-**Scope**: Slottets Drifttavlen (Autentificering)
-**Niveau**: Brugermål
-**Aktører**:
-- Medarbejder
-- Autentificeret medarbejder
-- System
+### Fully Dressed Use Case
+**Title**: Authenticate to access data
+**Scope**: Slottets Drifttavlen (Autorisation af adgang til Dashboard-data)
+**Level**: User Goal
+**Actors**:
+- Authenticated Staff Member
+- Time Event (system actor — Dashboard 60-second auto-refresh trigger)
+- Resource API (validates [Authorize] on protected endpoints)
+- Identity API (validates and refreshes tokens)
 
-**Relaterede Krav**:
+**Related Requirements**:
 - [REQ-F-005] Adgangskontrol og login (hurtigt login, minimumskrav til kodeord, initialer/e-mail som brugernavn).
 - [REQ-U-005] Hurtig og nem login-proces.
 - [REQ-DC-001] GDPR-overholdelse og sikker håndtering af persondata.
 - [REQ-R-003] Audit-log for alle ændringer og brugerhandlinger.
 
-**Forudsætninger**:
+**Preconditions**:
 - Systemet er i drift.
 - Identity API er tilgængelig.
-- Medarbejderen har en brugerkonto.
-- Brugeren er ikke allerede autentificeret (eller skal logge ind igen pga. udløbet session).
+- Resource API er tilgængelig.
+- Den autentificerede medarbejder har allerede autentificeret sig i henhold til UC-004, og klienten har gyldige tokens.
 
-**Hovedforløb**:
-1. Medarbejderen åbner login-siden.
-2. Medarbejderen indtaster e-mail og adgangskode og sender.
-3. Systemet validerer legitimationsoplysninger.
-4. Systemet udsteder et access token (JWT) og et refresh token og returnerer dem til klienten.
-5. Klienten gemmer tokens og navigerer til drifttavlen.
-6. Den autentificerede medarbejder forespørger på data til drifttavlen.
-7. Systemet autoriserer forespørgslen og returnerer data til autentificerede brugere.
+**Main Flow**:
+1. Den autentificerede medarbejder åbner Dashboard.
+2. Klienten læser gemte tokens fra TokenStorageService.
+3. Klienten forespørger Dashboard-data fra Resource API ved at bruge `Authorization: Bearer <JWT>`.
+4. Resource API validerer `[Authorize]` på det beskyttede endpoint og returnerer Dashboard-data.
+5. Klienten modtager svaret og viser Dashboard-data.
+6. Time Event udløses hver 60. sekund, og klienten gentager trin 3–5 for at auto-refresh Dashboard.
 
-**Udvidelser**:
-    a: På ethvert tidspunkt, hvis en netværks- eller serverfejl opstår, viser systemet en fejl og giver mulighed for at prøve igen.
-    b: På ethvert tidspunkt, hvis brugeren ikke er autentificeret, afviser systemet adgang til beskyttede data og sender brugeren til login.
-    3a: Legitimationsoplysninger er ugyldige.
-        1: Systemet afviser login og viser en generisk fejl (ingen token udstedes).
-    3b: Brugeren er autentificeret, men har ikke de nødvendige rettigheder.
-        1: Systemet afviser login eller nægter adgang og viser en autorisationsfejl.
-    6a: Access token er udløbet.
-        1: Klienten anmoder automatisk om et nyt access token (via `POST /Account/Refresh`, fx gennem `JwtRefreshMiddleware`).
-        2: Systemet validerer refresh token og udsteder et nyt access token.
-        3: Klienten forsøger den oprindelige forespørgsel igen.
-    6b: Refresh token er udløbet eller tilbagekaldt.
-        1: Systemet afviser fornyelses-forespørgslen.
-        2: Klienten rydder gemte tokens og sender brugeren til login.
+**Extensions**:
+    3a: Access token mangler.
+        1: Resource API svarer `401 Unauthorized`.
+        2: Klienten sender brugeren videre via RedirectToLogin.
+    3b: Access token er udløbet.
+        1: JwtRefreshMiddleware kalder `POST /Account/Refresh` på Identity API ved at bruge refresh token.
+        2: Identity API validerer refresh token og returnerer et nyt access token.
+        3: Klienten gentager trin 3.
+    3c: Refresh token er udløbet eller tilbagekaldt.
+        1: Identity API afviser `POST /Account/Refresh`.
+        2: Klienten rydder tokens i TokenStorageService og sender brugeren videre via RedirectToLogin.
+    4a: Brugeren mangler rettigheder.
+        1: Resource API svarer `403 Forbidden`.
+        2: Klienten viser en autorisationsfejl.
+    5a: Netværks- eller serverfejl.
+        1: Klienten viser en fejl og giver mulighed for at prøve igen.
 
-**Efterbetingelser**:
-- Ved succes er brugeren autentificeret og kan tilgå drifttavlens data, mens access token er gyldigt.
-- Ved fejl gemmes der ikke et access token, og der returneres ingen beskyttede data.
+**Postconditions**:
+- Ved succes udleveres Dashboard-data kun til autentificerede sessioner med et gyldigt access token.
+- Mislykkede autorisationsforsøg registreres i audit trail (REQ-R-003).
+- Ved fejl udleveres der ingen beskyttede Dashboard-data.
 
-## Vedligeholdelse
+## Maintenance
 - Opdater version og ændringslog ved større ændringer.
 - Gennemgå regelmæssigt use cases for nøjagtighed og relevans.
 - Gennemgå og godkend use cases med relevante interessenter før accept.
 
 ## Implementation Notes
-- Identity-endpoints (AccountController): `POST /Account/Register`, `POST /Account/Login`, `POST /Account/Refresh`, `POST /Account/Logout`, `DELETE /Account/{userId}`, `POST /Account/GetUserIdByEmail`.
-- Frontend login-side: `src/WebUI/WebUI.Client/Components/Pages/Login.razor`.
-- Login-endpoint: `POST /Account/Login` i `src/Api/Controllers/Identity/AccountController.cs`.
+- Login-formular og validering af credentials ejes af UC-004 (User Login). UC-007 starter efter et succesfuldt UC-004 login.
+- Identity endpoints (AccountController): `POST /Account/Login`, `POST /Account/Refresh`, `POST /Account/Logout`.
+- Resource API-beskyttelse: `[Authorize]` på beskyttede endpoints.
+- Klientens authorization header: Bearer token vedhæftes via `JwtAuthorizationMessageHandler` ved brug af TokenStorageService.
 - Token storage: `src/WebUI/WebUI.Client/Services/TokenStorageService.cs`.
-
-## Terms Translation
-| English          | Danish |
-|------------------|--------|
-| Authenticate     | Autentificere |
-| Authentication   | Autentificering |
-| Authorization    | Autorisation |
-| Login            | Login |
-| Credentials      | Legitimationsoplysninger |
-| Access token     | Access token |
-| Refresh token    | Refresh token |
-| Token expired    | Token udløbet |
-| JWT              | JWT |
-| Dashboard data   | Drifttavlens data |
-| Retry            | Prøv igen |
-| Network error    | Netværksfejl |
-| Permission       | Rettighed |
+- Audit logging (REQ-R-003) for mislykkede autorisationsforsøg håndteres af audit interceptor (UC-009 backend).

--- a/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.usecase.md
+++ b/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.usecase.md
@@ -4,7 +4,7 @@
 | Key            | Value |
 |----------------|-------|
 | Id             | UC-007 |
-| crossReference | BC<br/>REQ-F-005<br/>REQ-U-005<br/>REQ-DC-001<br/>REQ-R-003 |
+| crossReference | BC<br/>UC-004<br/>REQ-F-005<br/>REQ-U-005<br/>REQ-DC-001<br/>REQ-R-003 |
 | Title          | Authenticate to access data |
 | Author         | Team 6 |
 
@@ -12,56 +12,63 @@
 | Version | Date       | Description | Author |
 |---------|------------|-------------|--------|
 | 0001    | 2026-05-09 | Initial     | Team 6 |
+| 0002    | 2026-05-10 | Add Time Event actor, re-scope to data access (login flow owned by UC-004), add audit trail postcondition | Team 6 |
 
 ## Use Case Description
 
 ## User story
-As a staff member, I want to authenticate with my email and password before I can access dashboard data, so I can only view Resident-related information when I am properly logged in.
+As an authenticated staff member, I want every request for dashboard data — including periodic auto-refresh requests triggered by the client's Time Event — to be authorized by a valid token, so that resident-related information is only ever returned to a properly authenticated session.
 
 ### Brief Use Case
 **Title**: Authenticate to access data
 **Success Flow**:
-The staff member opens the login page, enters valid credentials, and the system authenticates the user. The system returns an access token (JWT) and a refresh token, the client stores them, and the authenticated staff member can access dashboard data through authenticated requests.
+The authenticated staff member opens the Dashboard and the client requests dashboard data from the Resource API using an access token (JWT) stored in the client. The Resource API validates `[Authorize]` on protected endpoints and returns dashboard data only when the token is valid. The Dashboard's Time Event triggers periodic (60-second) auto-refresh requests that follow the same authenticated request path.
 
 ### Casual Use Case
 **Title**: Authenticate to access data
-**Scope**: Slottets Drifttavlen (Authentication)
+**Scope**: Slottets Drifttavlen (Dashboard data access authorization)
 **Level**: User Goal
 **Actors**:
-- Staff Member
 - Authenticated Staff Member
-- System
+- Time Event (system actor — Dashboard 60-second auto-refresh trigger)
+- Resource API (validates [Authorize] on protected endpoints)
+- Identity API (validates and refreshes tokens)
 
 **Main Flow**:
-1: Staff Member opens the login page.
-2: Staff Member enters email and password and submits.
-3: System validates credentials and user access (role/permissions).
-4: System issues an access token (JWT) and refresh token.
-5: Client stores tokens and navigates to the Dashboard.
-6: Authenticated Staff Member accesses dashboard data.
+1: Authenticated Staff Member opens the Dashboard.
+2: Client reads stored tokens from TokenStorageService.
+3: Client requests dashboard data from Resource API using `Authorization: Bearer <JWT>`.
+4: Resource API validates `[Authorize]` and returns dashboard data.
+5: Client renders the dashboard data.
+6: Time Event triggers every 60 seconds and client repeats steps 3–5 to auto-refresh the Dashboard.
 
 **Main Extensions**:
-2a: Invalid credentials.
-    1: System shows an error message and issues no token.
-4a: Network or server error during login.
-    1: System shows an error and offers retry.
-6a: Access token is expired.
-    1: Client refreshes the access token using the refresh token.
-    2: System issues a new access token and the request is retried.
-6b: Refresh token is expired or revoked.
-    1: System denies the refresh request.
-    2: Client clears tokens and redirects to login.
+3a: Access token is missing.
+    1: Resource API responds `401 Unauthorized`.
+    2: Client redirects the user using RedirectToLogin.
+3b: Access token is expired.
+    1: JwtRefreshMiddleware calls `POST /Account/Refresh` on Identity API using the refresh token.
+    2: Client retries step 3 with the new access token.
+3c: Refresh token is expired or revoked.
+    1: Identity API rejects `POST /Account/Refresh`.
+    2: Client clears tokens in TokenStorageService and redirects the user using RedirectToLogin.
+4a: User lacks permissions.
+    1: Resource API responds `403 Forbidden`.
+    2: Client shows an authorization error message.
+5a: Network or server error.
+    1: Client shows an error and offers retry.
 
-**Summary**: Staff must authenticate before accessing dashboard data; tokens support continued access while keeping data protected.
+**Summary**: Dashboard data is returned only to authenticated sessions; tokens authorize both user-initiated and Time Event auto-refresh requests.
 
 ### Fully Dressed Use Case
 **Title**: Authenticate to access data
-**Scope**: Slottets Drifttavlen (Authentication)
+**Scope**: Slottets Drifttavlen (Dashboard data access authorization)
 **Level**: User Goal
 **Actors**:
-- Staff Member
 - Authenticated Staff Member
-- System
+- Time Event (system actor — Dashboard 60-second auto-refresh trigger)
+- Resource API (validates [Authorize] on protected endpoints)
+- Identity API (validates and refreshes tokens)
 
 **Related Requirements**:
 - [REQ-F-005] Access control and login (quick login, minimum password requirements, initials/email as username).
@@ -72,36 +79,38 @@ The staff member opens the login page, enters valid credentials, and the system 
 **Preconditions**:
 - System is operational.
 - Identity API is available.
-- Staff Member has a user account.
-- User is not currently authenticated (or must re-authenticate due to expired session).
+- Resource API is available.
+- Authenticated Staff Member has already authenticated according to UC-004 and the client holds valid tokens.
 
 **Main Flow**:
-1. Staff Member opens the login page.
-2. Staff Member enters email and password and submits.
-3. System validates the credentials.
-4. System issues an access token (JWT) and refresh token and returns them to the client.
-5. Client stores tokens and navigates to the Dashboard.
-6. Authenticated Staff Member requests dashboard data.
-7. System authorizes the request and returns data for authenticated users.
+1. Authenticated Staff Member opens the Dashboard.
+2. Client reads stored tokens from TokenStorageService.
+3. Client requests dashboard data from Resource API using `Authorization: Bearer <JWT>`.
+4. Resource API validates `[Authorize]` on the protected endpoint and returns dashboard data.
+5. Client receives the response and renders the dashboard data.
+6. Time Event triggers every 60 seconds and client repeats steps 3–5 to auto-refresh the Dashboard.
 
 **Extensions**:
-    a: At any time, if a network or server error occurs, system shows an error and offers retry.
-    b: At any time, if the user is not authenticated, system denies access to protected data and redirects the user to login.
-    3a: Credentials are invalid.
-        1: System rejects the login and shows a generic error (no token is issued).
-    3b: User is authenticated but does not have the required permissions.
-        1: System rejects the login or denies access and shows an authorization error.
-    6a: Access token is expired.
-        1: Client automatically requests a new access token (via `POST /Account/Refresh`, e.g., through `JwtRefreshMiddleware`).
-        2: System validates the refresh token and issues a new access token.
-        3: Client retries the original request.
-    6b: Refresh token is expired or revoked.
-        1: System rejects the refresh request.
-        2: Client clears stored tokens and redirects to login.
+    3a: Access token is missing.
+        1: Resource API responds `401 Unauthorized`.
+        2: Client redirects the user using RedirectToLogin.
+    3b: Access token is expired.
+        1: JwtRefreshMiddleware calls `POST /Account/Refresh` on Identity API using the refresh token.
+        2: Identity API validates the refresh token and returns a new access token.
+        3: Client retries step 3.
+    3c: Refresh token is expired or revoked.
+        1: Identity API rejects `POST /Account/Refresh`.
+        2: Client clears tokens in TokenStorageService and redirects the user using RedirectToLogin.
+    4a: User lacks permissions.
+        1: Resource API responds `403 Forbidden`.
+        2: Client shows an authorization error message.
+    5a: Network or server error.
+        1: Client shows an error and offers retry.
 
 **Postconditions**:
-- On success, the staff member is authenticated and can access dashboard data while the access token is valid.
-- On failure, no access token is stored and no protected data is returned.
+- On success, dashboard data is returned only for authenticated sessions with a valid access token.
+- Failed authorization attempts are recorded in the audit trail (REQ-R-003).
+- On failure, no protected dashboard data is returned.
 
 ## Maintenance
 - Update the version and change log for major changes.
@@ -109,7 +118,9 @@ The staff member opens the login page, enters valid credentials, and the system 
 - Review and approve use cases with relevant stakeholders before acceptance.
 
 ## Implementation Notes
-- Identity endpoints (AccountController): `POST /Account/Register`, `POST /Account/Login`, `POST /Account/Refresh`, `POST /Account/Logout`, `DELETE /Account/{userId}`, `POST /Account/GetUserIdByEmail`.
-- Frontend login page: `src/WebUI/WebUI.Client/Components/Pages/Login.razor`.
-- Login endpoint: `POST /Account/Login` in `src/Api/Controllers/Identity/AccountController.cs`.
+- Login form and credential validation are owned by UC-004 (User Login). UC-007 starts after a successful UC-004 login.
+- Identity endpoints (AccountController): `POST /Account/Login`, `POST /Account/Refresh`, `POST /Account/Logout`.
+- Resource API protection: `[Authorize]` on protected endpoints.
+- Client authorization header: Bearer token is attached via `JwtAuthorizationMessageHandler` using TokenStorageService.
 - Token storage: `src/WebUI/WebUI.Client/Services/TokenStorageService.cs`.
+- Audit logging (REQ-R-003) for failed authorization attempts is handled by the audit interceptor (UC-009 backend).


### PR DESCRIPTION
## Summary

Refines UC-007 "Authenticate to access data" use case (both EN and DA versions) to better reflect the system-to-system flow and avoid duplication with UC-004 (User Login).

This is a v0002 revision of the use case. Version 0001 (initial, by Team 6) is retained in the Version Log.

## What changed (3 themes + clean-up)

### Theme A — Time Event as actor
The Dashboard's 60-second auto-refresh timer is itself a system-actor that triggers authenticated requests. The use case now explicitly recognises this:

- Added `Time Event (system actor — Dashboard 60-second auto-refresh trigger)` to the actors list (Casual + Fully Dressed).
- Added Main Flow step 6 describing periodic re-fetch via the Time Event.

This is important for downstream artefacts (SSD, SD, DCD) which need to model system-to-system flows, not just user-initiated requests.

### Theme B — Re-scope to data access authorization
UC-007's title is "Authenticate to access **data**" — the login form itself is owned by UC-004. The previous v0001 main flow duplicated UC-004's "open login page → enter credentials → validate" steps. v0002 fixes this:

- Removed the `Staff Member` actor; UC-007 now starts from `Authenticated Staff Member` with valid tokens.
- Split the generic `System` actor into `Resource API` (validates `[Authorize]`) and `Identity API` (validates and refreshes tokens).
- Main Flow now starts from "client requests dashboard data" rather than "opens login page".
- Preconditions assume successful UC-004 login and tokens already in `TokenStorageService`.
- Added `UC-004` to `crossReference` in Metadata.
- Added clarifying note in Implementation Notes that the login form is owned by UC-004.

### Theme C — Audit trail postcondition
v0001 listed `REQ-R-003` (audit log) in cross-references but did not explain how it applies. v0002 makes it explicit:

- Added postcondition: "Failed authorization attempts are recorded in the audit trail (REQ-R-003)."
- Referenced the audit interceptor (UC-009 backend) in Implementation Notes.

### Clean-up
- Restructured Extensions to be precise about token states:
  - `3a` Access token missing → 401 → `RedirectToLogin`
  - `3b` Access token expired → `JwtRefreshMiddleware` → `POST /Account/Refresh` → retry
  - `3c` Refresh token expired/revoked → clear tokens → redirect
  - `4a` User lacks permissions → 403 Forbidden → error message
  - `5a` Network/server error → retry option
- Replaced vague "e.g., through JwtRefreshMiddleware" with precise "via JwtRefreshMiddleware".
- Removed `POST /Account/GetUserIdByEmail` from Implementation Notes (not part of authentication flow).
- Added `JwtAuthorizationMessageHandler` reference in Implementation Notes (the `DelegatingHandler` that attaches the Bearer token).
- Updated User Story to focus on data-access authorization for both user-initiated and Time Event-triggered requests.

## Why now

Doing this before generating the remaining UC-007 artefacts (Wireframe, DM, SSD, OC, SD, DCD, ERD) means each downstream artefact will be derived from a clean, focused use case rather than inheriting the v0001 ambiguities. It saves rework later.

## Files changed

- `docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.usecase.md` (EN)
- `docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.usecase.da.md` (DA)

160 insertions, 155 deletions across the two files.

## Notes for reviewer (@Tirsvad / @Jens)

- Both EN and DA versions have been updated in lockstep. Metadata field names remain in English on b