### PR TITLE
feat(uc-007): add domain model for data access authorization

### DIFF
--- a/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.dm.da.md
+++ b/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.dm.da.md
@@ -1,0 +1,100 @@
+# Domænemodel (DM) for Autentificér for at få adgang til data
+
+## Metadata
+| Nøgle               | Værdi                             |
+|---------------------|-----------------------------------|
+| Id                  | UC-007.DM                         |
+| crossReference      | BC<br/>UC-007<br/>UC-004<br/>REQ-F-005<br/>REQ-DC-001<br/>REQ-R-003 |
+
+## Versionslog
+| Version | Dato       | Beskrivelse              | Forfatter |
+|---------|------------|--------------------------|----------|
+| 0001    | 2026-05-10 | Initial                  | Team 6   |
+
+## Diagram
+```mermaid
+%% Domain Model Diagram for UC-007 Authenticate to access data
+classDiagram
+    class User {
+        Identifier
+    }
+
+    class AccessToken {
+        Token
+        IssuedAt
+        ExpiresAt
+    }
+
+    class RefreshToken {
+        Token
+        IssuedAt
+        ExpiresAt
+        IsRevoked
+    }
+
+    %% TimeEvent is a system actor (default IntervalSeconds = 60)
+    class TimeEvent {
+        IntervalSeconds
+        Trigger()
+    }
+
+    class ProtectedResource {
+        ResourceName
+        RequiresRole
+    }
+
+    class AuthorizationPolicy {
+        PolicyName
+        Evaluate(token, resource)
+    }
+
+    class AuditEntry {
+        EventTime
+        ChangeType
+        Description
+    }
+
+    User "1" -- "0..*" AccessToken : owns
+    User "1" -- "0..*" RefreshToken : owns
+
+    AccessToken "0..1" --> "1" RefreshToken : refreshable via
+
+    TimeEvent "1" --> "0..*" ProtectedResource : requests (every 60s)
+    ProtectedResource "1" --> "1" AuthorizationPolicy : protected by
+    AuthorizationPolicy "0..*" --> "0..*" AuditEntry : logs failed access
+```
+
+## Antagelser og Afhængigheder
+- `AccessToken` (JWT) er kortlivet (typisk 15 min) og bruges som Bearer token i hver forespørgsel til en `ProtectedResource`.
+- `RefreshToken` er langlivet og bruges til stille og roligt at hente et nyt `AccessToken`, når det nuværende udløber.
+- `TimeEvent` er en systemaktør: den kræver ikke brugerinteraktion, men skal stadig medbringe et gyldigt `AccessToken` ved hver periodisk genindlæsning.
+- Alle `ProtectedResource`-endpoints i Resource API’et er dekoreret med `[Authorize]`; `AuthorizationPolicy` håndhæves af ASP.NET Core middleware.
+- Mislykkede `AuthorizationPolicy`-evalueringer opretter `AuditEntry`-registreringer (REQ-R-003); vellykkede evalueringer kan også logges afhængigt af konfiguration.
+- Login i sig selv (legitimationsoplysninger -> initial `AccessToken` + `RefreshToken`) ejes af UC-004, ikke UC-007.
+
+## Termoversættelse
+
+| Original Term         | Dansk Oversættelse               |
+|----------------------|----------------------------------|
+| AccessToken          | Adgangstoken                     |
+| RefreshToken         | Fornyelsestoken                  |
+| TimeEvent            | Tidshændelse                     |
+| ProtectedResource    | Beskyttet ressource              |
+| AuthorizationPolicy  | Autorisationsregel               |
+| IssuedAt             | Udstedt                          |
+| ExpiresAt            | Udløber                          |
+| IsRevoked            | ErTilbagekaldt                   |
+| IntervalSeconds      | Intervalsekunder                 |
+| Trigger              | Udløs                            |
+| ResourceName         | Ressourcenavn                    |
+| RequiresRole         | KræverRolle                      |
+| PolicyName           | Regelnavn                        |
+| Evaluate             | Evaluér                          |
+| Identifier           | Identifikator                    |
+| Bearer token         | Bærer-token                      |
+
+## Noter
+- Login-domænet (Caregiver, AuthenticationSystem, Session) ejes af UC-004 — denne DM refererer kun til `User` som en passiv klasse for ejerskab af tokens.
+- `AccessToken` udstedes af Identity API (efter UC-004 login eller efter fornyelse). Rotation af RefreshToken anbefales ved hver fornyelse (sikkerhedsmæssig best practice).
+- `TimeEvent` repræsenterer drifttavlens auto-opdatering — det er en systemaktør i use casen, men fungerer som initiator af klientforespørgsler på domæneniveau.
+- `AuditEntry`-referencen matcher UC-009’s domænemodel; UC-007 tilføjer kun registreringer ved mislykket autorisation, og ejer ikke AuditLog-aggregatet.

--- a/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.dm.md
+++ b/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.dm.md
@@ -1,0 +1,100 @@
+# Domain Model (DM) for Authenticate to access data
+
+## Metadata
+| Key               | Value                             |
+|-------------------|-----------------------------------|
+| Id                | UC-007.DM                         |
+| crossReference    | BC<br/>UC-007<br/>UC-004<br/>REQ-F-005<br/>REQ-DC-001<br/>REQ-R-003 |
+
+## Version Log
+| Version | Date       | Description              | Author     |
+|---------|------------|--------------------------|------------|
+| 0001    | 2026-05-10 | Initial                  | Team 6     |
+
+## Diagram
+```mermaid
+%% Domain Model Diagram for UC-007 Authenticate to access data
+classDiagram
+    class User {
+        Identifier
+    }
+
+    class AccessToken {
+        Token
+        IssuedAt
+        ExpiresAt
+    }
+
+    class RefreshToken {
+        Token
+        IssuedAt
+        ExpiresAt
+        IsRevoked
+    }
+
+    %% TimeEvent is a system actor (default IntervalSeconds = 60)
+    class TimeEvent {
+        IntervalSeconds
+        Trigger()
+    }
+
+    class ProtectedResource {
+        ResourceName
+        RequiresRole
+    }
+
+    class AuthorizationPolicy {
+        PolicyName
+        Evaluate(token, resource)
+    }
+
+    class AuditEntry {
+        EventTime
+        ChangeType
+        Description
+    }
+
+    User "1" -- "0..*" AccessToken : owns
+    User "1" -- "0..*" RefreshToken : owns
+
+    AccessToken "0..1" --> "1" RefreshToken : refreshable via
+
+    TimeEvent "1" --> "0..*" ProtectedResource : requests (every 60s)
+    ProtectedResource "1" --> "1" AuthorizationPolicy : protected by
+    AuthorizationPolicy "0..*" --> "0..*" AuditEntry : logs failed access
+```
+
+## Assumptions and Dependencies
+- `AccessToken` (JWT) is short-lived (typically 15 min) and used as a Bearer token in every request to a `ProtectedResource`.
+- `RefreshToken` is long-lived and used to silently obtain a new `AccessToken` when the current one expires.
+- The `TimeEvent` is a system actor: it does not require user interaction but still must carry a valid `AccessToken` on each periodic re-fetch.
+- All `ProtectedResource` endpoints in the Resource API are decorated with `[Authorize]`; `AuthorizationPolicy` is enforced by ASP.NET Core middleware.
+- Failed `AuthorizationPolicy` evaluations create `AuditEntry` records (REQ-R-003); successful evaluations may also be logged based on configuration.
+- Login itself (credentials -> initial `AccessToken` + `RefreshToken`) is owned by UC-004, not UC-007.
+
+## Terms Translation
+
+| Original Term         | Danish Translation                |
+|----------------------|-----------------------------------|
+| AccessToken          | Adgangstoken                      |
+| RefreshToken         | Fornyelsestoken                   |
+| TimeEvent            | Tidshændelse                      |
+| ProtectedResource    | Beskyttet ressource               |
+| AuthorizationPolicy  | Autorisationsregel                |
+| IssuedAt             | Udstedt                           |
+| ExpiresAt            | Udløber                           |
+| IsRevoked            | ErTilbagekaldt                    |
+| IntervalSeconds      | Intervalsekunder                  |
+| Trigger              | Udløs                             |
+| ResourceName         | Ressourcenavn                     |
+| RequiresRole         | KræverRolle                       |
+| PolicyName           | Regelnavn                         |
+| Evaluate             | Evaluér                           |
+| Identifier           | Identifikator                     |
+| Bearer token         | Bærer-token                       |
+
+## Notes
+- Login domain (Caregiver, AuthenticationSystem, Session) is owned by UC-004 — this DM only references `User` as a passive class for ownership of tokens.
+- `AccessToken` is issued by Identity API (after UC-004 login or after refresh). RefreshToken rotation is recommended on each refresh (security best practice).
+- `TimeEvent` represents the Dashboard's auto-refresh — it is a system actor in the use case but acts as a client request initiator at the domain level.
+- `AuditEntry` reference matches UC-009's domain model; UC-007 only adds records via failed authorization, it does not own the AuditLog aggregate.


### PR DESCRIPTION
## Summary

Adds the Domain Model for UC-007 (Authenticate to access data).

Mermaid classDiagram in EN + DA, modeling the token domain and the data-access authorization flow:

- **User** (passive reference to UC-004's Caregiver — only the Identifier attribute)
- **AccessToken** — JWT, short-lived
- **RefreshToken** — long-lived, revocable
- **TimeEvent** — system actor that triggers periodic authenticated requests
- **ProtectedResource** — Resource API endpoints decorated with [Authorize]
- **AuthorizationPolicy** — evaluated by ASP.NET Core middleware
- **AuditEntry** (passive reference to UC-009 — for failed-authorization logging)

## Notes for reviewer

- The login domain (Caregiver, AuthenticationSystem, Session) is intentionally NOT duplicated — it remains owned by UC-004.
- Aligned with UC-007 v0002 use case (currently in PR `fix/uc007-usecase-actor-and-scope`).
- Docs-only — no code, no Docker build needed.

Closes #210