### PR TITLE
feat(uc-007): add entity relationship diagram for data access authori…

### DIFF
--- a/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.erd.md
+++ b/docs/use-cases/uc-007-dashBoard-authenticateToAccesData/uc-007.erd.md
@@ -1,0 +1,81 @@
+# Entity Relationship Diagram (ERD) for UC-007: Authenticate to Access Data
+
+## Metadata
+| Key            | Value                                            |
+|----------------|--------------------------------------------------|
+| Id             | UC-007.ERD                                       |
+| crossReference | UC-007.DCD<br>UC-007.DM<br>UC-007.USECASE        |
+| Version        | 0001                                             |
+| Date           | 2026-05-10                                       |
+| Author         | Team 6                                           |
+
+## Version Log
+| Version | Date       | Description              | Author     |
+|---------|------------|--------------------------|------------|
+| 0001    | 2026-05-10 | Initial version          | Team 6     |
+
+---
+
+## ERD Diagram
+```mermaid
+erDiagram
+    USER {
+        PK Id string
+        UserName string
+        Email string
+        PasswordHash string
+        SecurityStamp string
+        ConcurrencyStamp string
+    }
+
+    ASPNETUSERROLES {
+        PK FK UserId string
+        PK FK RoleId string
+    }
+
+    ASPNETROLES {
+        PK Id string
+        Name string
+        NormalizedName string
+    }
+
+    ASPNETUSERTOKENS {
+        PK FK UserId string
+        PK LoginProvider string
+        PK Name string
+        Value string
+    }
+
+    AUDITENTRY {
+        PK Id guid
+        EventTime datetime
+        RegisteredTime datetime
+        Entity string
+        ChangeType string
+        Description string
+        FK UserId string
+        Succeeded bool
+    }
+
+    USER ||--o{ ASPNETUSERROLES : has
+    ASPNETROLES ||--o{ ASPNETUSERROLES : assignedTo
+    USER ||--o{ ASPNETUSERTOKENS : owns
+    USER ||--o{ AUDITENTRY : authorizationLoggedFor
+```
+
+## Assumptions and Dependencies
+- UC-007 introduces no new persistent entities of its own. The diagram documents the existing Identity tables and the audit reference that participate in the authorize-on-request flow.
+- `USER` is the standard ASP.NET Core Identity user table (`AspNetUsers`); only the columns relevant to UC-007 (authentication and authorization) are shown.
+- `ASPNETUSERTOKENS` is the standard ASP.NET Core Identity token table. Refresh tokens are persisted here with `LoginProvider = "Slottets-Drifttavlen"` and `Name = "RefreshToken"`. The `Value` column holds the token string.
+- `ASPNETUSERROLES` and `ASPNETROLES` provide role membership consumed by `[Authorize(Roles = "...")]` attributes on protected endpoints.
+- Access tokens (JWT) are NOT persisted server-side — they are signed and self-contained, validated by the authentication middleware on each request.
+- Client-side, the access token and refresh token live in browser local storage via `TokenStorageService`; this is not represented in the ERD because it is not a database entity.
+- `AUDITENTRY` is owned by UC-009; it is referenced here because failed authorization attempts (401/403) result in audit entries with `Succeeded = false` (REQ-R-003).
+
+## Notes
+- See UC-007.DCD for the corresponding class diagram (token DTOs, services, middleware, controllers).
+- See UC-004.ERD for the original modeling of `User` in the context of initial login.
+- See UC-009.ERD for the full audit-log schema.
+- Only the latest version is kept in the main branch.
+
+---


### PR DESCRIPTION
## Summary

Adds the Entity Relationship Diagram (ERD) for UC-007 (Authenticate to access data).

EN-only (low-level design — table/column names map directly to schema, per team convention).

UC-007 introduces no new tables of its own. The ERD documents:

- **USER** — ASP.NET Core Identity user table (AspNetUsers), only auth-relevant columns
- **ASPNETUSERROLES + ASPNETROLES** — role membership for `[Authorize(Roles = "...")]` checks
- **ASPNETUSERTOKENS** — refresh-token persistence (`LoginProvider = "Slottets-Drifttavlen"`, `Name = "RefreshToken"`)
- **AUDITENTRY** — UC-009 reference where failed authorizations are logged (REQ-R-003)

## Notes for reviewer

- Access tokens (JWT) are intentionally NOT persisted server-side — they are signed, self-contained, and validated on each request.
- Client-side token storage (`TokenStorageService` → browser local storage) is not represented because it is not a database entity.
- Aligned with UC-007 v0002 use case (currently in PR `fix/uc007-usecase-actor-and-scope`).
- Docs-only.

Closes #215