### PR TITLE
432 uc010 ensure data security and gdpr compliance wireframe

### DIFF
--- a/.github/agents/userflow-artifact.agent.md
+++ b/.github/agents/userflow-artifact.agent.md
@@ -1,0 +1,82 @@
+---
+description: Generates, validates, and maintains User Flow Diagram (UFD) documentation in markdown using Mermaid flowchart syntax, following strict content, structure, and naming conventions for clarity and consistency.
+name: User Flow Diagram Agent
+tools:
+  - new
+  - edit/editFiles
+  - search
+  - lookup
+references:
+  - docs/bc.md
+  - .github/instructions/userflow.instructions.md
+  - docs/quality-criteria/artifact/qc-userflow.md
+---
+
+# User Flow Diagram Agent Specification
+
+## Instruction Compliance
+This agent MUST comply with the UFD instructions in `.github/instructions/userflow.instructions.md` and quality criteria in `docs/quality-criteria/artifact/qc-userflow.md`. All UFD artifacts must:
+- Follow the provided template and quality criteria.
+- Replace all placeholders with project-specific content.
+- Use Mermaid `flowchart TD` or `flowchart LR` syntax (never `sequenceDiagram`).
+- Use correct file naming, versioning, and language handling as specified.
+- Maintain a version log and unique version identifier for each UFD.
+- Store UFD files in the centralized repository, deleting or archiving older versions as required.
+- Ensure all new terms are added to the glossary files as per instructions.
+- Validate UFDs for completeness, clarity, and template compliance.
+
+## Agent Role
+The User Flow Diagram Agent is responsible for generating, validating, and maintaining UFDs based on the requirements defined in the use cases. It creates Mermaid flowchart representations of user navigation journeys for documentation and stakeholder communication. UFDs are user-perspective artifacts and complement (but do not replace) SSDs (system perspective), SDs (object perspective), and wireframes (visual layout).
+
+## Tool Usage Requirements
+- **File Creation**: The agent MUST use the `new` tool to physically create files. Never output raw markdown to chat when file creation is requested.
+- **File Updates**: The agent MUST use `edit/editFiles` to update existing UFDs.
+- **Use Case Reading**: Before creating a UFD, the agent MUST read the corresponding `uc-<id>.usecase.md` file located at `docs/use-cases/uc-<id>/uc-<id>.usecase.md` to extract main flow steps, extensions, and actors that should be reflected in the diagram. If the file does not exist, the agent MUST stop and ask the user for the use case content rather than generating a fictional flow.
+- **Glossary Updates**: When new domain terms appear in the UFD that are not already in `docs/glossary.md`, the agent MUST use `edit/editFiles` to add them to the glossary.
+- **Path Accuracy**: Before creating a file, the agent must check if the directory (e.g., `docs/use-cases/uc-<id>/`) exists. If not, create the directory structure first.
+
+## Agent Responsibilities
+- Create UFD files using the provided template and ensure all placeholders are replaced with project-specific content.
+- Store UFD files in the centralized repository, following naming conventions and versioning rules.
+- Maintain version logs, keep only the latest version in main, and archive older versions.
+- Use Mermaid `flowchart TD` (top-down) or `flowchart LR` (left-right) syntax — never omit the direction modifier.
+- Use node conventions: `([rounded])` for start/end, `[rectangle]` for screens/actions, `{diamond}` for decisions.
+- Label arrows with user-meaningful conditions (e.g., "Approve", "Cancel", "Not authorized").
+- Use user-facing labels only: what the user sees, clicks, or decides.
+  - ✅ Allowed: `Click Save`, `Confirm action`, `Page loads`, `Show error`
+  - ❌ Forbidden: `POST /api/policy`, `SaveAsync()`, `DbContext.SaveChanges()`, `Repository.Add()`
+- System internals (API calls, DB queries, service methods) belong in SSD/SD, never in UFD.
+
+## Workflow Triggers
+- On "Generate" or "Create" UFD: use the `new` tool with the correct path and naming convention.
+- On "Update" or "Edit" UFD: use the `edit/editFiles` tool with the UFD file path and specific changes.
+
+## Agent File Naming
+Name files in lowercase, using digits for the use case number, following the pattern: `uc-<use case number>.userflow.md`.
+Save files in the use case subfolder: `docs/use-cases/uc-<id>/uc-<id>.userflow.md`.
+Increment version numbers for significant changes.
+Include today's date and author in the version log.
+Only keep the latest version in main; archive or delete older versions.
+
+## Agent Validation
+- Review UFDs for completeness, clarity, and correct use of the template.
+- Verify that all placeholders are replaced with project-specific content.
+- Verify the diagram covers all main flows and key extensions from the linked use case.
+- If the referenced use case file does not exist, the agent MUST stop and ask the user for the use case content instead of generating a fictional flow.
+
+## Agent Maintenance
+- Update the version and change log for major changes.
+- Regularly review UFDs for accuracy and relevance.
+
+## Agent Language Handling
+- Use professional English for all metadata, versioning, and the default UFD file.
+- If the product owner's domain language is different from English, the agent MUST create a second UFD file with the diagram content translated into the product owner's language.
+- The translated file must use the correct language code suffix (e.g., `.da.md` for Danish), following the pattern: `uc-<use case number>.userflow.<language code>.md`.
+- Both files must be kept in the use case subfolder.
+- All other instructions (versioning, logging, archiving) apply to both language versions.
+
+## Compliance
+- Follow `.github/instructions/userflow.instructions.md` for all UFD artifact structure, content, and template requirements.
+
+## Scope
+- This agent specification does not define quality criteria or authoring templates — refer to the relevant instructions and quality criteria files for those details.

--- a/.github/instructions/userflow.instructions.md
+++ b/.github/instructions/userflow.instructions.md
@@ -1,0 +1,69 @@
+---
+description: 'User Flow Diagram template for project documentation.'
+applyTo: 'docs/use-cases/**/uc*.userflow.md'
+references:
+  - docs/quality-criteria/artifact/qc-userflow.md
+---
+
+# User Flow Diagram Instructions (Summary)
+- Use the provided User Flow Diagram (UFD) markdown template and examples.
+- A UFD shows the user's navigation journey across screens, decision points, and end states — from the user's perspective, NOT system internals.
+- Use Mermaid `flowchart TD` (top-down) or `flowchart LR` (left-right) syntax — never omit the direction modifier, and never use `sequenceDiagram` (that is reserved for SSD/SD).
+- Before generating a UFD, verify that the corresponding `uc-<id>.usecase.md` file exists. If not, abort and request the use case content rather than generating a fictional flow.
+- Replace all placeholders with project-specific content.
+- Store UFD files in `docs/use-cases/uc-<Insert Use Case Identifier>/` as `uc-<Insert Use Case Identifier>.userflow.md`.
+- Increment version numbers for significant changes; keep only the latest version in main, archive older versions.
+- Include metadata, version log (with date, author), Mermaid diagram in markdown code block, and notes section.
+- Notes section MUST mention: dependencies on other use cases, assumptions about prior authentication/authorization, edge cases not visualized in the diagram, and references to other artifacts (e.g., wireframe, SSD).
+- Create files in English; if product owner domain language differs, create a separate file with language code suffix (e.g., uc-xxx.userflow.da.md).
+- If the UFD introduces domain terms not already in `docs/glossary.md`, add them to that file. For Danish UFDs, also add the translation to `docs/glossary.da.md`.
+- Validate UFDs for completeness, clarity, and template compliance.
+- UFDs are user navigation only — do NOT include system sequence details (use SSD), object interactions (use SD), or UI layout (use wireframe).
+- Keep diagrams under 25 nodes for readability. If the flow is more complex, split into multiple diagrams (one per main journey) within the same file.
+
+## Template (Minimal)
+
+The following shows the required structure. The Mermaid code block is shown using `~~~mermaid` fences instead of triple-backticks to keep this template renderable inside this instructions file. When creating the actual UFD file, use standard triple-backtick fences (` ```mermaid `).
+
+## Metadata
+| Key            | Value                              |
+|----------------|------------------------------------|
+| Id             | [Use case identifier].UserFlow     |
+| crossReference | [Use case identifier]<br/>[Use case identifier].UC<br/>[Use case identifier].Wireframe |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | [date]     | Initial     | [name] |
+
+## User Flow Diagram
+
+[Brief description of the user journey covered by this diagram]
+
+~~~mermaid
+flowchart TD
+    Start([User starts]) --> Auth{Authorized?}
+    Auth -->|No| Deny[Access denied]
+    Auth -->|Yes| Page1[Main page]
+    Page1 --> Decision{User choice?}
+    Decision -->|Option A| ActionA[Perform action A]
+    Decision -->|Option B| ActionB[Perform action B]
+    ActionA --> Success([Success])
+    ActionB --> Success
+    Deny --> End([End])
+    Success --> End
+~~~
+
+## Node Conventions
+- `([Rounded])` — Start/End states (entry and exit points)
+- `[Rectangle]` — Screen, page, or user action
+- `{Diamond}` — Decision point (branch based on condition or user choice)
+- Arrows labeled with `|condition|` show branching logic
+- Use clear, user-facing labels (e.g., "Click Save", "Open Settings") — not technical terms
+
+## Notes
+[Add any clarifications about the flow, dependencies on other use cases, authentication assumptions, edge cases not visualized, and references to related artifacts]
+
+## Example Reference
+For a complete reference example, see `docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.userflow.md` once available.
+

--- a/docs/glossary.da.md
+++ b/docs/glossary.da.md
@@ -1,0 +1,22 @@
+# Glossary (Danish)
+
+## Language Translation Mapping
+| English Term | Product Owner Term | Notes |
+|--------------|-------------------|-------|
+| GDPR Compliance Dashboard | GDPR Compliance-dashboard / GDPR-overholdelsesdashboard | Admin-visning for UC-010. |
+| Data retention policy | Retention-politik / opbevaringspolitik | Politik pr. registreringstype. |
+| Legal minimum retention | Lovpligtigt minimum (opbevaring) | Minimumskrav fastsat i lovgivning. |
+| Anonymization candidate | Anonymiseringskandidat | Kandidat i anonymiseringskø. |
+| Hold (legal/audit hold) | Hold (legal/audit hold) | Forhindrer anonymisering ved aktive hensyn. |
+| Security incident | Sikkerhedshændelse | Hændelse der kræver undersøgelse/triage. |
+| Personal data breach | Brud på persondatasikkerheden | Kan udløse anmeldelsespligt. |
+| Subject Access Request (SAR) | Indsigtsanmodning (SAR) | GDPR Art. 15. |
+| SAR export package | SAR-eksportpakke | Eksport/rapport til anmoder. |
+| Data minimization | Dataminimering | Gennemgang i SAR-flow. |
+| Audit log / audit trail | Audit-log / revisionsspor | Sporbarhed (UC-009). |
+| Art. 33 notification | Art. 33-underretning | Underretning ved brud. |
+
+## Artifact Term Change Table
+| High-Level Term | Low-Level Term | Reason/Context |
+|-----------------|---------------|---------------|
+| N/A | N/A | Ingen omdøbte termer registreret endnu. |

--- a/docs/glossary.da.md
+++ b/docs/glossary.da.md
@@ -15,6 +15,8 @@
 | Data minimization | Dataminimering | Gennemgang i SAR-flow. |
 | Audit log / audit trail | Audit-log / revisionsspor | Sporbarhed (UC-009). |
 | Art. 33 notification | Art. 33-underretning | Underretning ved brud. |
+| DPO (Data Protection Officer) | Databeskyttelsesrådgiver (DPO) | Modtager ved brud-underretning. |
+| Phone assignments | Telefon-tildelinger | Valg i SAR-eksport. |
 
 ## Artifact Term Change Table
 | High-Level Term | Low-Level Term | Reason/Context |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -15,6 +15,8 @@
 | Data minimization | Principle of limiting disclosed/processed personal data to what is necessary for a purpose. | Applied during SAR review. |
 | Audit log / audit trail | A tamper-evident record of user actions and state changes. | Used for traceability (UC-009). |
 | Art. 33 notification | A notification step for reporting certain personal data breaches (GDPR Art. 33). | Triggered when breach conditions apply. |
+| DPO (Data Protection Officer) | The person/role responsible for oversight of data protection compliance and breach communication. | Recipient in breach notification confirmation. |
+| Phone assignments | Information about how phones or phone responsibilities are assigned (e.g., per shift/team). | Included as an optional item in SAR exports. |
 
 ## Artifact Term Change Table
 | High-Level Term | Low-Level Term | Reason/Context |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,22 @@
+# Glossary
+
+## Terms
+| Term | Definition | Notes |
+|------|------------|-------|
+| GDPR Compliance Dashboard | A dedicated admin view for managing GDPR-related operational tasks. | Entry point for UC-010 user journeys. |
+| Data retention policy | Rules that define how long specific categories of data are kept and on what legal basis. | Must respect legal minimums. |
+| Legal minimum retention | A mandatory minimum retention period required by law for specific record types. | Example: medicine documentation retention in Danish law. |
+| Anonymization candidate | A record or dataset suggested for anonymization based on retention rules and status. | Reviewed and actioned by Admin. |
+| Hold (legal/audit hold) | A constraint that prevents anonymization or deletion while an investigation, audit, or legal need is active. | Used in the anonymization queue decisions. |
+| Security incident | An event indicating suspicious activity or a potential security problem requiring investigation. | Managed in the incidents view. |
+| Personal data breach | A security incident involving unauthorized access, loss, or disclosure of personal data. | May require notification obligations. |
+| Subject Access Request (SAR) | A request by a data subject to access their personal data (GDPR Art. 15). | Handled as an export workflow. |
+| SAR export package | The generated export/report containing the data subject’s personal data and related processing records. | Reviewed for minimization before fulfillment. |
+| Data minimization | Principle of limiting disclosed/processed personal data to what is necessary for a purpose. | Applied during SAR review. |
+| Audit log / audit trail | A tamper-evident record of user actions and state changes. | Used for traceability (UC-009). |
+| Art. 33 notification | A notification step for reporting certain personal data breaches (GDPR Art. 33). | Triggered when breach conditions apply. |
+
+## Artifact Term Change Table
+| High-Level Term | Low-Level Term | Reason/Context |
+|-----------------|---------------|---------------|
+| N/A | N/A | No renamed terms recorded yet. |

--- a/docs/quality-criteria/artifact/qc-userflow.md
+++ b/docs/quality-criteria/artifact/qc-userflow.md
@@ -1,55 +1,68 @@
-# Quality Criteria: User Flow
-A User Flow illustrates the path taken by a user to accomplish a specific goal within a system. 
-This document defines quality criteria and a template for documenting user flows in markdown format, using Mermaid for visual diagrams.
+# Quality Criteria: User Flow Diagram (UFD)
+A User Flow Diagram illustrates the user's navigation journey across screens, decision points, and end states for a specific use case.
+This document defines quality criteria and a template for documenting UFDs in markdown format using Mermaid flowchart syntax.
 
 ## Metadata
 | Key               | Value                             |
 |-------------------|-----------------------------------|
-| Id                | QC-USERFLOW                      |
+| Id                | QC-USERFLOW                       |
 | crossReference    |                                   |
 
 ## Version and Change Log
-| Date       | Version | Description                     | Author        |
-|------------|---------|---------------------------------|---------------|
-| 2026-02-16 | 0001    | Initial creation of the document |               |
+| Date       | Version | Description                                          | Author  |
+|------------|---------|------------------------------------------------------|---------|
+| 2026-05-11 | 0001    | Initial creation of the document                     | Team 6  |
+| 2026-05-11 | 0002    | Tightened Mermaid syntax, completeness, and size     | Team 6  |
 
-## Quality Criteria for User Flow
-When evaluating a User Flow, consider the following quality criteria:
-1. **Objective & Persona Definition**: Clearly state the specific goal (e.g., checkout) and the user persona performing the action.
-2. **Entry Points**: Identify where the user starts their journey (e.g., landing page, email link).
-3. **Step & Decision Mapping**: Outline the sequence of screens, user actions (choose/input), and decision points (yes/no). Each step and decision must be clearly labeled.
-4. **Flow Types**: Specify the type of flow (chart flow, wire flow, screen flow) and ensure the diagram matches the intended detail level.
-5. **Diagram Conventions**: Use standard shapes:
-   - **Oval**: Start/End
-   - **Rectangle**: Screen/Webpage
-   - **Diamond**: Decision point
-   - **Arrow**: Direction of flow
-6. **Clarity & Simplicity**: The flow must be easy to follow, with concise labels and logical progression. Avoid unnecessary complexity.
-7. **Completeness**: All relevant steps, decisions, and possible outcomes must be included.
-8. **Relevance**: The flow must reflect the actual user journey for the defined objective and persona.
-9. **Consistency**: The flow should be logically consistent and align with related artifacts (e.g., use cases, UI wireframes).
-10. **Visual Appeal**: The diagram should be visually organized and easy to navigate. Use Mermaid's layout features to enhance readability.
-11. **Mermaid Syntax**: The diagram must use valid Mermaid flowchart syntax.
-12. **Test & Refine**: Review the flow for bottlenecks or unnecessary steps, and iterate based on feedback.
+## Quality Criteria for User Flow Diagrams
+When evaluating a UFD, consider the following quality criteria:
+1. **Clarity and Simplicity**: The flow should be easy to follow, with clear node labels, decision points, and arrows. Avoid unnecessary complexity.
+2. **Completeness**: Every step in the use case's main flow must appear as a node. Authorization failures, validation errors, and user-facing error states must be represented. Internal/technical extensions (e.g., 'database connection lost') need NOT appear since they belong in SSD.
+3. **Correctness**: The flow must accurately reflect the use case scope and the user's actual navigation experience. It must not introduce navigation paths not covered by the use case.
+4. **Consistency**: Node conventions must be applied consistently: `([rounded])` for start/end, `[rectangle]` for screens/actions, `{diamond}` for decisions.
+5. **User Perspective**: The diagram MUST describe what the user sees, clicks, and decides — NOT what the system does internally. System internals belong in SSD/SD artifacts.
+6. **Traceability**: Each node must be traceable to a step, decision, or outcome in the use case.
+7. **Mermaid Syntax**: The diagram MUST use Mermaid `flowchart TD` or `flowchart LR` syntax. Use of `sequenceDiagram` or `flowchart` without a direction modifier is incorrect.
+8. **No Implementation Details**: UFDs are navigation only. Do not include API endpoints, database operations, service names, or technical implementation details.
+9. **Branching Logic**: Decision diamonds must have clearly labeled outgoing arrows showing the condition for each branch (e.g., `|Approved|`, `|Rejected|`).
+10. **End States**: Every path must terminate in an explicit end state (success, failure, or cancellation). No dangling nodes.
+11. **Readability**: Diagrams should contain no more than 25 nodes. Larger flows must be split into multiple diagrams within the same file, one per main user journey.
+12. **Versioning and Change Log**: Every change must be logged with a version, date, and author.
+13. **Language/Translation Compliance**: If the product owner language is not English, create a separate translated file with the correct language code suffix.
 
-## Benefits of User Flows
-- **Improved UX**: Ensures a logical, intuitive path that reduces confusion.
-- **Enhanced Collaboration**: Provides a shared, visual understanding for designers, developers, and stakeholders.
-- **Efficient Development**: Identifies potential issues early, saving time during implementation.
+## Common Anti-Patterns (Do NOT do this)
+- ❌ Including technical method names like `SaveAsync()`, `Repository.Add()`, or `POST /api/policy` as node labels.
+- ❌ Showing system-internal messages (e.g., "DbContext returns success") — those belong in SSD/SD.
+- ❌ Creating an unauthenticated entry point when the use case requires authorization.
+- ❌ Omitting error/denied paths so the diagram looks "cleaner" — these paths are required for completeness.
+- ❌ Using `flowchart` without `TD` or `LR` direction modifier — produces invalid Mermaid.
+- ❌ Mixing user actions and system processes in the same node (e.g., "User saves and system validates" should be two nodes).
 
-## Example Mermaid User Flow
-```mermaid
-flowchart TD
-    Start([Start])
-    A[Landing Page]
-    B{Decision: Login?}
-    C[Dashboard]
-    D[Checkout]
-    End([End])
-    Start --> A --> B
-    B -- Yes --> C --> D --> End
-    B -- No --> End
-```
+## Relationship to Other Artifacts
+- **UC (Use Case)**: UFD visualizes the navigation derived from the use case's main flow and extensions.
+- **Wireframe**: UFD shows the journey BETWEEN screens; Wireframe shows the layout WITHIN a screen.
+- **SSD (System Sequence Diagram)**: SSD shows system-level message exchanges; UFD shows user-level navigation. They are complementary, not redundant.
+- **SD (Sequence Diagram)**: SD shows object collaborations inside the system; UFD shows the user's path outside the system.
+- **OC (Operation Contracts)**: OC defines preconditions/postconditions per system operation; UFD does not enforce these — they are validated at the SSD/SD/OC level.
+- **DCD (Domain Class Diagram)**: DCD describes the static structure of domain classes; UFD describes the user's runtime journey through the UI.
 
-## Filename Convention
-- Name files in lowercase, using digits for version, following the pattern: `userflow.uc-yyy.xxxx.md` (e.g., `userflow.uc-001.0001.md`) where `yyy` is the use case number.
+## Authoring Patterns and Templates
+For filename conventions, templates, and authoring examples, see `.github/instructions/userflow.instructions.md`.
+
+## Validation
+- Review UFDs for completeness, clarity, and correct use of the template.
+- Verify that all placeholders are replaced with project-specific content.
+- Verify the diagram covers the main flow and key extensions from the linked use case.
+- Verify that the linked use case file (`uc-<id>.usecase.md`) exists and matches the UFD's crossReference. A UFD without a matching use case is invalid.
+- Verify Mermaid syntax renders correctly — test at https://mermaid.live/ if in doubt.
+- Verify total node count is ≤ 25; if not, split into multiple diagrams within the file.
+
+## Maintenance
+- Update the version and change log for major changes.
+- Regularly review UFDs for accuracy and relevance.
+
+## Language
+- Professional
+- English
+- If product owner domain language is different, create a translated file with a language code suffix (e.g., `uc-xxx.userflow.da.md` for Danish).
+- Both files must be kept in the use case subfolder.

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.usecase.da.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.usecase.da.md
@@ -1,0 +1,185 @@
+# Use Case: Ensure data security and GDPR compliance (Danish)
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010 |
+| crossReference | BC<br/>REQ-DC-001<br/>REQ-R-003<br/>REQ-F-005 |
+| Title          | Ensure data security and GDPR compliance |
+| Author         | Team 6 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Use Case Description (Danish)
+
+## Brugerhistorie
+Som Admin vil jeg administrere retention-politikker, gennemgå anonymiseringskandidater, overvåge sikkerhedshændelser og besvare indsigtsanmodninger, så systemet overholder GDPR og dansk databeskyttelseslovgivning (Datatilsynet) og beskytter sårbare beboeres persondata.
+
+### Kort Use Case
+**Titel**: Sikre datasikkerhed og GDPR-overholdelse
+**Succesforløb**:
+Admin åbner GDPR Compliance-visningen og gennemgår de aktuelle retention-politikker og deres juridiske grundlag. Systemet viser anonymiseringskandidater foreslået af RetentionBackgroundService og giver Admin mulighed for at godkende eller afvise anonymisering. Systemet flagger mistænkelig aktivitet som sikkerhedshændelser via IncidentDetectionService, og Admin gennemgår, dokumenterer og eskalerer hændelser efter behov. Når en indsigtsanmodning (SAR) modtages, søger Admin efter den registrerede, genererer et eksportgrundlag for relevante persondata og registrerer afslutning; alle handlinger er adgangskontrollerede og audit-loggede.
+
+### Casual Use Case
+**Titel**: Sikre datasikkerhed og GDPR-overholdelse
+**Scope**: Slottets Drifttavlen (GDPR Compliance Layer — bygger videre på UC-007 autentificering og UC-009 audit logging)
+**Niveau**: Brugermål
+**Aktører**:
+- Admin (primary)
+- System (Slottets Drifttavlen)
+- RetentionBackgroundService (automated, suggests anonymization candidates)
+- IncidentDetectionService (automated, flags suspicious activity)
+
+**Hovedforløb**:
+1: Admin åbner GDPR Compliance-visningen.
+2: Systemet validerer Admin-adgang (REQ-F-005) og viser aktuelle retention-politikker og status.
+3: Admin gennemgår retention-politikker og opdaterer retention-perioder og juridisk grundlag, hvor det er relevant.
+4: Systemet validerer ændringerne, gemmer dem og registrerer ændringen i audit-loggen (REQ-R-003).
+5: Systemet viser anonymiseringskandidater foreslået af RetentionBackgroundService.
+6: Admin gennemgår kandidater og godkender anonymisering for egnede registreringer.
+7: Systemet udfører anonymisering, registrerer handlingen i audit-loggen og opdaterer registreringsstatus.
+8: Systemet viser sikkerhedshændelser flagget af IncidentDetectionService.
+9: Admin gennemgår hændelser, tilføjer undersøgelsesnoter og beslutter at lukke eller eskalere hændelser.
+10: Systemet registrerer hændelseshandlinger og beslutninger i audit-loggen.
+11: Admin registrerer en indsigtsanmodning (GDPR Art. 15) og søger efter den registrerede.
+12: Systemet genererer en eksport/rapport med den registreredes persondata og behandlingsoplysninger for det ønskede scope.
+13: Admin gennemgår eksporten for fuldstændighed og dataminimering og markerer derefter anmodningen som afsluttet.
+14: Systemet registrerer SAR-svar og afslutning i audit-loggen.
+
+**Hovedudvidelser**:
+1a: Admin er ikke autentificeret eller mangler Admin-rolle.
+    1: Systemet afviser adgang.
+    2: Systemet registrerer det afviste adgangsforsøg i audit-loggen.
+3a: Retention-ændring er ugyldig (fx kortere end lovpligtigt minimum for en registreringstype).
+    1: Systemet afviser ændringen og viser valideringsfeedback.
+    2: Systemet registrerer det afviste ændringsforsøg i audit-loggen.
+5a: RetentionBackgroundService er utilgængelig.
+    1: Systemet viser en advarsel og fortsætter uden kandidatforslag.
+    2: Systemet registrerer serviceproblemet til overvågning.
+6a: Kandidaten er ikke egnet (fx aktiv sag, uafsluttet audit/legal hold).
+    1: Systemet forhindrer anonymisering og forklarer hvorfor.
+8a: IncidentDetectionService rapporterer mistænkelig aktivitet.
+    1: Systemet opretter eller opdaterer en hændelse og fremhæver alvorlighed.
+    2: Admin eskalerer hændelsen i henhold til incident response-proceduren.
+12a: Eksport kan ikke genereres (fx teknisk fejl).
+    1: Systemet viser en fejl og giver mulighed for at prøve igen.
+    2: Systemet registrerer fejlen i audit-loggen.
+
+**Resumé**: Admin anvender retention- og anonymiseringsregler, overvåger hændelser og håndterer indsigtsanmodninger med sikker adgangskontrol og fuld audit logging.
+
+### Fuldt Udfoldet Use Case
+**Titel**: Sikre datasikkerhed og GDPR-overholdelse
+**Scope**: Slottets Drifttavlen (GDPR Compliance Layer — bygger videre på UC-007 autentificering og UC-009 audit logging)
+**Niveau**: Brugermål
+**Aktører**:
+- Admin (primary)
+- System (Slottets Drifttavlen)
+- RetentionBackgroundService (automated, suggests anonymization candidates)
+- IncidentDetectionService (automated, flags suspicious activity)
+
+**Relaterede Krav**:
+- [REQ-DC-001] GDPR-overholdelse og sikker håndtering af persondata.
+- [REQ-R-003] Audit-log for alle ændringer og brugerhandlinger.
+- [REQ-F-005] Adgangskontrol og login.
+- GDPR Art. 5(1)(e) — Opbevaringsbegrænsning (storage limitation).
+- GDPR Art. 15 — Ret til indsigt (Subject Access Request).
+- GDPR Art. 17 — Ret til sletning.
+- GDPR Art. 25 — Databeskyttelse gennem design og standardindstillinger.
+- GDPR Art. 30 — Fortegnelser over behandlingsaktiviteter.
+- GDPR Art. 32 — Sikkerhed i behandlingen.
+- GDPR Art. 33 — Anmeldelse af brud på persondatasikkerheden.
+- GDPR Art. 35 — Konsekvensanalyse (DPIA).
+- Autorisationsloven §22 (10 års opbevaring af medicindokumentation — dansk lovgivning).
+
+**Forudsætninger**:
+- Brugeren er autentificeret og har Admin-rolle.
+- Audit logging-infrastrukturen (UC-009) er i drift.
+- Baggrundsservices (RetentionBackgroundService, IncidentDetectionService) kører.
+- Standard retention-politikker er seeded i henhold til dansk lovgivning.
+
+**Default Retention Values**:
+
+| Data Category | Default | Legal Minimum | Configurable Range |
+|---|---|---|---|
+| Medicine Logs | 10 years | 10 years (Autorisationsloven §22) | Locked at 10 years |
+| Resident Notes | 5 years after discharge | None | 1–30 years |
+| Audit Logs | 2 years | None | 6 months – 10 years |
+| Login/Security Logs | 13 months | None | 3 months – 2 years |
+| Inactive User Accounts | 6 months after last login | None | 1–24 months |
+| Resident Anonymization Trigger | 90 days after discharge | None | 0–365 days |
+
+Note: For Medicine Logs, the system applies pseudonymization (replacing personal identifiers) rather than full anonymization, in order to preserve medicine history as required by Autorisationsloven §22 while removing personal traceability.
+
+**Hovedforløb**:
+1. Admin åbner GDPR Compliance-visningen.
+2. Systemet autoriserer anmodningen (REQ-F-005) og logger adgang i audit-loggen (REQ-R-003).
+3. Admin gennemgår aktuelle retention-politikker (pr. registreringstype) og deres retention-perioder.
+4. Admin opdaterer en eller flere retention-politikker, inkl. juridisk grundlag og ikrafttrædelsesdato når relevant.
+5. Systemet validerer ændringen mod lovpligtige minimumskrav (fx Autorisationsloven §22 for medicindokumentation) og eventuelle aktive holds.
+6. Systemet gemmer de opdaterede politikker og registrerer ændringen i audit-loggen.
+7. Systemet viser anonymiseringskandidater foreslået af RetentionBackgroundService, inkl. begrundelse (fx retention udløbet), registreringstype og seneste aktivitet.
+8. Admin gennemgår en kandidat og vælger handling (godkend anonymisering, afvis, udsæt eller påfør hold).
+9. Systemet udfører den valgte handling, opdaterer kandidatstatus og registrerer handlingen i audit-loggen.
+10. Systemet viser åbne sikkerhedshændelser og mistænkelig aktivitet flagget af IncidentDetectionService.
+11. Admin gennemgår en hændelse, tildeler alvorlighed, tilføjer undersøgelsesnoter og vælger handling (luk, eskalér eller underret).
+12. Systemet registrerer beslutning og eventuelle underretninger i audit-loggen.
+13. Admin registrerer en indsigtsanmodning (GDPR Art. 15) med anmoderoplysninger og scope/tidsinterval.
+14. Systemet identificerer persondata og relevante behandlingsoplysninger (GDPR Art. 30) for den registrerede.
+15. Systemet genererer en SAR-eksportpakke og logger eksportgenerering.
+16. Admin gennemgår eksporten for fuldstændighed og dataminimering og markerer SAR som opfyldt.
+17. Systemet registrerer afslutning (og eventuelle undtagelser) i audit-loggen.
+
+**Udvidelser**:
+    a: På ethvert tidspunkt, hvis autorisation fejler, afviser systemet adgang og registrerer forsøget i audit-loggen.
+    b: På ethvert tidspunkt, hvis en teknisk fejl opstår, viser systemet en fejl og registrerer fejlen i audit-loggen.
+    5a: Retention-politik bryder lovpligtigt minimum eller konfigurerede begrænsninger.
+        1: Systemet afviser ændringen og forklarer den brudte begrænsning.
+        2: Admin justerer politikken og gentager trin 4.
+    7a: RetentionBackgroundService kører ikke.
+        1: Systemet viser en advarsel om service health.
+        2: Admin fortsætter med manuel gennemgang eller planlægger et nyt forsøg.
+    7b: Der findes ingen anonymiseringskandidater.
+        1: Systemet viser en besked om, at der ikke er nogen afventende kandidater, og Admin fortsætter til incident-gennemgang.
+    9a: Anonymisering kan ikke udføres pga. et aktivt legal/audit hold.
+        1: Systemet forhindrer anonymisering og registrerer årsagen.
+        2: Admin fastholder hold og lukker kandidaten.
+    11a: Hændelsens alvorlighed indikerer muligt brud på persondatasikkerheden (GDPR Art. 33).
+        1: Admin eskalerer hændelsen og følger proceduren for brudsanmeldelse.
+        2: Systemet registrerer eskalationsbeslutning og tidsstempler.
+    15a: SAR-eksport er for stor eller scope er uklart.
+        1: Admin afgrænser scope eller deler eksporten.
+        2: Systemet regenererer eksporten.
+
+**Efterbetingelser**:
+- Retention-politikker er anvendt; ændringer og adgang er registreret i audit-loggen (REQ-R-003).
+- Anonymiseringskandidater er gennemgået, og handlinger er registreret i audit-loggen.
+- Sikkerhedshændelser er overvåget, triageret og registreret med sporbarhed.
+- Indsigtsanmodninger er håndteret med et auditerbart spor af hvad der er eksporteret og hvornår.
+
+## Vedligeholdelse
+- Opdater version og ændringslog ved større ændringer.
+- Gennemgå regelmæssigt use cases for nøjagtighed og relevans.
+- Gennemgå og godkend use cases med relevante interessenter før accept.
+
+## Implementation Notes
+- Denne use case forudsætter, at autentificering og adgangskontrol håndteres af UC-007, og at alle handlinger logges i henhold til UC-009.
+- Retention-politikker bør understøtte både lovpligtige minimumskrav (fx medicindokumentation) og operationelle holds (fx igangværende undersøgelse).
+- SAR-eksport bør være adgangskontrolleret, manipulationssikker og begrænset til det ønskede scope/tidsinterval.
+
+## Terms Translation
+| English                         | Danish |
+|---------------------------------|--------|
+| Data retention policy           | Retention-politik / opbevaringspolitik |
+| Storage limitation              | Opbevaringsbegrænsning |
+| Anonymization candidate         | Anonymiseringskandidat |
+| Audit log / audit trail         | Audit-log / revisionsspor |
+| Security incident               | Sikkerhedshændelse |
+| Suspicious activity             | Mistænkelig aktivitet |
+| Subject Access Request (SAR)    | Indsigtsanmodning |
+| Personal data breach            | Brud på persondatasikkerheden |
+| Records of processing activities| Fortegnelser over behandlingsaktiviteter |
+| Data protection by design       | Databeskyttelse gennem design |
+| DPIA                            | Konsekvensanalyse (DPIA) |

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.usecase.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.usecase.md
@@ -1,0 +1,170 @@
+# Use Case: Ensure data security and GDPR compliance
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010 |
+| crossReference | BC<br/>REQ-DC-001<br/>REQ-R-003<br/>REQ-F-005 |
+| Title          | Ensure data security and GDPR compliance |
+| Author         | Team 6 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Use Case Description
+
+## User story
+As an Admin, I want to manage data retention policies, review anonymization candidates, monitor security incidents, and respond to subject access requests, so that the system complies with GDPR and Danish data protection law (Datatilsynet) and protects vulnerable residents' personal data.
+
+### Brief Use Case
+**Title**: Ensure data security and GDPR compliance
+**Success Flow**:
+The Admin opens the GDPR Compliance view and reviews the current retention policies and their legal basis. The system shows anonymization candidates suggested by RetentionBackgroundService and allows the Admin to approve or reject anonymization actions. The system flags suspicious activity as security incidents via IncidentDetectionService, and the Admin reviews, documents, and escalates incidents when needed. When a subject access request (SAR) is received, the Admin searches for the data subject, generates an export of relevant personal data, and records completion; all actions are access-controlled and audit logged.
+
+### Casual Use Case
+**Title**: Ensure data security and GDPR compliance
+**Scope**: Slottets Drifttavlen (GDPR Compliance Layer — builds on top of UC-007 authentication and UC-009 audit logging)
+**Level**: User Goal
+**Actors**:
+- Admin (primary)
+- System (Slottets Drifttavlen)
+- RetentionBackgroundService (automated, suggests anonymization candidates)
+- IncidentDetectionService (automated, flags suspicious activity)
+
+**Main Flow**:
+1: Admin opens the GDPR Compliance view.
+2: System validates Admin access (REQ-F-005) and shows current retention policies and status.
+3: Admin reviews retention policies and updates retention periods and legal basis where applicable.
+4: System validates the retention policy changes, saves them, and records the change in the audit log (REQ-R-003).
+5: System shows anonymization candidates suggested by RetentionBackgroundService.
+6: Admin reviews candidates and approves anonymization actions for eligible records.
+7: System performs anonymization, records the action in the audit log, and updates record status.
+8: System displays security incidents flagged by IncidentDetectionService.
+9: Admin reviews incidents, adds investigation notes, and decides to close or escalate incidents.
+10: System records incident actions and decisions in the audit log.
+11: Admin registers a subject access request (GDPR Art. 15) and searches for the data subject.
+12: System generates an export/report of the data subject’s personal data and processing records for the requested scope.
+13: Admin reviews the export for completeness and minimization, then marks the request as completed.
+14: System records the SAR response and completion in the audit log.
+
+**Main Extensions**:
+1a: Admin is not authenticated or lacks the Admin role.
+    1: System denies access.
+    2: System records the denied access attempt in the audit log.
+3a: Retention policy change is invalid (e.g., shorter than legal minimum for a record type).
+    1: System rejects the change and shows validation feedback.
+    2: System records the rejected change attempt in the audit log.
+5a: RetentionBackgroundService is unavailable.
+    1: System shows a warning and continues without candidate suggestions.
+    2: System records the service health issue for monitoring.
+6a: Candidate is not eligible (e.g., active case, unresolved audit/legal hold).
+    1: System prevents anonymization and explains why.
+8a: IncidentDetectionService reports suspicious activity.
+    1: System creates or updates an incident entry and highlights severity.
+    2: Admin escalates the incident according to the incident response procedure.
+12a: Export cannot be generated (e.g., technical error).
+    1: System shows an error and offers retry.
+    2: System records the failure in the audit log.
+
+**Summary**: The Admin applies retention and anonymization rules, monitors incidents, and fulfills SARs with secure access control and full audit logging.
+
+### Fully Dressed Use Case
+**Title**: Ensure data security and GDPR compliance
+**Scope**: Slottets Drifttavlen (GDPR Compliance Layer — builds on top of UC-007 authentication and UC-009 audit logging)
+**Level**: User Goal
+**Actors**:
+- Admin (primary)
+- System (Slottets Drifttavlen)
+- RetentionBackgroundService (automated, suggests anonymization candidates)
+- IncidentDetectionService (automated, flags suspicious activity)
+
+**Related Requirements**:
+- [REQ-DC-001] GDPR compliance and secure handling of personal data.
+- [REQ-R-003] Audit log for all changes and user actions.
+- [REQ-F-005] Access control and login.
+- GDPR Art. 5(1)(e) — Storage limitation.
+- GDPR Art. 15 — Right of access (Subject Access Request).
+- GDPR Art. 17 — Right to erasure.
+- GDPR Art. 25 — Data protection by design and by default.
+- GDPR Art. 30 — Records of processing activities.
+- GDPR Art. 32 — Security of processing.
+- GDPR Art. 33 — Notification of personal data breach.
+- GDPR Art. 35 — Data protection impact assessment (DPIA).
+- Autorisationsloven §22 (10-year medicine documentation retention — Danish law).
+
+**Preconditions**:
+- User is authenticated and assigned the Admin role.
+- Audit logging infrastructure (UC-009) is operational.
+- Background services (RetentionBackgroundService, IncidentDetectionService) are running.
+- Default retention policies are seeded according to Danish law.
+
+**Default Retention Values**:
+
+| Data Category | Default | Legal Minimum | Configurable Range |
+|---|---|---|---|
+| Medicine Logs | 10 years | 10 years (Autorisationsloven §22) | Locked at 10 years |
+| Resident Notes | 5 years after discharge | None | 1–30 years |
+| Audit Logs | 2 years | None | 6 months – 10 years |
+| Login/Security Logs | 13 months | None | 3 months – 2 years |
+| Inactive User Accounts | 6 months after last login | None | 1–24 months |
+| Resident Anonymization Trigger | 90 days after discharge | None | 0–365 days |
+
+Note: For Medicine Logs, the system applies pseudonymization (replacing personal identifiers) rather than full anonymization, in order to preserve medicine history as required by Autorisationsloven §22 while removing personal traceability.
+
+**Main Flow**:
+1. Admin opens the GDPR Compliance view.
+2. System authorizes the request (REQ-F-005) and logs the access in the audit log (REQ-R-003).
+3. Admin reviews current retention policies (by record type) and their configured retention periods.
+4. Admin updates one or more retention policies, including legal basis and effective date when required.
+5. System validates the change against mandatory minimums (e.g., Autorisationsloven §22 for medicine documentation) and any active holds.
+6. System saves the updated policies and records the policy change in the audit log.
+7. System displays anonymization candidates suggested by RetentionBackgroundService, including candidate reason (e.g., retention expired), record type, and last activity.
+8. Admin reviews a candidate and selects an action (approve anonymization, reject, postpone, or apply hold).
+9. System performs the selected action, updates the candidate status, and records the action in the audit log.
+10. System displays open security incidents and suspicious activities flagged by IncidentDetectionService.
+11. Admin reviews an incident, assigns severity, adds investigation notes, and selects an action (close, escalate, or notify).
+12. System records the incident decision and any notifications in the audit log.
+13. Admin registers a Subject Access Request (GDPR Art. 15) with requester details and scope/time range.
+14. System identifies personal data and relevant processing records (GDPR Art. 30) for the data subject.
+15. System generates a SAR export package and logs the export generation.
+16. Admin reviews the export for completeness and minimization, then marks the SAR as fulfilled.
+17. System records the completion (and any exceptions) in the audit log.
+
+**Extensions**:
+    a: At any time, if authorization fails, system denies access and records the attempt in the audit log.
+    b: At any time, if a technical error occurs, system shows an error and records the failure in the audit log.
+    5a: Retention policy violates legal minimum or configured constraints.
+        1: System rejects the change and explains the violated constraint.
+        2: Admin adjusts the policy and retries step 4.
+    7a: RetentionBackgroundService is not running.
+        1: System shows a service health warning.
+        2: Admin continues with manual review or schedules a retry.
+    7b: No anonymization candidates exist.
+        1: System shows a 'No pending candidates' message and the admin proceeds to incident review.
+    9a: Anonymization cannot be applied due to an active legal/audit hold.
+        1: System prevents anonymization and records the reason.
+        2: Admin applies or maintains the hold and closes the candidate.
+    11a: Incident severity indicates a potential personal data breach (GDPR Art. 33).
+        1: Admin escalates the incident and follows the breach notification procedure.
+        2: System records the escalation decision and timestamps.
+    15a: SAR export is too large or contains ambiguous scope.
+        1: Admin narrows the scope or splits the export.
+        2: System regenerates the export.
+
+**Postconditions**:
+- Retention policies are applied; changes and access are recorded in the audit log (REQ-R-003).
+- Anonymization candidates are reviewed and actions are recorded in the audit log.
+- Security incidents are monitored, triaged, and recorded with traceability.
+- Subject access requests are fulfilled with an auditable record of what was exported and when.
+
+## Maintenance
+- Update the version and change log for major changes.
+- Regularly review use cases for accuracy and relevance.
+- Review and approve use cases with relevant stakeholders before acceptance.
+
+## Implementation Notes
+- This use case assumes authentication and access control are handled by UC-007 and that all actions are captured by the audit logging approach described in UC-009.
+- Retention policies should support legal minimums (e.g., medicine documentation) and operational holds (e.g., ongoing investigation).
+- SAR exports should be access-controlled, tamper-evident, and limited to the requested scope/time range.

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.userflow.da.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.userflow.da.md
@@ -1,0 +1,71 @@
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010.UserFlow |
+| crossReference | UC-010<br/>UC-010.UC<br/>UC-010.Wireframe |
+| Title          | Ensure data security and GDPR compliance — User Flow Diagram (Danish) |
+| Author         | Team 6 |
+| Date           | 2026-05-11 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## User Flow Diagram
+Dette brugerflow viser, hvordan en Admin navigerer i GDPR Compliance Dashboard for at konfigurere retention-politikker, gennemgå anonymiseringskandidater, overvåge og håndtere sikkerhedshændelser samt behandle indsigtsanmodninger (SAR).
+
+```mermaid
+flowchart TD
+    Start([Admin opens GDPR Dashboard]) --> Auth{Admin role?}
+
+    Auth -->|Nej| Denied([Access denied])
+    Auth -->|Ja| Dashboard[GDPR Compliance Dashboard]
+
+    %% Indgange fra dashboardet
+    Dashboard -->|Konfigurér retention-politikker| Retention[Retention-indstillinger]
+    Dashboard -->|Gennemgå anonymiseringskø| Queue[Anonymiseringskø]
+    Dashboard -->|Overvåg og håndtér sikkerhedshændelser| Incidents[Sikkerhedshændelser]
+    Dashboard -->|Behandl indsigtsanmodning - SAR| Sar[Indsigtsanmodning - SAR]
+
+    %% Flow 1: Retention-indstillinger
+    Retention -->|Redigér politik + Gem| LegalMin{Lovpligtigt minimum OK?}
+    LegalMin -->|Nej| RetentionError[Vis valideringsfejl]
+    RetentionError -->|Justér politik| Retention
+    Retention -->|Annullér| Cancelled([Cancelled])
+    LegalMin -->|Ja| Success([Action complete])
+
+    %% Flow 2: Anonymiseringskø
+    Queue -->|Vælg kandidat| QueueDecision{Godkend / Afvis / Udsæt / Påfør hold?}
+    QueueDecision -->|Godkend| Execute[Udfør handling]
+    QueueDecision -->|Afvis| Execute
+    QueueDecision -->|Udsæt| Execute
+    QueueDecision -->|Påfør hold| Execute
+    Execute -->|Udført| Success
+
+    %% Flow 3: Sikkerhedshændelser
+    Incidents -->|Vælg hændelse| IncidentDecision{Luk / Eskalér / Underret brud?}
+    IncidentDecision -->|Luk| Success
+    IncidentDecision -->|Eskalér| Success
+    IncidentDecision -->|Underret brud| Art33[Udløs Art. 33-underretning]
+    Art33 -->|Sendt| Success
+
+    %% Flow 4: Indsigtsanmodning (SAR)
+    Sar -->|Indtast beboer-id + Søg| Found{Registreret fundet?}
+    Found -->|Nej| NotFound[Vis fejl]
+    NotFound -->|Prøv igen| Sar
+    Found -->|Ja| Export[Generér eksport]
+    Export -->|Gennemgå| Review[Gennemgå for dataminimering]
+    Review -->|Markér opfyldt| Success
+
+    %% Returveje
+    Success -->|Tilbage til dashboard| Dashboard
+    Success -->|Tilbage til kø| Queue
+    Cancelled -->|Tilbage til dashboard| Dashboard
+```
+
+## Notes
+- Alle handlinger går via det eksisterende autentificerings-/autorisationslag (UC-007).
+- Alle tilstandsændringer persisteres i audit-loggen via den eksisterende `AuditInterceptor` (UC-009).
+- Baggrundsservices (RetentionBackgroundService, IncidentDetectionService) leverer anonymiseringskandidater og incident-signaler; disse er bevidst ikke visualiseret som brugertrin i diagrammet.
+- Ikke visualiseret: advarsler om service health (fx service utilgængelig), "ingen afventende kandidater" samt tekniske fejl (fx fejl ved eksportgenerering med retry) — de håndteres som fejl-/statusbeskeder i UI, men er ikke udfoldet for at holde diagrammet under nodegrænsen.

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.userflow.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.userflow.md
@@ -1,0 +1,71 @@
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010.UserFlow |
+| crossReference | UC-010<br/>UC-010.UC<br/>UC-010.Wireframe |
+| Title          | Ensure data security and GDPR compliance — User Flow Diagram |
+| Author         | Team 6 |
+| Date           | 2026-05-11 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## User Flow Diagram
+This user flow shows how an Admin navigates the GDPR Compliance Dashboard to configure retention policies, review anonymization candidates, monitor and handle security incidents, and process Subject Access Requests (SAR).
+
+```mermaid
+flowchart TD
+    Start([Admin opens GDPR Dashboard]) --> Auth{Admin role?}
+
+    Auth -->|No| Denied([Access denied])
+    Auth -->|Yes| Dashboard[GDPR Compliance Dashboard]
+
+    %% Entry points from the dashboard
+    Dashboard -->|Configure retention policies| Retention[Retention Settings]
+    Dashboard -->|Review anonymization candidates queue| Queue[Anonymization Queue]
+    Dashboard -->|Monitor and handle security incidents| Incidents[Security Incidents]
+    Dashboard -->|Process Subject Access Request - SAR| Sar[Subject Access Request]
+
+    %% Flow 1: Retention Settings
+    Retention -->|Edit policy + Save| LegalMin{Legal minimum OK?}
+    LegalMin -->|No| RetentionError[Show validation error]
+    RetentionError -->|Adjust policy| Retention
+    Retention -->|Cancel| Cancelled([Cancelled])
+    LegalMin -->|Yes| Success([Action complete])
+
+    %% Flow 2: Anonymization Queue
+    Queue -->|Select candidate| QueueDecision{Approve / Reject / Postpone / Apply hold?}
+    QueueDecision -->|Approve| Execute[Execute action]
+    QueueDecision -->|Reject| Execute
+    QueueDecision -->|Postpone| Execute
+    QueueDecision -->|Apply hold| Execute
+    Execute -->|Done| Success
+
+    %% Flow 3: Security Incidents
+    Incidents -->|Select incident| IncidentDecision{Close / Escalate / Notify breach?}
+    IncidentDecision -->|Close| Success
+    IncidentDecision -->|Escalate| Success
+    IncidentDecision -->|Notify breach| Art33[Trigger Art. 33 notification]
+    Art33 -->|Sent| Success
+
+    %% Flow 4: Subject Access Request (SAR)
+    Sar -->|Enter resident identifier + Search| Found{Resident found?}
+    Found -->|No| NotFound[Show error]
+    NotFound -->|Retry| Sar
+    Found -->|Yes| Export[Generate export]
+    Export -->|Review| Review[Review for minimization]
+    Review -->|Mark fulfilled| Success
+
+    %% Return paths
+    Success -->|Back to dashboard| Dashboard
+    Success -->|Back to queue| Queue
+    Cancelled -->|Back to dashboard| Dashboard
+```
+
+## Notes
+- All actions traverse through the existing authentication/authorization layer (UC-007).
+- All state changes are persisted to the audit log via the existing `AuditInterceptor` (UC-009).
+- Background services (RetentionBackgroundService, IncidentDetectionService) supply anonymization candidates and incident signals; these are intentionally not visualized as user-facing steps in the diagram.
+- Not visualized: service-health warnings (e.g., candidate service unavailable), “no pending candidates”, and technical failures (e.g., export generation retry) — these are handled as user-facing errors/messages in the UI but are not expanded to keep the diagram under the node limit.

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.wireframe.da.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.wireframe.da.md
@@ -1,0 +1,269 @@
+# Wireframe: UC-010 Sikre datasikkerhed og GDPR-overholdelse
+
+## Metadata
+| Nøgle          | Værdi |
+|----------------|-------|
+| Id             | UC-010.Wireframe |
+| crossReference | UC-010 UC-010.UC UC-010.UserFlow |
+| Author         | Team 6 |
+| Version        | 0001 |
+| Date           | 2026-05-11 |
+
+## Versionslog
+| Version | Dato       | Beskrivelse | Forfatter |
+|---------|------------|-------------|-----------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Wireframe
+Dette wireframe dækker det Admin-beskyttede GDPR Compliance-dashboard og de fire undersider:
+Retention-indstillinger, Anonymiseringskø, Sikkerhedshændelser og Indsigtsanmodning (SAR).
+
+## Overblik — Navigationskort
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard                                      Rolle: Admin     |
++----------------------------------------------------------------------------------+
+|  [Retention-indstillinger]  [Anonymiseringskø]   [Sikkerhedshændelser]   [SAR]   |
+|                                                                                  |
+|  Note: Badges viser aktuelle antal på dashboard-tiles.                            |
++----------------------------------------------------------------------------------+
+```
+
+## Skærm 1 — GDPR Compliance Dashboard
+
+Overview layout (hvor denne skærm ligger i navigationen):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard                                      Rolle: Admin     |
++----------------------------------------------------------------------------------+
+|  Aktuel side: GDPR Compliance Dashboard                                           |
+|  Tiles navigerer til de fire undersider                                           |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Landingsside:
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard                                      Rolle: Admin     |
++----------------------------------------------------------------------------------+
+|  +----------------------+  +----------------------+  +----------------------+     |
+|  | Retention-indst.     |  | Anonymiseringskø     |  | Sikkerhedshændelser  |     |
+|  | [Åbn]                |  | Afventer: [ 12 ]     |  | Åbne:    [  3 ]      |     |
+|  +----------------------+  +----------------------+  +----------------------+     |
+|                                                                                  |
+|  +----------------------+                                                         |
+|  | Indsigtsanmodning    |  (SAR)                                                  |
+|  | [Åbn]   [Ny SAR]     |                                                         |
+|  +----------------------+                                                         |
+|                                                                                  |
+|  Statusoversigt                                                                  |
+|  Sidste retention-run:  2026-05-10 02:00                                          |
+|  Næste planlagte run:   2026-05-12 02:00                                          |
++----------------------------------------------------------------------------------+
+```
+
+## Skærm 2 — Retention-indstillinger
+
+Overview layout (fra dashboard til denne skærm):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Retention-indstillinger            Rolle: Admin   |
++----------------------------------------------------------------------------------+
+|  [Tilbage til dashboard]   Aktuel side: Retention-indstillinger                    |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Tabel med retention-politikker:
+
+```text
++----------------------------------------------------------------------------------+
+|  Retention-indstillinger                                      Rolle: Admin       |
++----------------------------------------------------------------------------------+
+|  ADVARSEL: Ændringer logges automatisk. Medicine Logs er låst til 10 år          |
+|  jf. Autorisationsloven §22.                                                     |
++----------------------------------------------------------------------------------+
+|  Politikker                                                                       |
+|  +---------------------------+------------------+--------------+----------------+ |
+|  | Datakategori              | Aktuel retention | Lovmin.      | Interval       | |
+|  +---------------------------+------------------+--------------+----------------+ |
+|  | Medicine Logs             | 10 år (låst)     | 10 år        | låst           | |
+|  |                           |                  |              |        [Gem]   | |
+|  | Resident Notes            | [ 5 år         ] | ingen        | 1–30 år        | |
+|  |                           |                  |              |        [Gem]   | |
+|  | Audit Logs                | [ 2 år         ] | ingen        | 6m–10y         | |
+|  |                           |                  |              |        [Gem]   | |
+|  | Login/Security Logs       | [ 13 mdr       ] | ingen        | 3m–2y          | |
+|  |                           |                  |              |        [Gem]   | |
+|  | Inactive User Accounts    | [ 6 mdr        ] | ingen        | 1–24m          | |
+|  |                           |                  |              |        [Gem]   | |
+|  | Resident Anonym. Trigger  | [ 90 dage      ] | ingen        | 0–365d         | |
+|  |                           |                  |              |        [Gem]   | |
+|  +---------------------------+------------------+--------------+----------------+ |
+|                                                                                  |
+|  [Se politik-historik]  (åbner audit-log filtreret for denne entitetstype)       |
+|  [Tilbage til dashboard]                                                        |
++----------------------------------------------------------------------------------+
+```
+
+## Skærm 3 — Anonymiseringskø
+
+Overview layout (fra dashboard til denne skærm):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Anonymiseringskø                  Rolle: Admin    |
++----------------------------------------------------------------------------------+
+|  [Tilbage til dashboard]   Aktuel side: Anonymiseringskø                         |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Kø-tabel + handlinger:
+
+```text
++----------------------------------------------------------------------------------+
+|  Anonymiseringskø                                          Rolle: Admin         |
++----------------------------------------------------------------------------------+
+|  Filter:  [Alle kategorier ▼]                                                   |
+|                                                                                  |
+|  Kandidater                                                                       |
+|  +----------+------------------+----------------+--------------+----------------+ |
+|  | Beboer   | Kategori         | Begrundelse    | Senest aktiv | Handlinger     | |
+|  +----------+------------------+----------------+--------------+----------------+ |
+|  | AB       | Resident Notes   | Retention udl. | 2026-03-01   | [Godkend]      | |
+|  |          |                  |                |              | [Afvis]        | |
+|  |          |                  |                |              | [Udsæt]        | |
+|  |          |                  |                |              | [Påfør hold]   | |
+|  +----------+------------------+----------------+--------------+----------------+ |
+|                                                                                  |
+|  Tom tilstand (når ingen rækker):                                                |
+|  "Ingen afventende kandidater"                                                   |
+|                                                                                  |
+|  [Tilbage til dashboard]                                                        |
++----------------------------------------------------------------------------------+
+```
+
+Modal preview — Bekræft anonymisering:
+
+```text
++--------------------------------------------------------------+
+|  Bekræft handling                                             |
++--------------------------------------------------------------+
+|  Anonymisér beboer AB?                                        |
+|                                                              |
+|  Denne handling logges og kan ikke fortrydes for felter        |
+|  uden for Medicine Logs.                                      |
+|                                                              |
+|  [Bekræft]  [Annullér]                                        |
++--------------------------------------------------------------+
+```
+
+## Skærm 4 — Sikkerhedshændelser
+
+Overview layout (fra dashboard til denne skærm):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Sikkerhedshændelser              Rolle: Admin     |
++----------------------------------------------------------------------------------+
+|  [Tilbage til dashboard]   Aktuel side: Sikkerhedshændelser                      |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Liste + detaljepanel:
+
+```text
++----------------------------------------------------------------------------------+
+|  Sikkerhedshændelser                                      Rolle: Admin           |
++----------------------------------------------------------------------------------+
+|  Filtre:  [Alvorlighed ▼]  [Status ▼]  [Datointerval: ________ til ________]     |
+|                                                                                  |
+|  Hændelser                                                                        |
+|  +------+------------+------------------+----------+----------+---------+         |
+|  | ID   | Registreret| Type             | Alvorl.  | Status   | [Vis]   |         |
+|  +------+------------+------------------+----------+----------+---------+         |
+|  | INC1 | 2026-05-10 | Mistænkelig login| Høj      | Åben     | [Vis]   |         |
+|  +------+------------+------------------+----------+----------+---------+         |
+|                                                                                  |
+|  Valgt hændelse (detaljer)                                                       |
+|  ID: INC1      Registreret: 2026-05-10   Type: Mistænkelig login                 |
+|  Alvorlighed: Høj      Status: Åben                                            |
+|                                                                                  |
+|  Undersøgelsesnoter:                                                             |
+|  [                                                                            ]  |
+|  [                                                                            ]  |
+|  [                                                                            ]  |
+|                                                                                  |
+|  Handlinger:  [Luk]  [Eskalér]  [Underret brud (Art. 33)]                        |
+|                                                                                  |
+|  [Tilbage til dashboard]                                                        |
++----------------------------------------------------------------------------------+
+```
+
+Modal preview — Underret brud (Art. 33):
+
+```text
++--------------------------------------------------------------+
+|  Underret brud (Art. 33)                                     |
++--------------------------------------------------------------+
+|  Hændelse:    INC1                                           |
+|  Tidsstempel: 2026-05-11 10:30                                |
+|  Modtager:    dpo@slottet.local                               |
+|                                                              |
+|  [Bekræft underretning]  [Annullér]                            |
++--------------------------------------------------------------+
+```
+
+## Skærm 5 — Indsigtsanmodning (SAR)
+
+Overview layout (fra dashboard til denne skærm):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Indsigtsanmodning (SAR)           Rolle: Admin    |
++----------------------------------------------------------------------------------+
+|  [Tilbage til dashboard]   Aktuel side: Indsigtsanmodning (SAR)                   |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Søgning + eksport + afslutning:
+
+```text
++----------------------------------------------------------------------------------+
+|  Indsigtsanmodning (SAR)                                Rolle: Admin            |
++----------------------------------------------------------------------------------+
+|  Søg beboer                                                                       |
+|  Beboer-id:  [______________]   [Søg]                                             |
+|                                                                                  |
+|  Søgeresultat                                                                     |
+|  Beboer: AB (kun initialer)      Registreringsdato: 2024-01-12                    |
+|                                                                                  |
+|  Eksportvalg                                                                      |
+|  [✓] Resident Notes                                                               |
+|  [✓] Medicine Logs                                                                |
+|  [✓] Audit-log / revisionsspor                                                    |
+|  [✓] Telefon-tildelinger                                                          |
+|                                                                                  |
+|  [Generér eksport]  Fremdrift: [##########------]  60%                             |
+|                                                                                  |
+|  Downloads                                                                        |
+|  [Download .json]   [Download .pdf]                                               |
+|                                                                                  |
+|  Gennemgang + afslutning                                                          |
+|  [Markér som opfyldt]                                                             |
+|                                                                                  |
+|  [Tilbage til dashboard]                                                        |
++----------------------------------------------------------------------------------+
+```
+
+## Notes
+- Alle sider er kun for Admin og beskyttet af eksisterende UC-007 autentificering.
+- Alle handlinger, der ændrer tilstand, registreres via eksisterende UC-009 AuditInterceptor.
+- Beboer-id vises kun som initialer (REQ-DC-001 / GDPR dataminimering).
+- Anonymiseringskøen udfyldes asynkront af RetentionBackgroundService (ikke bruger-drevet).
+- Sikkerhedshændelser udfyldes asynkront af IncidentDetectionService.
+- Bekræftelsesmodaler kræves for destruktive handlinger (anonymisering, brud-underretning).
+- SAR-eksporter skal gennemgås før udlevering for at sikre dataminimering jf. GDPR Art. 12(3).

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.wireframe.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.wireframe.md
@@ -1,0 +1,269 @@
+# Wireframe: UC-010 Ensure data security and GDPR compliance
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010.Wireframe |
+| crossReference | UC-010 UC-010.UC UC-010.UserFlow |
+| Author         | Team 6 |
+| Version        | 0001 |
+| Date           | 2026-05-11 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Wireframe
+This wireframe covers the Admin-only GDPR Compliance Dashboard and its four sub-pages: Retention Settings,
+Anonymization Queue, Security Incidents, and Subject Access Request (SAR).
+
+## Overview — Navigation Map
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard                                      Role: Admin      |
++----------------------------------------------------------------------------------+
+|  [Retention Settings]   [Anonymization Queue]   [Security Incidents]   [SAR]     |
+|                                                                                  |
+|  Notes: Badges show current counts on the dashboard tiles.                        |
++----------------------------------------------------------------------------------+
+```
+
+## Screen 1 — GDPR Compliance Dashboard
+
+Overview layout (where this screen sits in navigation):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard                                      Role: Admin      |
++----------------------------------------------------------------------------------+
+|  Current page: GDPR Compliance Dashboard                                          |
+|  Tiles navigate to the four sub-pages                                             |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Landing page:
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard                                      Role: Admin      |
++----------------------------------------------------------------------------------+
+|  +----------------------+  +----------------------+  +----------------------+     |
+|  | Retention Settings   |  | Anonymization Queue  |  | Security Incidents   |     |
+|  | [Open]               |  | Pending:  [ 12 ]     |  | Open:     [  3 ]     |     |
+|  +----------------------+  +----------------------+  +----------------------+     |
+|                                                                                  |
+|  +----------------------+                                                         |
+|  | Subject Access Req.  |  (SAR)                                                  |
+|  | [Open]     [New SAR] |                                                         |
+|  +----------------------+                                                         |
+|                                                                                  |
+|  Status summary                                                                   |
+|  Last retention run:  2026-05-10 02:00                                            |
+|  Next scheduled run:  2026-05-12 02:00                                            |
++----------------------------------------------------------------------------------+
+```
+
+## Screen 2 — Retention Settings
+
+Overview layout (from dashboard to this screen):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Retention Settings                 Role: Admin    |
++----------------------------------------------------------------------------------+
+|  [Back to Dashboard]   Current page: Retention Settings                             |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Retention policies table:
+
+```text
++----------------------------------------------------------------------------------+
+|  Retention Settings                                            Role: Admin       |
++----------------------------------------------------------------------------------+
+|  WARNING: Changes are logged automatically. Medicine Logs are locked at 10 years |
+|  per Autorisationsloven §22.                                                      |
++----------------------------------------------------------------------------------+
+|  Policies                                                                         |
+|  +---------------------------+------------------+--------------+----------------+ |
+|  | Data Category             | Current Retention| Legal Minimum| Range          | |
+|  +---------------------------+------------------+--------------+----------------+ |
+|  | Medicine Logs             | 10 years (locked)| 10 years     | locked         | |
+|  |                           |                  |              |        [Save]  | |
+|  | Resident Notes            | [ 5 years      ] | none         | 1–30 years     | |
+|  |                           |                  |              |        [Save]  | |
+|  | Audit Logs                | [ 2 years      ] | none         | 6m–10y         | |
+|  |                           |                  |              |        [Save]  | |
+|  | Login/Security Logs       | [ 13 months    ] | none         | 3m–2y          | |
+|  |                           |                  |              |        [Save]  | |
+|  | Inactive User Accounts    | [ 6 months     ] | none         | 1–24m          | |
+|  |                           |                  |              |        [Save]  | |
+|  | Resident Anonym. Trigger  | [ 90 days      ] | none         | 0–365d         | |
+|  |                           |                  |              |        [Save]  | |
+|  +---------------------------+------------------+--------------+----------------+ |
+|                                                                                  |
+|  [View Policy History]  (opens audit log filtered for retention policy changes)  |
+|  [Back to Dashboard]                                                             |
++----------------------------------------------------------------------------------+
+```
+
+## Screen 3 — Anonymization Queue
+
+Overview layout (from dashboard to this screen):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Anonymization Queue               Role: Admin     |
++----------------------------------------------------------------------------------+
+|  [Back to Dashboard]   Current page: Anonymization Queue                           |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Queue table + actions:
+
+```text
++----------------------------------------------------------------------------------+
+|  Anonymization Queue                                         Role: Admin         |
++----------------------------------------------------------------------------------+
+|  Filter:  [All categories ▼]                                                      |
+|                                                                                  |
+|  Candidates                                                                       |
+|  +----------+------------------+----------------+--------------+----------------+ |
+|  | Resident | Category         | Reason         | Last Activity| Actions        | |
+|  +----------+------------------+----------------+--------------+----------------+ |
+|  | AB       | Resident Notes   | Retention exp. | 2026-03-01   | [Approve]      | |
+|  |          |                  |                |              | [Reject]       | |
+|  |          |                  |                |              | [Postpone]     | |
+|  |          |                  |                |              | [Apply Hold]   | |
+|  +----------+------------------+----------------+--------------+----------------+ |
+|                                                                                  |
+|  Empty state (when no rows):                                                     |
+|  "No pending candidates"                                                         |
+|                                                                                  |
+|  [Back to Dashboard]                                                             |
++----------------------------------------------------------------------------------+
+```
+
+Modal preview — Confirm anonymization:
+
+```text
++--------------------------------------------------------------+
+|  Confirm action                                               |
++--------------------------------------------------------------+
+|  Anonymize resident AB?                                       |
+|                                                              |
+|  This action is logged and cannot be undone for fields        |
+|  outside Medicine Logs.                                       |
+|                                                              |
+|  [Confirm]  [Cancel]                                          |
++--------------------------------------------------------------+
+```
+
+## Screen 4 — Security Incidents
+
+Overview layout (from dashboard to this screen):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Security Incidents               Role: Admin      |
++----------------------------------------------------------------------------------+
+|  [Back to Dashboard]   Current page: Security Incidents                           |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — List + detail panel:
+
+```text
++----------------------------------------------------------------------------------+
+|  Security Incidents                                         Role: Admin          |
++----------------------------------------------------------------------------------+
+|  Filters:  [Severity ▼]  [Status ▼]  [Date range: ________ to ________]          |
+|                                                                                  |
+|  Incidents                                                                        |
+|  +------+------------+------------------+----------+----------+---------+         |
+|  | ID   | Detected   | Type             | Severity | Status   | [View]  |         |
+|  +------+------------+------------------+----------+----------+---------+         |
+|  | INC1 | 2026-05-10 | Suspicious login | High     | Open     | [View]  |         |
+|  +------+------------+------------------+----------+----------+---------+         |
+|                                                                                  |
+|  Selected incident (detail)                                                      |
+|  ID: INC1      Detected: 2026-05-10     Type: Suspicious login                   |
+|  Severity: High      Status: Open                                              |
+|                                                                                  |
+|  Investigation notes:                                                            |
+|  [                                                                            ]  |
+|  [                                                                            ]  |
+|  [                                                                            ]  |
+|                                                                                  |
+|  Actions:  [Close]  [Escalate]  [Notify Breach (Art. 33)]                        |
+|                                                                                  |
+|  [Back to Dashboard]                                                             |
++----------------------------------------------------------------------------------+
+```
+
+Modal preview — Notify breach (Art. 33):
+
+```text
++--------------------------------------------------------------+
+|  Notify breach (Art. 33)                                     |
++--------------------------------------------------------------+
+|  Incident:   INC1                                            |
+|  Timestamp:  2026-05-11 10:30                                 |
+|  Recipient:  dpo@slottet.local                                |
+|                                                              |
+|  [Confirm notification]  [Cancel]                             |
++--------------------------------------------------------------+
+```
+
+## Screen 5 — Subject Access Request (SAR)
+
+Overview layout (from dashboard to this screen):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Subject Access Request (SAR)     Role: Admin      |
++----------------------------------------------------------------------------------+
+|  [Back to Dashboard]   Current page: Subject Access Request (SAR)                  |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Search + export + fulfillment:
+
+```text
++----------------------------------------------------------------------------------+
+|  Subject Access Request (SAR)                               Role: Admin          |
++----------------------------------------------------------------------------------+
+|  Search resident                                                                   |
+|  Resident identifier:  [______________]   [Search]                                 |
+|                                                                                  |
+|  Search result                                                                    |
+|  Resident: AB (initials only)      Registration date: 2024-01-12                  |
+|                                                                                  |
+|  Export options                                                                    |
+|  [✓] Resident Notes                                                               |
+|  [✓] Medicine Logs                                                                |
+|  [✓] Audit Trail                                                                  |
+|  [✓] Phone Assignments                                                            |
+|                                                                                  |
+|  [Generate Export]   Progress:  [##########------]  60%                            |
+|                                                                                  |
+|  Downloads                                                                        |
+|  [Download .json]   [Download .pdf]                                               |
+|                                                                                  |
+|  Review + completion                                                              |
+|  [Mark as Fulfilled]                                                              |
+|                                                                                  |
+|  [Back to Dashboard]                                                             |
++----------------------------------------------------------------------------------+
+```
+
+## Notes
+- All pages are Admin-only and protected by existing UC-007 authentication.
+- All state-changing actions are recorded via existing UC-009 AuditInterceptor.
+- Resident identifiers shown as initials only (REQ-DC-001 / GDPR data minimization).
+- The Anonymization Queue is populated asynchronously by RetentionBackgroundService (not user-driven).
+- Security Incidents are populated asynchronously by IncidentDetectionService.
+- Confirmation modals are required for destructive actions (anonymization, breach notification).
+- SAR exports must be reviewed before delivery to ensure data minimization per GDPR Art. 12(3).


### PR DESCRIPTION
## Summary
ASCII wireframes for the 5 admin-only screens that implement UC-010.

## Screens covered
1. **GDPR Compliance Dashboard** — navigation hub with counter badges
2. **Retention Settings** — 6 data categories with locked legal minimums
3. **Anonymization Queue** — candidate review with confirmation modal
4. **Security Incidents** — list + detail panel + Art. 33 breach notification modal
5. **Subject Access Request** — export workflow with progress and review

## Design decisions
- All screens show resident initials only (REQ-DC-001 / data minimization)
- Confirmation modals required for destructive actions (anonymization, breach notification)
- Empty states explicitly documented
- Breadcrumb navigation between dashboard and sub-pages

## Glossary
- 2 new terms added: DPO (Data Protection Officer), Phone assignments

Closes #432