### PR TITLE
feat(uc-007): add sequence diagram for data access authorization

### DIFF
--- a/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.sd.md
+++ b/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.sd.md
@@ -1,0 +1,115 @@
+# UC-007 Authenticate to Access Data Sequence Diagram
+
+## Metadata
+| Key            | Value                              |
+|----------------|------------------------------------|
+| Id             | UC-007.SD                          |
+| crossReference | UC-007.SSD UC-007.OC UC-007.DM     |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-10 | Initial     | Team 6 |
+
+## Sequence Diagram
+
+### Presentation Layer → Application Layer
+```mermaid
+sequenceDiagram
+    actor AuthenticatedStaffMember as Actor
+    actor TimeEvent as TimeEvent (system actor)
+    participant DashboardPage as DashboardPage (WebUI.Client)
+    participant TokenStorage as TokenStorageService (WebUI.Client)
+    participant AuthHandler as JwtAuthorizationMessageHandler (WebUI.Client)
+    participant HttpClient as HttpClient (WebUI.Client)
+
+    AuthenticatedStaffMember->>+DashboardPage: OpenDashboard()
+    DashboardPage->>+TokenStorage: GetAccessTokenAsync()
+    TokenStorage-->>-DashboardPage: accessToken | null
+
+    alt accessTokenMissing
+        %% Extension 3a
+        DashboardPage-->>AuthenticatedStaffMember: RedirectToLogin(/login?returnUrl=...)
+    else accessTokenPresent
+        DashboardPage->>+HttpClient: GET /api/resource (request)
+        HttpClient->>+AuthHandler: SendAsync(request)
+        AuthHandler->>+TokenStorage: GetAccessTokenAsync()
+        TokenStorage-->>-AuthHandler: accessToken
+        AuthHandler-->>-HttpClient: request with Authorization: Bearer accessToken
+    end
+
+    %% Time Event periodic re-fetch (system-initiated)
+    loop every 60 seconds
+        TimeEvent->>DashboardPage: TriggerRefresh()
+        DashboardPage->>HttpClient: GET /api/resource (request)
+    end
+```
+
+### WebUI.Client → WebApi (Resource API call with token)
+```mermaid
+sequenceDiagram
+    participant HttpClient as HttpClient (WebUI.Client)
+    participant ResourceController as ResourceAPIController (Api) [Authorize]
+    participant Repository as Repository (Infrastructure.Data)
+
+    HttpClient->>+ResourceController: GET /api/resource (Bearer accessToken)
+
+    alt accessTokenValid AND hasPermissions
+        ResourceController->>+Repository: GetDataAsync()
+        Repository-->>-ResourceController: data
+        ResourceController-->>HttpClient: 200 OK (DashboardDataDto)
+    else accessTokenInvalidOrExpired
+        %% Extension 3b: token expired
+        ResourceController-->>HttpClient: 401 Unauthorized
+    else permissionDenied
+        %% Extension 4a
+        ResourceController-->>HttpClient: 403 Forbidden
+    else internalError
+        %% Extension 5a
+        ResourceController-->>-HttpClient: 5xx Error
+    end
+```
+
+### Refresh Flow (Identity API call when 401 received)
+```mermaid
+sequenceDiagram
+    participant HttpClient as HttpClient (WebUI.Client)
+    participant RefreshMiddleware as JwtRefreshMiddleware (WebUI.Client)
+    participant TokenStorage as TokenStorageService (WebUI.Client)
+    participant AccountController as AccountController (Api)
+    participant TokenService as TokenService (Core)
+
+    HttpClient->>+RefreshMiddleware: 401 Unauthorized intercepted
+    RefreshMiddleware->>+TokenStorage: GetRefreshTokenAsync()
+    TokenStorage-->>-RefreshMiddleware: refreshToken
+
+    RefreshMiddleware->>+AccountController: POST /Account/Refresh (refreshToken)
+    AccountController->>+TokenService: ValidateRefreshTokenAsync(refreshToken)
+
+    alt refreshTokenValid
+        TokenService-->>AccountController: valid
+        AccountController->>TokenService: IssueNewAccessTokenAsync()
+        TokenService-->>-AccountController: newAccessToken
+        AccountController-->>RefreshMiddleware: 200 OK (newAccessToken)
+        RefreshMiddleware->>+TokenStorage: SetTokenAsync(newAccessToken)
+        TokenStorage-->>-RefreshMiddleware: stored
+        RefreshMiddleware-->>HttpClient: retry original request with newAccessToken
+    else refreshTokenExpiredOrRevoked
+        %% Extension 3c
+        TokenService-->>AccountController: invalid
+        AccountController-->>RefreshMiddleware: 401 Unauthorized
+        RefreshMiddleware->>+TokenStorage: RemoveTokenAsync()
+        TokenStorage-->>-RefreshMiddleware: cleared
+        RefreshMiddleware-->>-HttpClient: RedirectToLogin(/login?returnUrl=...)
+    end
+```
+
+## Notes
+- UC-007 enforces authorization on every Resource API request, including periodic re-fetches triggered by the Time Event (system actor).
+- The `JwtAuthorizationMessageHandler` is a `DelegatingHandler` that automatically attaches the Bearer token to all outgoing requests.
+- The `JwtRefreshMiddleware` intercepts 401 responses and silently refreshes the access token before retrying — extension 3b is invisible to the user.
+- DTOs cross all layer boundaries (no entities exposed):
+  - `DashboardDataDto`, `LoginRequestDto`, `LoginResponseDto`, `RefreshTokenRequestDto`
+- Clean Architecture dependency direction is preserved: WebUI.Client → Core (interfaces) ← Infrastructure (implementations); Api → Infrastructure.Data (repositories).
+- Failed authorization attempts (401/403) are recorded in the audit trail by the audit interceptor (UC-009 backend, REQ-R-003).
+- Login itself (initial token issuance from credentials) is owned by UC-004 — UC-007.SD only covers the refresh flow on Identity API.


### PR DESCRIPTION
## Summary

Adds the Sequence Diagram (SD) for UC-007 (Authenticate to access data).

EN-only (low-level design uses technical terms that map directly to code, so no Danish translation per team convention).

Three Mermaid sequence diagrams following UC-009 SD convention (one per layer boundary):

1. **Presentation → Application** — DashboardPage uses TokenStorageService + JwtAuthorizationMessageHandler. Includes Time Event 60s loop.
2. **WebUI.Client → WebApi** — ResourceAPIController guarded by `[Authorize]`. Covers extensions 3b, 4a, 5a.
3. **Refresh flow** — JwtRefreshMiddleware intercepts 401 and calls Identity API. Covers extension 3c.

## Notes for reviewer

- Login flow (initial token issuance) intentionally NOT modeled — owned by UC-004.
- Failed authorizations link to UC-009 audit trail (REQ-R-003).
- Clean Architecture dependency direction preserved.
- Aligned with UC-007 v0002 use case (currently in PR `fix/uc007-usecase-actor-and-scope`).
- Docs-only.

Closes #213