### PR TITLE
feat(uc-007): add wireframe for data access authorization

### DIFF
--- a/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.wireframe.da.md
+++ b/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.wireframe.da.md
@@ -1,0 +1,100 @@
+# Wireframe: UC-007 Autentificér for at få adgang til data
+
+## Metadata
+| Key            | Value                                                               |
+|----------------|---------------------------------------------------------------------|
+| Id             | UC-007.Wireframe                                                    |
+| crossReference | UC-007 UC-007.UC UC-007.DM REQ-F-005 REQ-U-005 REQ-DC-001 uc-007    |
+
+## Version Log
+| Version | Date       | Description | Author         |
+|---------|------------|-------------|----------------|
+| 0001    | 2026-05-10 | Initial     | GitHub Copilot |
+
+## Wireframe
+
+UC-007 viser, hvordan drifttavlen håndterer adgang til beskyttede data baseret på token-tilstand:
+- Ingen token: beskyttede data hentes ikke, og brugeren sendes videre til login.
+- Gyldig token: beskyttede data hentes og vises.
+- Udløbet access token + gyldig refresh token: sessionen fornyes stille, mens data forbliver synlige.
+- Ugyldig/udløbet refresh token: tokens ryddes, og brugeren skal logge ind igen.
+
+Skærm A — Drifttavle (ikke autentificeret, kort auto-redirect):
+
+```text
++----------------------------------------------------------------------------------+
+|  SLOTTETS DRIFTTAVLEN                                                            |
++----------------------------------------------------------------------------------+
+|                                                                                  |
+|  Du er ikke logget ind. Du sendes til login...                                   |
+|                                                                                  |
+|  [Ingen beskyttede data hentes eller vises]                                      |
+|                                                                                  |
++----------------------------------------------------------------------------------+
+```
+
+- Footer note: Time Event fires - JwtAuthenticationStateProvider detects no token - RedirectToLogin navigates to /login?returnUrl=...
+
+Skærm B — Drifttavle (autentificeret, normal drift):
+
+```text
++----------------------------------------------------------------------------------+
+|  SLOTTETS DRIFTTAVLEN   [Shift: D/E/N]   user@slottet.dk              [Log af]   |
++----------------------------------------------------------------------------------+
+|  +------------+  +------------+  +------------+  +------------+                 |
+|  | [Beboer]   |  | [Beboer]   |  | [Beboer]   |  | [Beboer]   |                 |
+|  | [data...]  |  | [data...]  |  | [data...]  |  | [data...]  |                 |
+|  +------------+  +------------+  +------------+  +------------+                 |
+|                                                                                  |
+|  +--------------------------------------+                                        |
+|  | PhoneList (fælles)                   |                                        |
+|  | [ ... placeholders ... ]             |                                        |
+|  +--------------------------------------+                                        |
++----------------------------------------------------------------------------------+
+```
+
+- Footer note: Time Event fires every 60s - HttpClient attaches Bearer token via JwtAuthorizationMessageHandler - GET /endpoint - 200 OK
+
+Skærm C — Drifttavle (stille token-fornyelse, udvidelse 3b):
+
+```text
++----------------------------------------------------------------------------------+
+|  SLOTTETS DRIFTTAVLEN   [Shift: D/E/N]   user@slottet.dk              [Log af]   |
++----------------------------------------------------------------------------------+
+|  Status: Opdaterer session...                                                    |
+|                                                                                  |
+|  +------------+  +------------+  +------------+  +------------+                 |
+|  | [Beboer]   |  | [Beboer]   |  | [Beboer]   |  | [Beboer]   |                 |
+|  | [data...]  |  | [data...]  |  | [data...]  |  | [data...]  |                 |
+|  +------------+  +------------+  +------------+  +------------+                 |
+|                                                                                  |
+|  +--------------------------------------+                                        |
+|  | PhoneList (fælles)                   |                                        |
+|  | [ ... placeholders ... ]             |                                        |
+|  +--------------------------------------+                                        |
++----------------------------------------------------------------------------------+
+```
+
+- Footer note: Access token expired - JwtRefreshMiddleware intercepts 401 - POST /Account/Refresh - new JWT stored - request retried
+
+Skærm D — Drifttavle (hard logout, udvidelse 3c):
+
+```text
++----------------------------------------------------------------------------------+
+|  SLOTTETS DRIFTTAVLEN                                                            |
++----------------------------------------------------------------------------------+
+|                                                                                  |
+|  Din session er udløbet. Log ind igen for at fortsætte.                           |
+|                                                                                  |
+|  [Ingen beskyttede data hentes eller vises]                                      |
+|                                                                                  |
++----------------------------------------------------------------------------------+
+```
+
+- Footer note: Refresh token expired - TokenStorageService.RemoveTokenAsync() - RedirectToLogin to /login
+
+## Notes
+- Login-formularen er dækket af UC-004 (se docs/use-cases/uc-004-login/uc-004.WireFrame.md). Denne UC-007 wireframe fokuserer på tilstandsændringer for adgang til data på drifttavlen.
+- Time Event behandles som en system-aktør; hvert tick skal inkludere en Bearer token.
+- Token-tilstande afspejlet i UI: ingen token, gyldig token, udløbet access + gyldig refresh, ugyldig refresh.
+- Implementation references: RedirectToLogin.razor.cs, TokenStorageService.cs, JwtAuthenticationStateProvider, JwtRefreshMiddleware, JwtAuthorizationMessageHandler.

--- a/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.wireframe.md
+++ b/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.wireframe.md
@@ -1,0 +1,100 @@
+# Wireframe: UC-007 Authenticate to access data
+
+## Metadata
+| Key            | Value                                                               |
+|----------------|---------------------------------------------------------------------|
+| Id             | UC-007.Wireframe                                                    |
+| crossReference | UC-007 UC-007.UC UC-007.DM REQ-F-005 REQ-U-005 REQ-DC-001 uc-007    |
+
+## Version Log
+| Version | Date       | Description | Author         |
+|---------|------------|-------------|----------------|
+| 0001    | 2026-05-10 | Initial     | GitHub Copilot |
+
+## Wireframe
+
+UC-007 illustrates Dashboard data-access authorization states:
+- No token present: protected data is not fetched and the user is redirected to login.
+- Valid token present: protected data is fetched and rendered.
+- Expired access token + valid refresh token: session is refreshed silently while keeping data visible.
+- Invalid/expired refresh token: tokens are cleared and the user is forced to login again.
+
+Screen A — Dashboard (unauthenticated state, brief auto-redirect):
+
+```text
++----------------------------------------------------------------------------------+
+|  SLOTTETS DRIFTTAVLEN                                                            |
++----------------------------------------------------------------------------------+
+|                                                                                  |
+|  Du er ikke logget ind. Du sendes til login...                                   |
+|                                                                                  |
+|  [Ingen beskyttede data hentes eller vises]                                      |
+|                                                                                  |
++----------------------------------------------------------------------------------+
+```
+
+- Footer note: Time Event fires - JwtAuthenticationStateProvider detects no token - RedirectToLogin navigates to /login?returnUrl=...
+
+Screen B — Dashboard (authenticated, normal operation):
+
+```text
++----------------------------------------------------------------------------------+
+|  SLOTTETS DRIFTTAVLEN   [Shift: D/E/N]   user@slottet.dk              [Log af]   |
++----------------------------------------------------------------------------------+
+|  +------------+  +------------+  +------------+  +------------+                 |
+|  | [Beboer]   |  | [Beboer]   |  | [Beboer]   |  | [Beboer]   |                 |
+|  | [data...]  |  | [data...]  |  | [data...]  |  | [data...]  |                 |
+|  +------------+  +------------+  +------------+  +------------+                 |
+|                                                                                  |
+|  +--------------------------------------+                                        |
+|  | PhoneList (fælles)                   |                                        |
+|  | [ ... placeholders ... ]             |                                        |
+|  +--------------------------------------+                                        |
++----------------------------------------------------------------------------------+
+```
+
+- Footer note: Time Event fires every 60s - HttpClient attaches Bearer token via JwtAuthorizationMessageHandler - GET /endpoint - 200 OK
+
+Screen C — Dashboard (silent token refresh, extension 3b):
+
+```text
++----------------------------------------------------------------------------------+
+|  SLOTTETS DRIFTTAVLEN   [Shift: D/E/N]   user@slottet.dk              [Log af]   |
++----------------------------------------------------------------------------------+
+|  Status: Opdaterer session...                                                    |
+|                                                                                  |
+|  +------------+  +------------+  +------------+  +------------+                 |
+|  | [Beboer]   |  | [Beboer]   |  | [Beboer]   |  | [Beboer]   |                 |
+|  | [data...]  |  | [data...]  |  | [data...]  |  | [data...]  |                 |
+|  +------------+  +------------+  +------------+  +------------+                 |
+|                                                                                  |
+|  +--------------------------------------+                                        |
+|  | PhoneList (fælles)                   |                                        |
+|  | [ ... placeholders ... ]             |                                        |
+|  +--------------------------------------+                                        |
++----------------------------------------------------------------------------------+
+```
+
+- Footer note: Access token expired - JwtRefreshMiddleware intercepts 401 - POST /Account/Refresh - new JWT stored - request retried
+
+Screen D — Dashboard (hard logout, extension 3c):
+
+```text
++----------------------------------------------------------------------------------+
+|  SLOTTETS DRIFTTAVLEN                                                            |
++----------------------------------------------------------------------------------+
+|                                                                                  |
+|  Din session er udløbet. Log ind igen for at fortsætte.                           |
+|                                                                                  |
+|  [Ingen beskyttede data hentes eller vises]                                      |
+|                                                                                  |
++----------------------------------------------------------------------------------+
+```
+
+- Footer note: Refresh token expired - TokenStorageService.RemoveTokenAsync() - RedirectToLogin to /login
+
+## Notes
+- The login form is covered by UC-004 (see docs/use-cases/uc-004-login/uc-004.WireFrame.md). This UC-007 wireframe focuses on Dashboard data-access state changes.
+- The Time Event is treated as a system actor; each tick must include a Bearer token.
+- Token states reflected in UI: no token, valid token, expired access + valid refresh, invalid refresh.
+- Implementation references: RedirectToLogin.razor.cs, TokenStorageService.cs, JwtAuthenticationStateProvider, JwtRefreshMiddleware, JwtAuthorizationMessageHandler.


### PR DESCRIPTION
## Summary

Adds the wireframe artifact for UC-007 (Authenticate to access data).

ASCII-art screens (EN + DA) following the UC-009 wireframe style. Four Dashboard states are covered:

- **A** Unauthenticated — brief auto-redirect to /login
- **B** Authenticated — normal operation with Time Event auto-refresh
- **C** Silent token refresh — extension 3b (access token expired, refresh succeeds)
- **D** Hard logout — extension 3c (refresh token expired, redirect to login)

Each screen includes a footer note describing the system-to-system flow (Time Event, RedirectToLogin, JwtRefreshMiddleware, JwtAuthorizationMessageHandler).

## Notes for reviewer

- Login form itself is owned by UC-004 (referenced in Notes section).
- This wireframe is consistent with UC-007 v0002 use case (currently in PR `fix/uc007-usecase-actor-and-scope`).
- Docs-only — no code, no Docker build needed.

Closes #209