### PR TITLE
feat(uc-007): add system sequence diagram for data access authorization

### DIFF
--- a/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.ssd.da.md
+++ b/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.ssd.da.md
@@ -1,0 +1,85 @@
+# Systemsekvensdiagram for Autentificér for at få adgang til data
+
+## Metadata
+| Nøgle           | Værdi                      |
+|-----------------|----------------------------|
+| Id              | UC-007.SSD                 |
+| crossReference  | UC-007 UC-007.DM UC-007.UC |
+
+## Versionslog
+| Version | Dato       | Beskrivelse | Forfatter |
+|---------|------------|-------------|-----------|
+| 0001    | 2026-05-10 | Initial SSD | Team 6    |
+
+## Systemsekvensdiagram
+
+```mermaid
+sequenceDiagram
+    actor AuthenticatedStaffMember
+    actor TimeEvent
+    participant ResourceAPI
+    participant IdentityAPI
+
+    AuthenticatedStaffMember ->> ResourceAPI: requestDashboardData(accessToken)
+
+    alt accessTokenValid
+        ResourceAPI -->> AuthenticatedStaffMember: dashboardData
+
+    else accessTokenMissing
+        %% Extension 3a: accessTokenMissing
+        ResourceAPI -->> AuthenticatedStaffMember: 401 Unauthorized
+        AuthenticatedStaffMember ->> AuthenticatedStaffMember: redirectToLogin()
+
+    else accessTokenExpired
+        %% Extension 3b: accessTokenExpired
+        ResourceAPI -->> AuthenticatedStaffMember: 401 Unauthorized
+        AuthenticatedStaffMember ->> IdentityAPI: refreshToken(refreshToken)
+
+        alt refreshTokenValid
+            IdentityAPI -->> AuthenticatedStaffMember: newAccessToken
+            AuthenticatedStaffMember ->> ResourceAPI: requestDashboardData(newAccessToken)
+            ResourceAPI -->> AuthenticatedStaffMember: dashboardData
+
+        else refreshTokenExpiredOrRevoked
+            %% Extension 3c: refreshTokenExpiredOrRevoked
+            IdentityAPI -->> AuthenticatedStaffMember: 401 Unauthorized
+            AuthenticatedStaffMember ->> AuthenticatedStaffMember: clearTokensAndRedirectToLogin()
+        end
+
+    else permissionDenied
+        %% Extension 4a: permissionDenied
+        ResourceAPI -->> AuthenticatedStaffMember: 403 Forbidden
+        AuthenticatedStaffMember -->> AuthenticatedStaffMember: showAuthorizationError()
+
+    else networkOrServerError
+        %% Extension 5a: networkOrServerError
+        ResourceAPI -->> AuthenticatedStaffMember: error
+        AuthenticatedStaffMember -->> AuthenticatedStaffMember: showRetryOption()
+    end
+
+    %% After the dashboard data is successfully loaded, a periodic re-fetch is initiated.
+    loop every 60 seconds
+        TimeEvent ->> ResourceAPI: requestDashboardData(accessToken)
+        ResourceAPI -->> TimeEvent: dashboardData
+    end
+```
+
+## Sprogoversættelse
+
+| Original Term                   | Dansk Oversættelse              |
+|--------------------------------|----------------------------------|
+| AuthenticatedStaffMember       | Autentificeret medarbejder       |
+| TimeEvent                      | Tidshændelse                     |
+| ResourceAPI                    | Ressource-API                    |
+| IdentityAPI                    | Identity-API                     |
+| requestDashboardData           | anmodOmDashboardData             |
+| accessToken                    | adgangstoken                     |
+| refreshToken                   | fornyelsestoken                  |
+| dashboardData                  | dashboardData                    |
+| redirectToLogin                | viderestilTilLogin               |
+| clearTokensAndRedirectToLogin  | rydTokensOgViderestilTilLogin     |
+| showAuthorizationError         | visAutorisationsfejl             |
+| showRetryOption                | visForsøgIgen                    |
+| newAccessToken                 | nytAdgangstoken                  |
+| 401 Unauthorized               | 401 Uautoriseret                 |
+| 403 Forbidden                  | 403 Forbudt                      |

--- a/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.ssd.md
+++ b/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.ssd.md
@@ -1,0 +1,85 @@
+# System Sequence Diagram for Authenticate to access data
+
+## Metadata
+| Key            | Value                        |
+|----------------|------------------------------|
+| Id             | UC-007.SSD                   |
+| crossReference | UC-007 UC-007.DM UC-007.UC   |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-10 | Initial SSD | Team 6 |
+
+## System Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor AuthenticatedStaffMember
+    actor TimeEvent
+    participant ResourceAPI
+    participant IdentityAPI
+
+    AuthenticatedStaffMember ->> ResourceAPI: requestDashboardData(accessToken)
+
+    alt accessTokenValid
+        ResourceAPI -->> AuthenticatedStaffMember: dashboardData
+
+    else accessTokenMissing
+        %% Extension 3a: accessTokenMissing
+        ResourceAPI -->> AuthenticatedStaffMember: 401 Unauthorized
+        AuthenticatedStaffMember ->> AuthenticatedStaffMember: redirectToLogin()
+
+    else accessTokenExpired
+        %% Extension 3b: accessTokenExpired
+        ResourceAPI -->> AuthenticatedStaffMember: 401 Unauthorized
+        AuthenticatedStaffMember ->> IdentityAPI: refreshToken(refreshToken)
+
+        alt refreshTokenValid
+            IdentityAPI -->> AuthenticatedStaffMember: newAccessToken
+            AuthenticatedStaffMember ->> ResourceAPI: requestDashboardData(newAccessToken)
+            ResourceAPI -->> AuthenticatedStaffMember: dashboardData
+
+        else refreshTokenExpiredOrRevoked
+            %% Extension 3c: refreshTokenExpiredOrRevoked
+            IdentityAPI -->> AuthenticatedStaffMember: 401 Unauthorized
+            AuthenticatedStaffMember ->> AuthenticatedStaffMember: clearTokensAndRedirectToLogin()
+        end
+
+    else permissionDenied
+        %% Extension 4a: permissionDenied
+        ResourceAPI -->> AuthenticatedStaffMember: 403 Forbidden
+        AuthenticatedStaffMember -->> AuthenticatedStaffMember: showAuthorizationError()
+
+    else networkOrServerError
+        %% Extension 5a: networkOrServerError
+        ResourceAPI -->> AuthenticatedStaffMember: error
+        AuthenticatedStaffMember -->> AuthenticatedStaffMember: showRetryOption()
+    end
+
+    %% After the dashboard data is successfully loaded, a periodic re-fetch is initiated.
+    loop every 60 seconds
+        TimeEvent ->> ResourceAPI: requestDashboardData(accessToken)
+        ResourceAPI -->> TimeEvent: dashboardData
+    end
+```
+
+## Language Translation
+
+| Original Term                   | Danish Translation               |
+|--------------------------------|----------------------------------|
+| AuthenticatedStaffMember       | Autentificeret medarbejder       |
+| TimeEvent                      | Tidshændelse                     |
+| ResourceAPI                    | Ressource-API                    |
+| IdentityAPI                    | Identity-API                     |
+| requestDashboardData           | anmodOmDashboardData             |
+| accessToken                    | adgangstoken                     |
+| refreshToken                   | fornyelsestoken                  |
+| dashboardData                  | dashboardData                    |
+| redirectToLogin                | viderestilTilLogin               |
+| clearTokensAndRedirectToLogin  | rydTokensOgViderestilTilLogin     |
+| showAuthorizationError         | visAutorisationsfejl             |
+| showRetryOption                | visForsøgIgen                    |
+| newAccessToken                 | nytAdgangstoken                  |
+| 401 Unauthorized               | 401 Uautoriseret                 |
+| 403 Forbidden                  | 403 Forbudt                      |


### PR DESCRIPTION
## Summary

Adds the System Sequence Diagram (SSD) for UC-007 (Authenticate to access data).

Mermaid sequenceDiagram in EN + DA showing system boundaries:

**Actors:**
- AuthenticatedStaffMember (human, initial dashboard load)
- TimeEvent (system actor, 60-second periodic re-fetch)

**System participants:**
- ResourceAPI (validates [Authorize] on protected endpoints)
- IdentityAPI (issues and refreshes tokens)

**Flows covered:**
- Main: `requestDashboardData(accessToken)` → 200 OK
- 3a: token missing → 401 → redirectToLogin
- 3b: token expired → refresh → retry
- 3c: refresh expired → clear tokens → redirect
- 4a: permission denied → 403 Forbidden
- 5a: network/server error → retry option
- Loop: TimeEvent every 60s

## Notes for reviewer

- TimeEvent shown as `actor` to emphasize that it is a system actor external to the System boundary (consistent with UC-007 v0002 use case).
- System split into ResourceAPI + IdentityAPI rather than a single "System" participant — matches the actor split introduced in UC-007 v0002.
- Internal components (managers, repositories) deliberately not shown — those belong in SD (#213).
- Aligned with UC-007 v0002 use case (currently in PR `fix/uc007-usecase-actor-and-scope`).
- Docs-only — no code, no Docker build needed.

Closes #211