### PR TITLE
feat(uc-007): add operation contract for data access authorization

### DIFF
--- a/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.oc.da.md
+++ b/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.oc.da.md
@@ -1,0 +1,94 @@
+# Operationskontrakt: Autentificér for at få adgang til data
+
+## Metadata
+| Nøgle           | Værdi                              |
+|-----------------|------------------------------------|
+| Id              | UC-007.OC                          |
+| crossReference  | UC-007.SSD UC-007.DM UC-007.UC     |
+
+## Versionslog
+| Version | Dato       | Beskrivelse | Forfatter |
+|---------|------------|-------------|-----------|
+| 0001    | 2026-05-10 | Initial     | Team 6    |
+
+## Operationskontrakt
+
+```mermaid
+sequenceDiagram
+    actor AuthenticatedStaffMember
+    actor TimeEvent
+    participant ResourceAPI
+    participant IdentityAPI
+
+    AuthenticatedStaffMember ->> ResourceAPI: requestDashboardData(accessToken)
+
+    alt accessTokenValid
+        ResourceAPI -->> AuthenticatedStaffMember: dashboardData
+
+    else accessTokenMissing
+        %% Extension 3a: accessTokenMissing
+        ResourceAPI -->> AuthenticatedStaffMember: 401 Unauthorized
+        AuthenticatedStaffMember ->> AuthenticatedStaffMember: redirectToLogin()
+
+    else accessTokenExpired
+        %% Extension 3b: accessTokenExpired
+        ResourceAPI -->> AuthenticatedStaffMember: 401 Unauthorized
+        AuthenticatedStaffMember ->> IdentityAPI: refreshToken(refreshToken)
+
+        alt refreshTokenValid
+            IdentityAPI -->> AuthenticatedStaffMember: newAccessToken
+            AuthenticatedStaffMember ->> ResourceAPI: requestDashboardData(newAccessToken)
+            ResourceAPI -->> AuthenticatedStaffMember: dashboardData
+
+        else refreshTokenExpiredOrRevoked
+            %% Extension 3c: refreshTokenExpiredOrRevoked
+            IdentityAPI -->> AuthenticatedStaffMember: 401 Unauthorized
+            AuthenticatedStaffMember ->> AuthenticatedStaffMember: clearTokensAndRedirectToLogin()
+        end
+
+    else permissionDenied
+        %% Extension 4a: permissionDenied
+        ResourceAPI -->> AuthenticatedStaffMember: 403 Forbidden
+        AuthenticatedStaffMember -->> AuthenticatedStaffMember: showAuthorizationError()
+
+    else networkOrServerError
+        %% Extension 5a: networkOrServerError
+        ResourceAPI -->> AuthenticatedStaffMember: error
+        AuthenticatedStaffMember -->> AuthenticatedStaffMember: showRetryOption()
+    end
+
+    %% Efter Dashboard-data er hentet, igangsættes en periodisk genindlæsning.
+    loop every 60 seconds
+        TimeEvent ->> ResourceAPI: requestDashboardData(accessToken)
+        ResourceAPI -->> TimeEvent: dashboardData
+    end
+```
+
+### Anmod om Dashboard-data
+- **Forudsætninger**:
+  - AuthenticatedStaffMember har gennemført UC-004 login.
+  - Klienten har et AccessToken (muligvis udløbet) og et RefreshToken i TokenStorageService.
+  - ResourceAPI er tilgængelig.
+- **Efterbetingelser**:
+  - Ved succes (gyldigt token): ResourceAPI returnerer de anmodede Dashboard-data.
+  - Ved accessTokenMissing (3a): ResourceAPI returnerer 401 Unauthorized; klienten viderestiller til login via RedirectToLogin.
+  - Ved accessTokenExpired (3b): ResourceAPI returnerer 401 Unauthorized; klienten udløser Forny adgangstoken og forsøger derefter igen med det nye token.
+  - Ved permissionDenied (4a): ResourceAPI returnerer 403 Forbidden; klienten viser en autorisationsfejl.
+  - Ved networkOrServerError (5a): klienten viser en fejl med mulighed for at prøve igen.
+  - Mislykkede autorisationer registreres i audit trail (REQ-R-003).
+
+### Forny adgangstoken
+- **Forudsætninger**:
+  - Klienten har et ikke-tilbagekaldt, ikke-udløbet RefreshToken i TokenStorageService.
+  - IdentityAPI er tilgængelig.
+- **Efterbetingelser**:
+  - Ved succes: IdentityAPI udsteder et nyt AccessToken; klienten gemmer det i TokenStorageService og gentager den oprindelige forespørgsel.
+  - Ved refreshTokenExpiredOrRevoked (3c): IdentityAPI returnerer 401 Unauthorized; klienten rydder gemte tokens via TokenStorageService.RemoveTokenAsync() og viderestiller til login.
+
+### Udløs periodisk genindlæsning (Tidshændelse)
+- **Forudsætninger**:
+  - Dashboard er indlæst med gyldige tokens i TokenStorageService.
+  - 60-sekunders interval er forløbet siden sidste hentning.
+- **Efterbetingelser**:
+  - TimeEvent kalder Anmod om Dashboard-data med det aktuelle AccessToken; flowet fortsætter ifølge efterbetingelserne for Anmod om Dashboard-data.
+  - Denne operation er system-initieret (ingen brugerinteraktion påkrævet), men er underlagt samme autorisationsregler som brugerinitierede forespørgsler.

--- a/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.oc.md
+++ b/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.oc.md
@@ -1,0 +1,94 @@
+# Operation Contract: Authenticate to access data
+
+## Metadata
+| Key            | Value                              |
+|----------------|------------------------------------|
+| Id             | UC-007.OC                          |
+| crossReference | UC-007.SSD UC-007.DM UC-007.UC     |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-10 | Initial     | Team 6 |
+
+## Operation Contract
+
+```mermaid
+sequenceDiagram
+    actor AuthenticatedStaffMember
+    actor TimeEvent
+    participant ResourceAPI
+    participant IdentityAPI
+
+    AuthenticatedStaffMember ->> ResourceAPI: requestDashboardData(accessToken)
+
+    alt accessTokenValid
+        ResourceAPI -->> AuthenticatedStaffMember: dashboardData
+
+    else accessTokenMissing
+        %% Extension 3a: accessTokenMissing
+        ResourceAPI -->> AuthenticatedStaffMember: 401 Unauthorized
+        AuthenticatedStaffMember ->> AuthenticatedStaffMember: redirectToLogin()
+
+    else accessTokenExpired
+        %% Extension 3b: accessTokenExpired
+        ResourceAPI -->> AuthenticatedStaffMember: 401 Unauthorized
+        AuthenticatedStaffMember ->> IdentityAPI: refreshToken(refreshToken)
+
+        alt refreshTokenValid
+            IdentityAPI -->> AuthenticatedStaffMember: newAccessToken
+            AuthenticatedStaffMember ->> ResourceAPI: requestDashboardData(newAccessToken)
+            ResourceAPI -->> AuthenticatedStaffMember: dashboardData
+
+        else refreshTokenExpiredOrRevoked
+            %% Extension 3c: refreshTokenExpiredOrRevoked
+            IdentityAPI -->> AuthenticatedStaffMember: 401 Unauthorized
+            AuthenticatedStaffMember ->> AuthenticatedStaffMember: clearTokensAndRedirectToLogin()
+        end
+
+    else permissionDenied
+        %% Extension 4a: permissionDenied
+        ResourceAPI -->> AuthenticatedStaffMember: 403 Forbidden
+        AuthenticatedStaffMember -->> AuthenticatedStaffMember: showAuthorizationError()
+
+    else networkOrServerError
+        %% Extension 5a: networkOrServerError
+        ResourceAPI -->> AuthenticatedStaffMember: error
+        AuthenticatedStaffMember -->> AuthenticatedStaffMember: showRetryOption()
+    end
+
+    %% After the dashboard data is successfully loaded, a periodic re-fetch is initiated.
+    loop every 60 seconds
+        TimeEvent ->> ResourceAPI: requestDashboardData(accessToken)
+        ResourceAPI -->> TimeEvent: dashboardData
+    end
+```
+
+### Request Dashboard Data
+- **Preconditions**:
+  - AuthenticatedStaffMember has completed UC-004 login.
+  - Client holds an AccessToken (potentially expired) and a RefreshToken in TokenStorageService.
+  - ResourceAPI is available.
+- **Postconditions**:
+  - On success (token valid): ResourceAPI returns the requested dashboard data.
+  - On accessTokenMissing (3a): ResourceAPI returns 401 Unauthorized; client redirects to login via RedirectToLogin.
+  - On accessTokenExpired (3b): ResourceAPI returns 401 Unauthorized; client triggers Refresh Access Token, then retries with the new token.
+  - On permissionDenied (4a): ResourceAPI returns 403 Forbidden; client displays an authorization error.
+  - On networkOrServerError (5a): client displays an error with a retry option.
+  - Failed authorizations are recorded in the audit trail (REQ-R-003).
+
+### Refresh Access Token
+- **Preconditions**:
+  - Client holds a non-revoked, non-expired RefreshToken in TokenStorageService.
+  - IdentityAPI is available.
+- **Postconditions**:
+  - On success: IdentityAPI issues a new AccessToken; client stores it in TokenStorageService and retries the original request.
+  - On refreshTokenExpiredOrRevoked (3c): IdentityAPI returns 401 Unauthorized; client clears stored tokens via TokenStorageService.RemoveTokenAsync() and redirects to login.
+
+### Trigger Periodic Re-fetch (Time Event)
+- **Preconditions**:
+  - Dashboard is loaded with valid tokens in TokenStorageService.
+  - 60-second interval has elapsed since the last fetch.
+- **Postconditions**:
+  - TimeEvent invokes Request Dashboard Data with the current AccessToken; flow continues per Request Dashboard Data postconditions.
+  - This operation is system-initiated (no user interaction required) but inherits the same authorization rules as user-initiated requests.


### PR DESCRIPTION
## Summary

Adds the Operation Contract (OC) for UC-007 (Authenticate to access data).

OC reuses the SSD diagram and documents pre/postconditions for three operations:

- **Request Dashboard Data** — main authorized flow (extensions 3a, 3b, 4a, 5a)
- **Refresh Access Token** — silent token refresh (extension 3c)
- **Trigger Periodic Re-fetch (Time Event)** — system-initiated re-fetch every 60s

## Notes for reviewer

- Mermaid diagram is identical to UC-007.SSD (per UC-009 OC convention).
- Failed authorizations link to UC-009 audit trail (REQ-R-003).
- Aligned with UC-007 v0002 use case (currently in PR `fix/uc007-usecase-actor-and-scope`).
- Docs-only.

Closes #212