### PR TITLE
UC-010: Use Case for data security and GDPR compliance

### DIFF
--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.usecase.da.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.usecase.da.md
@@ -1,0 +1,185 @@
+# Use Case: Ensure data security and GDPR compliance (Danish)
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010 |
+| crossReference | BC<br/>REQ-DC-001<br/>REQ-R-003<br/>REQ-F-005 |
+| Title          | Ensure data security and GDPR compliance |
+| Author         | Team 6 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Use Case Description (Danish)
+
+## Brugerhistorie
+Som Admin vil jeg administrere retention-politikker, gennemgå anonymiseringskandidater, overvåge sikkerhedshændelser og besvare indsigtsanmodninger, så systemet overholder GDPR og dansk databeskyttelseslovgivning (Datatilsynet) og beskytter sårbare beboeres persondata.
+
+### Kort Use Case
+**Titel**: Sikre datasikkerhed og GDPR-overholdelse
+**Succesforløb**:
+Admin åbner GDPR Compliance-visningen og gennemgår de aktuelle retention-politikker og deres juridiske grundlag. Systemet viser anonymiseringskandidater foreslået af RetentionBackgroundService og giver Admin mulighed for at godkende eller afvise anonymisering. Systemet flagger mistænkelig aktivitet som sikkerhedshændelser via IncidentDetectionService, og Admin gennemgår, dokumenterer og eskalerer hændelser efter behov. Når en indsigtsanmodning (SAR) modtages, søger Admin efter den registrerede, genererer et eksportgrundlag for relevante persondata og registrerer afslutning; alle handlinger er adgangskontrollerede og audit-loggede.
+
+### Casual Use Case
+**Titel**: Sikre datasikkerhed og GDPR-overholdelse
+**Scope**: Slottets Drifttavlen (GDPR Compliance Layer — bygger videre på UC-007 autentificering og UC-009 audit logging)
+**Niveau**: Brugermål
+**Aktører**:
+- Admin (primary)
+- System (Slottets Drifttavlen)
+- RetentionBackgroundService (automated, suggests anonymization candidates)
+- IncidentDetectionService (automated, flags suspicious activity)
+
+**Hovedforløb**:
+1: Admin åbner GDPR Compliance-visningen.
+2: Systemet validerer Admin-adgang (REQ-F-005) og viser aktuelle retention-politikker og status.
+3: Admin gennemgår retention-politikker og opdaterer retention-perioder og juridisk grundlag, hvor det er relevant.
+4: Systemet validerer ændringerne, gemmer dem og registrerer ændringen i audit-loggen (REQ-R-003).
+5: Systemet viser anonymiseringskandidater foreslået af RetentionBackgroundService.
+6: Admin gennemgår kandidater og godkender anonymisering for egnede registreringer.
+7: Systemet udfører anonymisering, registrerer handlingen i audit-loggen og opdaterer registreringsstatus.
+8: Systemet viser sikkerhedshændelser flagget af IncidentDetectionService.
+9: Admin gennemgår hændelser, tilføjer undersøgelsesnoter og beslutter at lukke eller eskalere hændelser.
+10: Systemet registrerer hændelseshandlinger og beslutninger i audit-loggen.
+11: Admin registrerer en indsigtsanmodning (GDPR Art. 15) og søger efter den registrerede.
+12: Systemet genererer en eksport/rapport med den registreredes persondata og behandlingsoplysninger for det ønskede scope.
+13: Admin gennemgår eksporten for fuldstændighed og dataminimering og markerer derefter anmodningen som afsluttet.
+14: Systemet registrerer SAR-svar og afslutning i audit-loggen.
+
+**Hovedudvidelser**:
+1a: Admin er ikke autentificeret eller mangler Admin-rolle.
+    1: Systemet afviser adgang.
+    2: Systemet registrerer det afviste adgangsforsøg i audit-loggen.
+3a: Retention-ændring er ugyldig (fx kortere end lovpligtigt minimum for en registreringstype).
+    1: Systemet afviser ændringen og viser valideringsfeedback.
+    2: Systemet registrerer det afviste ændringsforsøg i audit-loggen.
+5a: RetentionBackgroundService er utilgængelig.
+    1: Systemet viser en advarsel og fortsætter uden kandidatforslag.
+    2: Systemet registrerer serviceproblemet til overvågning.
+6a: Kandidaten er ikke egnet (fx aktiv sag, uafsluttet audit/legal hold).
+    1: Systemet forhindrer anonymisering og forklarer hvorfor.
+8a: IncidentDetectionService rapporterer mistænkelig aktivitet.
+    1: Systemet opretter eller opdaterer en hændelse og fremhæver alvorlighed.
+    2: Admin eskalerer hændelsen i henhold til incident response-proceduren.
+12a: Eksport kan ikke genereres (fx teknisk fejl).
+    1: Systemet viser en fejl og giver mulighed for at prøve igen.
+    2: Systemet registrerer fejlen i audit-loggen.
+
+**Resumé**: Admin anvender retention- og anonymiseringsregler, overvåger hændelser og håndterer indsigtsanmodninger med sikker adgangskontrol og fuld audit logging.
+
+### Fuldt Udfoldet Use Case
+**Titel**: Sikre datasikkerhed og GDPR-overholdelse
+**Scope**: Slottets Drifttavlen (GDPR Compliance Layer — bygger videre på UC-007 autentificering og UC-009 audit logging)
+**Niveau**: Brugermål
+**Aktører**:
+- Admin (primary)
+- System (Slottets Drifttavlen)
+- RetentionBackgroundService (automated, suggests anonymization candidates)
+- IncidentDetectionService (automated, flags suspicious activity)
+
+**Relaterede Krav**:
+- [REQ-DC-001] GDPR-overholdelse og sikker håndtering af persondata.
+- [REQ-R-003] Audit-log for alle ændringer og brugerhandlinger.
+- [REQ-F-005] Adgangskontrol og login.
+- GDPR Art. 5(1)(e) — Opbevaringsbegrænsning (storage limitation).
+- GDPR Art. 15 — Ret til indsigt (Subject Access Request).
+- GDPR Art. 17 — Ret til sletning.
+- GDPR Art. 25 — Databeskyttelse gennem design og standardindstillinger.
+- GDPR Art. 30 — Fortegnelser over behandlingsaktiviteter.
+- GDPR Art. 32 — Sikkerhed i behandlingen.
+- GDPR Art. 33 — Anmeldelse af brud på persondatasikkerheden.
+- GDPR Art. 35 — Konsekvensanalyse (DPIA).
+- Autorisationsloven §22 (10 års opbevaring af medicindokumentation — dansk lovgivning).
+
+**Forudsætninger**:
+- Brugeren er autentificeret og har Admin-rolle.
+- Audit logging-infrastrukturen (UC-009) er i drift.
+- Baggrundsservices (RetentionBackgroundService, IncidentDetectionService) kører.
+- Standard retention-politikker er seeded i henhold til dansk lovgivning.
+
+**Default Retention Values**:
+
+| Data Category | Default | Legal Minimum | Configurable Range |
+|---|---|---|---|
+| Medicine Logs | 10 years | 10 years (Autorisationsloven §22) | Locked at 10 years |
+| Resident Notes | 5 years after discharge | None | 1–30 years |
+| Audit Logs | 2 years | None | 6 months – 10 years |
+| Login/Security Logs | 13 months | None | 3 months – 2 years |
+| Inactive User Accounts | 6 months after last login | None | 1–24 months |
+| Resident Anonymization Trigger | 90 days after discharge | None | 0–365 days |
+
+Note: For Medicine Logs, the system applies pseudonymization (replacing personal identifiers) rather than full anonymization, in order to preserve medicine history as required by Autorisationsloven §22 while removing personal traceability.
+
+**Hovedforløb**:
+1. Admin åbner GDPR Compliance-visningen.
+2. Systemet autoriserer anmodningen (REQ-F-005) og logger adgang i audit-loggen (REQ-R-003).
+3. Admin gennemgår aktuelle retention-politikker (pr. registreringstype) og deres retention-perioder.
+4. Admin opdaterer en eller flere retention-politikker, inkl. juridisk grundlag og ikrafttrædelsesdato når relevant.
+5. Systemet validerer ændringen mod lovpligtige minimumskrav (fx Autorisationsloven §22 for medicindokumentation) og eventuelle aktive holds.
+6. Systemet gemmer de opdaterede politikker og registrerer ændringen i audit-loggen.
+7. Systemet viser anonymiseringskandidater foreslået af RetentionBackgroundService, inkl. begrundelse (fx retention udløbet), registreringstype og seneste aktivitet.
+8. Admin gennemgår en kandidat og vælger handling (godkend anonymisering, afvis, udsæt eller påfør hold).
+9. Systemet udfører den valgte handling, opdaterer kandidatstatus og registrerer handlingen i audit-loggen.
+10. Systemet viser åbne sikkerhedshændelser og mistænkelig aktivitet flagget af IncidentDetectionService.
+11. Admin gennemgår en hændelse, tildeler alvorlighed, tilføjer undersøgelsesnoter og vælger handling (luk, eskalér eller underret).
+12. Systemet registrerer beslutning og eventuelle underretninger i audit-loggen.
+13. Admin registrerer en indsigtsanmodning (GDPR Art. 15) med anmoderoplysninger og scope/tidsinterval.
+14. Systemet identificerer persondata og relevante behandlingsoplysninger (GDPR Art. 30) for den registrerede.
+15. Systemet genererer en SAR-eksportpakke og logger eksportgenerering.
+16. Admin gennemgår eksporten for fuldstændighed og dataminimering og markerer SAR som opfyldt.
+17. Systemet registrerer afslutning (og eventuelle undtagelser) i audit-loggen.
+
+**Udvidelser**:
+    a: På ethvert tidspunkt, hvis autorisation fejler, afviser systemet adgang og registrerer forsøget i audit-loggen.
+    b: På ethvert tidspunkt, hvis en teknisk fejl opstår, viser systemet en fejl og registrerer fejlen i audit-loggen.
+    5a: Retention-politik bryder lovpligtigt minimum eller konfigurerede begrænsninger.
+        1: Systemet afviser ændringen og forklarer den brudte begrænsning.
+        2: Admin justerer politikken og gentager trin 4.
+    7a: RetentionBackgroundService kører ikke.
+        1: Systemet viser en advarsel om service health.
+        2: Admin fortsætter med manuel gennemgang eller planlægger et nyt forsøg.
+    7b: Der findes ingen anonymiseringskandidater.
+        1: Systemet viser en besked om, at der ikke er nogen afventende kandidater, og Admin fortsætter til incident-gennemgang.
+    9a: Anonymisering kan ikke udføres pga. et aktivt legal/audit hold.
+        1: Systemet forhindrer anonymisering og registrerer årsagen.
+        2: Admin fastholder hold og lukker kandidaten.
+    11a: Hændelsens alvorlighed indikerer muligt brud på persondatasikkerheden (GDPR Art. 33).
+        1: Admin eskalerer hændelsen og følger proceduren for brudsanmeldelse.
+        2: Systemet registrerer eskalationsbeslutning og tidsstempler.
+    15a: SAR-eksport er for stor eller scope er uklart.
+        1: Admin afgrænser scope eller deler eksporten.
+        2: Systemet regenererer eksporten.
+
+**Efterbetingelser**:
+- Retention-politikker er anvendt; ændringer og adgang er registreret i audit-loggen (REQ-R-003).
+- Anonymiseringskandidater er gennemgået, og handlinger er registreret i audit-loggen.
+- Sikkerhedshændelser er overvåget, triageret og registreret med sporbarhed.
+- Indsigtsanmodninger er håndteret med et auditerbart spor af hvad der er eksporteret og hvornår.
+
+## Vedligeholdelse
+- Opdater version og ændringslog ved større ændringer.
+- Gennemgå regelmæssigt use cases for nøjagtighed og relevans.
+- Gennemgå og godkend use cases med relevante interessenter før accept.
+
+## Implementation Notes
+- Denne use case forudsætter, at autentificering og adgangskontrol håndteres af UC-007, og at alle handlinger logges i henhold til UC-009.
+- Retention-politikker bør understøtte både lovpligtige minimumskrav (fx medicindokumentation) og operationelle holds (fx igangværende undersøgelse).
+- SAR-eksport bør være adgangskontrolleret, manipulationssikker og begrænset til det ønskede scope/tidsinterval.
+
+## Terms Translation
+| English                         | Danish |
+|---------------------------------|--------|
+| Data retention policy           | Retention-politik / opbevaringspolitik |
+| Storage limitation              | Opbevaringsbegrænsning |
+| Anonymization candidate         | Anonymiseringskandidat |
+| Audit log / audit trail         | Audit-log / revisionsspor |
+| Security incident               | Sikkerhedshændelse |
+| Suspicious activity             | Mistænkelig aktivitet |
+| Subject Access Request (SAR)    | Indsigtsanmodning |
+| Personal data breach            | Brud på persondatasikkerheden |
+| Records of processing activities| Fortegnelser over behandlingsaktiviteter |
+| Data protection by design       | Databeskyttelse gennem design |
+| DPIA                            | Konsekvensanalyse (DPIA) |

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.usecase.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.usecase.md
@@ -1,0 +1,170 @@
+# Use Case: Ensure data security and GDPR compliance
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010 |
+| crossReference | BC<br/>REQ-DC-001<br/>REQ-R-003<br/>REQ-F-005 |
+| Title          | Ensure data security and GDPR compliance |
+| Author         | Team 6 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Use Case Description
+
+## User story
+As an Admin, I want to manage data retention policies, review anonymization candidates, monitor security incidents, and respond to subject access requests, so that the system complies with GDPR and Danish data protection law (Datatilsynet) and protects vulnerable residents' personal data.
+
+### Brief Use Case
+**Title**: Ensure data security and GDPR compliance
+**Success Flow**:
+The Admin opens the GDPR Compliance view and reviews the current retention policies and their legal basis. The system shows anonymization candidates suggested by RetentionBackgroundService and allows the Admin to approve or reject anonymization actions. The system flags suspicious activity as security incidents via IncidentDetectionService, and the Admin reviews, documents, and escalates incidents when needed. When a subject access request (SAR) is received, the Admin searches for the data subject, generates an export of relevant personal data, and records completion; all actions are access-controlled and audit logged.
+
+### Casual Use Case
+**Title**: Ensure data security and GDPR compliance
+**Scope**: Slottets Drifttavlen (GDPR Compliance Layer — builds on top of UC-007 authentication and UC-009 audit logging)
+**Level**: User Goal
+**Actors**:
+- Admin (primary)
+- System (Slottets Drifttavlen)
+- RetentionBackgroundService (automated, suggests anonymization candidates)
+- IncidentDetectionService (automated, flags suspicious activity)
+
+**Main Flow**:
+1: Admin opens the GDPR Compliance view.
+2: System validates Admin access (REQ-F-005) and shows current retention policies and status.
+3: Admin reviews retention policies and updates retention periods and legal basis where applicable.
+4: System validates the retention policy changes, saves them, and records the change in the audit log (REQ-R-003).
+5: System shows anonymization candidates suggested by RetentionBackgroundService.
+6: Admin reviews candidates and approves anonymization actions for eligible records.
+7: System performs anonymization, records the action in the audit log, and updates record status.
+8: System displays security incidents flagged by IncidentDetectionService.
+9: Admin reviews incidents, adds investigation notes, and decides to close or escalate incidents.
+10: System records incident actions and decisions in the audit log.
+11: Admin registers a subject access request (GDPR Art. 15) and searches for the data subject.
+12: System generates an export/report of the data subject’s personal data and processing records for the requested scope.
+13: Admin reviews the export for completeness and minimization, then marks the request as completed.
+14: System records the SAR response and completion in the audit log.
+
+**Main Extensions**:
+1a: Admin is not authenticated or lacks the Admin role.
+    1: System denies access.
+    2: System records the denied access attempt in the audit log.
+3a: Retention policy change is invalid (e.g., shorter than legal minimum for a record type).
+    1: System rejects the change and shows validation feedback.
+    2: System records the rejected change attempt in the audit log.
+5a: RetentionBackgroundService is unavailable.
+    1: System shows a warning and continues without candidate suggestions.
+    2: System records the service health issue for monitoring.
+6a: Candidate is not eligible (e.g., active case, unresolved audit/legal hold).
+    1: System prevents anonymization and explains why.
+8a: IncidentDetectionService reports suspicious activity.
+    1: System creates or updates an incident entry and highlights severity.
+    2: Admin escalates the incident according to the incident response procedure.
+12a: Export cannot be generated (e.g., technical error).
+    1: System shows an error and offers retry.
+    2: System records the failure in the audit log.
+
+**Summary**: The Admin applies retention and anonymization rules, monitors incidents, and fulfills SARs with secure access control and full audit logging.
+
+### Fully Dressed Use Case
+**Title**: Ensure data security and GDPR compliance
+**Scope**: Slottets Drifttavlen (GDPR Compliance Layer — builds on top of UC-007 authentication and UC-009 audit logging)
+**Level**: User Goal
+**Actors**:
+- Admin (primary)
+- System (Slottets Drifttavlen)
+- RetentionBackgroundService (automated, suggests anonymization candidates)
+- IncidentDetectionService (automated, flags suspicious activity)
+
+**Related Requirements**:
+- [REQ-DC-001] GDPR compliance and secure handling of personal data.
+- [REQ-R-003] Audit log for all changes and user actions.
+- [REQ-F-005] Access control and login.
+- GDPR Art. 5(1)(e) — Storage limitation.
+- GDPR Art. 15 — Right of access (Subject Access Request).
+- GDPR Art. 17 — Right to erasure.
+- GDPR Art. 25 — Data protection by design and by default.
+- GDPR Art. 30 — Records of processing activities.
+- GDPR Art. 32 — Security of processing.
+- GDPR Art. 33 — Notification of personal data breach.
+- GDPR Art. 35 — Data protection impact assessment (DPIA).
+- Autorisationsloven §22 (10-year medicine documentation retention — Danish law).
+
+**Preconditions**:
+- User is authenticated and assigned the Admin role.
+- Audit logging infrastructure (UC-009) is operational.
+- Background services (RetentionBackgroundService, IncidentDetectionService) are running.
+- Default retention policies are seeded according to Danish law.
+
+**Default Retention Values**:
+
+| Data Category | Default | Legal Minimum | Configurable Range |
+|---|---|---|---|
+| Medicine Logs | 10 years | 10 years (Autorisationsloven §22) | Locked at 10 years |
+| Resident Notes | 5 years after discharge | None | 1–30 years |
+| Audit Logs | 2 years | None | 6 months – 10 years |
+| Login/Security Logs | 13 months | None | 3 months – 2 years |
+| Inactive User Accounts | 6 months after last login | None | 1–24 months |
+| Resident Anonymization Trigger | 90 days after discharge | None | 0–365 days |
+
+Note: For Medicine Logs, the system applies pseudonymization (replacing personal identifiers) rather than full anonymization, in order to preserve medicine history as required by Autorisationsloven §22 while removing personal traceability.
+
+**Main Flow**:
+1. Admin opens the GDPR Compliance view.
+2. System authorizes the request (REQ-F-005) and logs the access in the audit log (REQ-R-003).
+3. Admin reviews current retention policies (by record type) and their configured retention periods.
+4. Admin updates one or more retention policies, including legal basis and effective date when required.
+5. System validates the change against mandatory minimums (e.g., Autorisationsloven §22 for medicine documentation) and any active holds.
+6. System saves the updated policies and records the policy change in the audit log.
+7. System displays anonymization candidates suggested by RetentionBackgroundService, including candidate reason (e.g., retention expired), record type, and last activity.
+8. Admin reviews a candidate and selects an action (approve anonymization, reject, postpone, or apply hold).
+9. System performs the selected action, updates the candidate status, and records the action in the audit log.
+10. System displays open security incidents and suspicious activities flagged by IncidentDetectionService.
+11. Admin reviews an incident, assigns severity, adds investigation notes, and selects an action (close, escalate, or notify).
+12. System records the incident decision and any notifications in the audit log.
+13. Admin registers a Subject Access Request (GDPR Art. 15) with requester details and scope/time range.
+14. System identifies personal data and relevant processing records (GDPR Art. 30) for the data subject.
+15. System generates a SAR export package and logs the export generation.
+16. Admin reviews the export for completeness and minimization, then marks the SAR as fulfilled.
+17. System records the completion (and any exceptions) in the audit log.
+
+**Extensions**:
+    a: At any time, if authorization fails, system denies access and records the attempt in the audit log.
+    b: At any time, if a technical error occurs, system shows an error and records the failure in the audit log.
+    5a: Retention policy violates legal minimum or configured constraints.
+        1: System rejects the change and explains the violated constraint.
+        2: Admin adjusts the policy and retries step 4.
+    7a: RetentionBackgroundService is not running.
+        1: System shows a service health warning.
+        2: Admin continues with manual review or schedules a retry.
+    7b: No anonymization candidates exist.
+        1: System shows a 'No pending candidates' message and the admin proceeds to incident review.
+    9a: Anonymization cannot be applied due to an active legal/audit hold.
+        1: System prevents anonymization and records the reason.
+        2: Admin applies or maintains the hold and closes the candidate.
+    11a: Incident severity indicates a potential personal data breach (GDPR Art. 33).
+        1: Admin escalates the incident and follows the breach notification procedure.
+        2: System records the escalation decision and timestamps.
+    15a: SAR export is too large or contains ambiguous scope.
+        1: Admin narrows the scope or splits the export.
+        2: System regenerates the export.
+
+**Postconditions**:
+- Retention policies are applied; changes and access are recorded in the audit log (REQ-R-003).
+- Anonymization candidates are reviewed and actions are recorded in the audit log.
+- Security incidents are monitored, triaged, and recorded with traceability.
+- Subject access requests are fulfilled with an auditable record of what was exported and when.
+
+## Maintenance
+- Update the version and change log for major changes.
+- Regularly review use cases for accuracy and relevance.
+- Review and approve use cases with relevant stakeholders before acceptance.
+
+## Implementation Notes
+- This use case assumes authentication and access control are handled by UC-007 and that all actions are captured by the audit logging approach described in UC-009.
+- Retention policies should support legal minimums (e.g., medicine documentation) and operational holds (e.g., ongoing investigation).
+- SAR exports should be access-controlled, tamper-evident, and limited to the requested scope/time range.


### PR DESCRIPTION
## Summary
Adds the foundational use case document for UC-010 — ensuring full GDPR compliance for Slottets Drifttavlen, including retention policies, anonymization, security incident handling, and Subject Access Requests.

## Scope
- Primary actor: Admin (role from UC-007)
- Built on top of UC-007 (auth) and UC-009 (audit logging)
- Covers GDPR Art. 5, 12, 15, 17, 25, 30, 32, 33, 35
- Special handling for Medicine Logs per Autorisationsloven §22 (10-year retention)

## Files
- `docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.usecase.md`
- `docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.usecase.da.md`

Closes #430