### PR TITLE
218 uc007 dashboard authenticatetoaccesdata code backend api

### DIFF
--- a/src/Api/Controllers/AuditController.cs
+++ b/src/Api/Controllers/AuditController.cs
@@ -7,6 +7,7 @@ using Core.Mappers;
 
 using Domain.Entities;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers;
@@ -28,6 +29,8 @@ namespace Api.Controllers;
 /// </code>
 /// </example>
 [ApiController]
+// UC-007: REQ-F-005 — Audit history requires authentication.
+[Authorize]
 [Route("[controller]")]
 public class AuditController(IAuditRepository auditRepository) : ControllerBase
 {

--- a/src/Api/Controllers/DatabaseController.cs
+++ b/src/Api/Controllers/DatabaseController.cs
@@ -1,13 +1,16 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 
 using Core.Interfaces.Services;
-
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers;
 
 [ApiController]
+// UC-007: Health check endpoint — must remain accessible without authentication
+// for Docker healthcheck and external monitoring.
+[AllowAnonymous]
 [Route("[controller]")]
 public class DatabaseController(IDatabaseService databaseService) : ControllerBase
 {

--- a/src/Api/Controllers/MedicineController.cs
+++ b/src/Api/Controllers/MedicineController.cs
@@ -1,10 +1,12 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 using Core.DTOs;
 using Core.Interfaces.Repositories;
 using Core.Mappers;
 
 using Domain.Entities;
+
+using Microsoft.AspNetCore.Authorization;
 
 using Microsoft.AspNetCore.Mvc;
 
@@ -24,6 +26,8 @@ namespace Api.Controllers;
 /// Provides endpoints for retrieving medicine and painkiller status for a specific resident.
 /// </remarks>
 [ApiController]
+// UC-007: REQ-F-005 — Medicine data requires authentication.
+[Authorize]
 [Route("[controller]")]
 public class MedicineController(IMedicineRepository medicineRepository, IPainkillerRepository painkillerRepository) : Controller
 {

--- a/src/Api/Controllers/PhoneAssignmentsController.cs
+++ b/src/Api/Controllers/PhoneAssignmentsController.cs
@@ -3,7 +3,7 @@
 
 using Core.DTOs;
 using Core.Interfaces.Services;
-
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers;
@@ -12,6 +12,8 @@ namespace Api.Controllers;
 /// API controller for managing phone assignments on the dashboard.
 /// </summary>
 [ApiController]
+// UC-007: REQ-F-005 — Phone assignment data requires authentication.
+[Authorize]
 [Route("[controller]")]
 public class PhoneAssignmentsController(IPhoneAssignmentService phoneAssignmentService) : ControllerBase
 {

--- a/src/Api/Controllers/ResidentController.cs
+++ b/src/Api/Controllers/ResidentController.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 
 
@@ -22,6 +22,8 @@ namespace Api.Controllers;
 /// Provides endpoints for retrieving resident information and related notes.
 /// </remarks>
 [ApiController]
+// UC-007: REQ-F-005 — All resident data requires authentication.
+[Authorize]
 [Route("residents")]
 public class ResidentController(IResidentRepository residentRepository) : ControllerBase
 {

--- a/src/Api/Controllers/ResidentNoteController.cs
+++ b/src/Api/Controllers/ResidentNoteController.cs
@@ -1,9 +1,9 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 
 using Core.DTOs;
 using Core.Interfaces.Services;
-
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers;
@@ -24,6 +24,8 @@ namespace Api.Controllers;
 /// </code>
 /// </example>
 [ApiController]
+// UC-007: REQ-F-005 — Resident note data requires authentication.
+[Authorize]
 [Route("[controller]")]
 public class ResidentNoteController : ControllerBase
 {

--- a/src/Api/Controllers/TestController.cs
+++ b/src/Api/Controllers/TestController.cs
@@ -3,7 +3,7 @@
 
 #if DEBUG
 using Core.Interfaces.Services;
-
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers;
@@ -13,6 +13,8 @@ namespace Api.Controllers;
 /// Only available in DEBUG builds — excluded from production.
 /// </summary>
 [ApiController]
+// UC-007: REQ-F-005 — Test endpoint requires authentication even in DEBUG.
+[Authorize]
 [Route("api/test")]
 public class TestController(IAuditService auditService) : ControllerBase
 {

--- a/tests/WebApi.Tests/Controllers/Medicine/MedicineControllerTests.cs
+++ b/tests/WebApi.Tests/Controllers/Medicine/MedicineControllerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 
 
@@ -22,7 +22,9 @@ namespace WebApi.Tests.Controllers.Medicine;
 
 public class MedicineControllerTests(CustomWebApplicationFactory<Api.Program> factory) : IClassFixture<CustomWebApplicationFactory<Api.Program>>
 {
-    private readonly HttpClient _client = factory.CreateClient();
+    // UC-007: data endpoints require authentication; use the authenticated test client.
+    private readonly HttpClient _client = factory.CreateAuthenticatedClient();
+    private readonly CustomWebApplicationFactory<Api.Program> _factory = factory;
 
     [Fact]
     public async Task GetMedicineStatus_ValidResidentId_ReturnsOk()
@@ -113,6 +115,25 @@ public class MedicineControllerTests(CustomWebApplicationFactory<Api.Program> fa
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
+    /// <summary>
+    /// UC-007 (REQ-F-005): Verifies that the [Authorize] attribute on
+    /// MedicineController returns 401 Unauthorized when no Bearer token is provided.
+    /// </summary>
+    [Fact]
+    public async Task GetMedicineStatus_WithoutAuthentication_Returns401()
+    {
+        // Arrange: a fresh client WITHOUT the Bearer token
+        HttpClient unauthenticatedClient = _factory.CreateClient();
+        Guid residentId = Guid.NewGuid();
+
+        // Act
+        HttpResponseMessage response = await unauthenticatedClient.GetAsync(
+            $"/Medicine/{residentId}",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
 
 }
 

--- a/tests/WebApi.Tests/Controllers/PhoneAssignments/PhoneAssignmentsControllerIntegrationTests.cs
+++ b/tests/WebApi.Tests/Controllers/PhoneAssignments/PhoneAssignmentsControllerIntegrationTests.cs
@@ -9,7 +9,9 @@ namespace WebApi.Tests.Controllers.PhoneAssignments;
 
 public class PhoneAssignmentsControllerIntegrationTests(CustomWebApplicationFactory<Api.Program> factory) : IClassFixture<CustomWebApplicationFactory<Api.Program>>
 {
-    private readonly HttpClient _client = factory.CreateClient();
+    // UC-007: data endpoints require authentication; use the authenticated test client.
+    private readonly HttpClient _client = factory.CreateAuthenticatedClient();
+    private readonly CustomWebApplicationFactory<Api.Program> _factory = factory;
 
     [Fact]
     public async Task GetCurrentPhoneAssignmentsForActiveShift_ReturnsOk()
@@ -39,4 +41,23 @@ public class PhoneAssignmentsControllerIntegrationTests(CustomWebApplicationFact
                 cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(result);
     }
+    /// <summary>
+    /// UC-007 (REQ-F-005): Verifies that the [Authorize] attribute on
+    /// PhoneAssignmentsController returns 401 Unauthorized when no Bearer token is provided.
+    /// </summary>
+    [Fact]
+    public async Task GetCurrentPhoneAssignmentsForActiveShift_WithoutAuthentication_Returns401()
+    {
+        // Arrange: a fresh client WITHOUT the Bearer token
+        HttpClient unauthenticatedClient = _factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await unauthenticatedClient.GetAsync(
+            "/PhoneAssignments/active-shift",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(System.Net.HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
 }

--- a/tests/WebApi.Tests/CustomWebApplicationFactory.cs
+++ b/tests/WebApi.Tests/CustomWebApplicationFactory.cs
@@ -111,5 +111,21 @@ public class CustomWebApplicationFactory<TStartup> : WebApplicationFactory<TStar
             _ = userManager.AddToRoleAsync(adminUser, adminRole).GetAwaiter().GetResult();
         }
     }
+
+    /// <summary>
+    /// Creates an HttpClient pre-configured with a Bearer token recognized by
+    /// MockJwtAuthHandler. Use this in integration tests that hit [Authorize]-protected
+    /// endpoints. The authenticated principal has role "admin" and email
+    /// "admin@example.com".
+    /// </summary>
+    /// <returns>An <see cref="HttpClient"/> with a default Authorization header set.</returns>
+    public HttpClient CreateAuthenticatedClient()
+    {
+        HttpClient client = CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "test-jwt-token");
+        return client;
+    }
     #endregion
 }
+


### PR DESCRIPTION
## Summary

Implements UC-007 (Authenticate to access data) at the API boundary.
All data-returning controllers now require a valid JWT Bearer token;
DatabaseController is explicitly opted out for health-check access.
Integration tests are updated to use the existing MockJwtAuthHandler
through a new `CreateAuthenticatedClient()` helper, and two new tests
explicitly verify 401 enforcement.

This PR closes both **#218 (Code-Backend-Api)** and **#219 (Code-Backend-Api-Test)** because the `[Authorize]` attributes and their tests are atomic — landing the attributes without the test fix would break CI.

## Authorization changes

| Controller | Attribute | Reason |
|---|---|---|
| AuditController | `[Authorize]` | UC-009 read endpoints |
| MedicineController | `[Authorize]` | REQ-F-005 |
| PhoneAssignmentsController | `[Authorize]` | REQ-F-005 |
| ResidentController | `[Authorize]` | REQ-F-005 |
| ResidentNoteController | `[Authorize]` | REQ-F-005 |
| TestController | `[Authorize]` | REQ-F-005 (DEBUG-only endpoint) |
| **DatabaseController** | **`[AllowAnonymous]`** | Health check exemption |

## Test infrastructure

- `CustomWebApplicationFactory.CreateAuthenticatedClient()` — returns an `HttpClient` with the test Bearer token already set. Reuses the existing `MockJwtAuthHandler` registered as the default `TestScheme`.
- `MedicineControllerTests` (5 tests) and `PhoneAssignmentsControllerIntegrationTests` (2 tests) updated to use the authenticated client.
- 2 new tests added that explicitly verify 401 Unauthorized when no Bearer token is provided:
  - `MedicineControllerTests.GetMedicineStatus_WithoutAuthentication_Returns401`
  - `PhoneAssignmentsControllerIntegrationT