### PR TITLE
UC-010 code (3/5): Infrastructure — managers, repositories, migration

### DIFF
--- a/.github/agents/userflow-artifact.agent.md
+++ b/.github/agents/userflow-artifact.agent.md
@@ -1,0 +1,82 @@
+---
+description: Generates, validates, and maintains User Flow Diagram (UFD) documentation in markdown using Mermaid flowchart syntax, following strict content, structure, and naming conventions for clarity and consistency.
+name: User Flow Diagram Agent
+tools:
+  - new
+  - edit/editFiles
+  - search
+  - lookup
+references:
+  - docs/bc.md
+  - .github/instructions/userflow.instructions.md
+  - docs/quality-criteria/artifact/qc-userflow.md
+---
+
+# User Flow Diagram Agent Specification
+
+## Instruction Compliance
+This agent MUST comply with the UFD instructions in `.github/instructions/userflow.instructions.md` and quality criteria in `docs/quality-criteria/artifact/qc-userflow.md`. All UFD artifacts must:
+- Follow the provided template and quality criteria.
+- Replace all placeholders with project-specific content.
+- Use Mermaid `flowchart TD` or `flowchart LR` syntax (never `sequenceDiagram`).
+- Use correct file naming, versioning, and language handling as specified.
+- Maintain a version log and unique version identifier for each UFD.
+- Store UFD files in the centralized repository, deleting or archiving older versions as required.
+- Ensure all new terms are added to the glossary files as per instructions.
+- Validate UFDs for completeness, clarity, and template compliance.
+
+## Agent Role
+The User Flow Diagram Agent is responsible for generating, validating, and maintaining UFDs based on the requirements defined in the use cases. It creates Mermaid flowchart representations of user navigation journeys for documentation and stakeholder communication. UFDs are user-perspective artifacts and complement (but do not replace) SSDs (system perspective), SDs (object perspective), and wireframes (visual layout).
+
+## Tool Usage Requirements
+- **File Creation**: The agent MUST use the `new` tool to physically create files. Never output raw markdown to chat when file creation is requested.
+- **File Updates**: The agent MUST use `edit/editFiles` to update existing UFDs.
+- **Use Case Reading**: Before creating a UFD, the agent MUST read the corresponding `uc-<id>.usecase.md` file located at `docs/use-cases/uc-<id>/uc-<id>.usecase.md` to extract main flow steps, extensions, and actors that should be reflected in the diagram. If the file does not exist, the agent MUST stop and ask the user for the use case content rather than generating a fictional flow.
+- **Glossary Updates**: When new domain terms appear in the UFD that are not already in `docs/glossary.md`, the agent MUST use `edit/editFiles` to add them to the glossary.
+- **Path Accuracy**: Before creating a file, the agent must check if the directory (e.g., `docs/use-cases/uc-<id>/`) exists. If not, create the directory structure first.
+
+## Agent Responsibilities
+- Create UFD files using the provided template and ensure all placeholders are replaced with project-specific content.
+- Store UFD files in the centralized repository, following naming conventions and versioning rules.
+- Maintain version logs, keep only the latest version in main, and archive older versions.
+- Use Mermaid `flowchart TD` (top-down) or `flowchart LR` (left-right) syntax — never omit the direction modifier.
+- Use node conventions: `([rounded])` for start/end, `[rectangle]` for screens/actions, `{diamond}` for decisions.
+- Label arrows with user-meaningful conditions (e.g., "Approve", "Cancel", "Not authorized").
+- Use user-facing labels only: what the user sees, clicks, or decides.
+  - ✅ Allowed: `Click Save`, `Confirm action`, `Page loads`, `Show error`
+  - ❌ Forbidden: `POST /api/policy`, `SaveAsync()`, `DbContext.SaveChanges()`, `Repository.Add()`
+- System internals (API calls, DB queries, service methods) belong in SSD/SD, never in UFD.
+
+## Workflow Triggers
+- On "Generate" or "Create" UFD: use the `new` tool with the correct path and naming convention.
+- On "Update" or "Edit" UFD: use the `edit/editFiles` tool with the UFD file path and specific changes.
+
+## Agent File Naming
+Name files in lowercase, using digits for the use case number, following the pattern: `uc-<use case number>.userflow.md`.
+Save files in the use case subfolder: `docs/use-cases/uc-<id>/uc-<id>.userflow.md`.
+Increment version numbers for significant changes.
+Include today's date and author in the version log.
+Only keep the latest version in main; archive or delete older versions.
+
+## Agent Validation
+- Review UFDs for completeness, clarity, and correct use of the template.
+- Verify that all placeholders are replaced with project-specific content.
+- Verify the diagram covers all main flows and key extensions from the linked use case.
+- If the referenced use case file does not exist, the agent MUST stop and ask the user for the use case content instead of generating a fictional flow.
+
+## Agent Maintenance
+- Update the version and change log for major changes.
+- Regularly review UFDs for accuracy and relevance.
+
+## Agent Language Handling
+- Use professional English for all metadata, versioning, and the default UFD file.
+- If the product owner's domain language is different from English, the agent MUST create a second UFD file with the diagram content translated into the product owner's language.
+- The translated file must use the correct language code suffix (e.g., `.da.md` for Danish), following the pattern: `uc-<use case number>.userflow.<language code>.md`.
+- Both files must be kept in the use case subfolder.
+- All other instructions (versioning, logging, archiving) apply to both language versions.
+
+## Compliance
+- Follow `.github/instructions/userflow.instructions.md` for all UFD artifact structure, content, and template requirements.
+
+## Scope
+- This agent specification does not define quality criteria or authoring templates — refer to the relevant instructions and quality criteria files for those details.

--- a/.github/instructions/userflow.instructions.md
+++ b/.github/instructions/userflow.instructions.md
@@ -1,0 +1,69 @@
+---
+description: 'User Flow Diagram template for project documentation.'
+applyTo: 'docs/use-cases/**/uc*.userflow.md'
+references:
+  - docs/quality-criteria/artifact/qc-userflow.md
+---
+
+# User Flow Diagram Instructions (Summary)
+- Use the provided User Flow Diagram (UFD) markdown template and examples.
+- A UFD shows the user's navigation journey across screens, decision points, and end states — from the user's perspective, NOT system internals.
+- Use Mermaid `flowchart TD` (top-down) or `flowchart LR` (left-right) syntax — never omit the direction modifier, and never use `sequenceDiagram` (that is reserved for SSD/SD).
+- Before generating a UFD, verify that the corresponding `uc-<id>.usecase.md` file exists. If not, abort and request the use case content rather than generating a fictional flow.
+- Replace all placeholders with project-specific content.
+- Store UFD files in `docs/use-cases/uc-<Insert Use Case Identifier>/` as `uc-<Insert Use Case Identifier>.userflow.md`.
+- Increment version numbers for significant changes; keep only the latest version in main, archive older versions.
+- Include metadata, version log (with date, author), Mermaid diagram in markdown code block, and notes section.
+- Notes section MUST mention: dependencies on other use cases, assumptions about prior authentication/authorization, edge cases not visualized in the diagram, and references to other artifacts (e.g., wireframe, SSD).
+- Create files in English; if product owner domain language differs, create a separate file with language code suffix (e.g., uc-xxx.userflow.da.md).
+- If the UFD introduces domain terms not already in `docs/glossary.md`, add them to that file. For Danish UFDs, also add the translation to `docs/glossary.da.md`.
+- Validate UFDs for completeness, clarity, and template compliance.
+- UFDs are user navigation only — do NOT include system sequence details (use SSD), object interactions (use SD), or UI layout (use wireframe).
+- Keep diagrams under 25 nodes for readability. If the flow is more complex, split into multiple diagrams (one per main journey) within the same file.
+
+## Template (Minimal)
+
+The following shows the required structure. The Mermaid code block is shown using `~~~mermaid` fences instead of triple-backticks to keep this template renderable inside this instructions file. When creating the actual UFD file, use standard triple-backtick fences (` ```mermaid `).
+
+## Metadata
+| Key            | Value                              |
+|----------------|------------------------------------|
+| Id             | [Use case identifier].UserFlow     |
+| crossReference | [Use case identifier]<br/>[Use case identifier].UC<br/>[Use case identifier].Wireframe |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | [date]     | Initial     | [name] |
+
+## User Flow Diagram
+
+[Brief description of the user journey covered by this diagram]
+
+~~~mermaid
+flowchart TD
+    Start([User starts]) --> Auth{Authorized?}
+    Auth -->|No| Deny[Access denied]
+    Auth -->|Yes| Page1[Main page]
+    Page1 --> Decision{User choice?}
+    Decision -->|Option A| ActionA[Perform action A]
+    Decision -->|Option B| ActionB[Perform action B]
+    ActionA --> Success([Success])
+    ActionB --> Success
+    Deny --> End([End])
+    Success --> End
+~~~
+
+## Node Conventions
+- `([Rounded])` — Start/End states (entry and exit points)
+- `[Rectangle]` — Screen, page, or user action
+- `{Diamond}` — Decision point (branch based on condition or user choice)
+- Arrows labeled with `|condition|` show branching logic
+- Use clear, user-facing labels (e.g., "Click Save", "Open Settings") — not technical terms
+
+## Notes
+[Add any clarifications about the flow, dependencies on other use cases, authentication assumptions, edge cases not visualized, and references to related artifacts]
+
+## Example Reference
+For a complete reference example, see `docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.userflow.md` once available.
+

--- a/docs/glossary.da.md
+++ b/docs/glossary.da.md
@@ -17,6 +17,7 @@
 | Art. 33 notification | Art. 33-underretning | Underretning ved brud. |
 | DPO (Data Protection Officer) | Databeskyttelsesrådgiver (DPO) | Modtager ved brud-underretning. |
 | Phone assignments | Telefon-tildelinger | Valg i SAR-eksport. |
+| Pseudonymization | Pseudonymisering | Bruges for Medicine Logs pga. lovpligtige opbevaringskrav. |
 
 ## Artifact Term Change Table
 | High-Level Term | Low-Level Term | Reason/Context |

--- a/docs/glossary.da.md
+++ b/docs/glossary.da.md
@@ -1,0 +1,22 @@
+# Glossary (Danish)
+
+## Language Translation Mapping
+| English Term | Product Owner Term | Notes |
+|--------------|-------------------|-------|
+| GDPR Compliance Dashboard | GDPR Compliance-dashboard / GDPR-overholdelsesdashboard | Admin-visning for UC-010. |
+| Data retention policy | Retention-politik / opbevaringspolitik | Politik pr. registreringstype. |
+| Legal minimum retention | Lovpligtigt minimum (opbevaring) | Minimumskrav fastsat i lovgivning. |
+| Anonymization candidate | Anonymiseringskandidat | Kandidat i anonymiseringskø. |
+| Hold (legal/audit hold) | Hold (legal/audit hold) | Forhindrer anonymisering ved aktive hensyn. |
+| Security incident | Sikkerhedshændelse | Hændelse der kræver undersøgelse/triage. |
+| Personal data breach | Brud på persondatasikkerheden | Kan udløse anmeldelsespligt. |
+| Subject Access Request (SAR) | Indsigtsanmodning (SAR) | GDPR Art. 15. |
+| SAR export package | SAR-eksportpakke | Eksport/rapport til anmoder. |
+| Data minimization | Dataminimering | Gennemgang i SAR-flow. |
+| Audit log / audit trail | Audit-log / revisionsspor | Sporbarhed (UC-009). |
+| Art. 33 notification | Art. 33-underretning | Underretning ved brud. |
+
+## Artifact Term Change Table
+| High-Level Term | Low-Level Term | Reason/Context |
+|-----------------|---------------|---------------|
+| N/A | N/A | Ingen omdøbte termer registreret endnu. |

--- a/docs/glossary.da.md
+++ b/docs/glossary.da.md
@@ -15,6 +15,8 @@
 | Data minimization | Dataminimering | Gennemgang i SAR-flow. |
 | Audit log / audit trail | Audit-log / revisionsspor | Sporbarhed (UC-009). |
 | Art. 33 notification | Art. 33-underretning | Underretning ved brud. |
+| DPO (Data Protection Officer) | Databeskyttelsesrådgiver (DPO) | Modtager ved brud-underretning. |
+| Phone assignments | Telefon-tildelinger | Valg i SAR-eksport. |
 
 ## Artifact Term Change Table
 | High-Level Term | Low-Level Term | Reason/Context |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -15,6 +15,8 @@
 | Data minimization | Principle of limiting disclosed/processed personal data to what is necessary for a purpose. | Applied during SAR review. |
 | Audit log / audit trail | A tamper-evident record of user actions and state changes. | Used for traceability (UC-009). |
 | Art. 33 notification | A notification step for reporting certain personal data breaches (GDPR Art. 33). | Triggered when breach conditions apply. |
+| DPO (Data Protection Officer) | The person/role responsible for oversight of data protection compliance and breach communication. | Recipient in breach notification confirmation. |
+| Phone assignments | Information about how phones or phone responsibilities are assigned (e.g., per shift/team). | Included as an optional item in SAR exports. |
 
 ## Artifact Term Change Table
 | High-Level Term | Low-Level Term | Reason/Context |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -17,6 +17,7 @@
 | Art. 33 notification | A notification step for reporting certain personal data breaches (GDPR Art. 33). | Triggered when breach conditions apply. |
 | DPO (Data Protection Officer) | The person/role responsible for oversight of data protection compliance and breach communication. | Recipient in breach notification confirmation. |
 | Phone assignments | Information about how phones or phone responsibilities are assigned (e.g., per shift/team). | Included as an optional item in SAR exports. |
+| Pseudonymization | Replacing direct identifiers with an indirect reference so data can no longer be attributed to a specific person without additional information. | Used for Medicine Logs due to legal retention requirements. |
 
 ## Artifact Term Change Table
 | High-Level Term | Low-Level Term | Reason/Context |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,22 @@
+# Glossary
+
+## Terms
+| Term | Definition | Notes |
+|------|------------|-------|
+| GDPR Compliance Dashboard | A dedicated admin view for managing GDPR-related operational tasks. | Entry point for UC-010 user journeys. |
+| Data retention policy | Rules that define how long specific categories of data are kept and on what legal basis. | Must respect legal minimums. |
+| Legal minimum retention | A mandatory minimum retention period required by law for specific record types. | Example: medicine documentation retention in Danish law. |
+| Anonymization candidate | A record or dataset suggested for anonymization based on retention rules and status. | Reviewed and actioned by Admin. |
+| Hold (legal/audit hold) | A constraint that prevents anonymization or deletion while an investigation, audit, or legal need is active. | Used in the anonymization queue decisions. |
+| Security incident | An event indicating suspicious activity or a potential security problem requiring investigation. | Managed in the incidents view. |
+| Personal data breach | A security incident involving unauthorized access, loss, or disclosure of personal data. | May require notification obligations. |
+| Subject Access Request (SAR) | A request by a data subject to access their personal data (GDPR Art. 15). | Handled as an export workflow. |
+| SAR export package | The generated export/report containing the data subject’s personal data and related processing records. | Reviewed for minimization before fulfillment. |
+| Data minimization | Principle of limiting disclosed/processed personal data to what is necessary for a purpose. | Applied during SAR review. |
+| Audit log / audit trail | A tamper-evident record of user actions and state changes. | Used for traceability (UC-009). |
+| Art. 33 notification | A notification step for reporting certain personal data breaches (GDPR Art. 33). | Triggered when breach conditions apply. |
+
+## Artifact Term Change Table
+| High-Level Term | Low-Level Term | Reason/Context |
+|-----------------|---------------|---------------|
+| N/A | N/A | No renamed terms recorded yet. |

--- a/docs/quality-criteria/artifact/qc-userflow.md
+++ b/docs/quality-criteria/artifact/qc-userflow.md
@@ -1,55 +1,68 @@
-# Quality Criteria: User Flow
-A User Flow illustrates the path taken by a user to accomplish a specific goal within a system. 
-This document defines quality criteria and a template for documenting user flows in markdown format, using Mermaid for visual diagrams.
+# Quality Criteria: User Flow Diagram (UFD)
+A User Flow Diagram illustrates the user's navigation journey across screens, decision points, and end states for a specific use case.
+This document defines quality criteria and a template for documenting UFDs in markdown format using Mermaid flowchart syntax.
 
 ## Metadata
 | Key               | Value                             |
 |-------------------|-----------------------------------|
-| Id                | QC-USERFLOW                      |
+| Id                | QC-USERFLOW                       |
 | crossReference    |                                   |
 
 ## Version and Change Log
-| Date       | Version | Description                     | Author        |
-|------------|---------|---------------------------------|---------------|
-| 2026-02-16 | 0001    | Initial creation of the document |               |
+| Date       | Version | Description                                          | Author  |
+|------------|---------|------------------------------------------------------|---------|
+| 2026-05-11 | 0001    | Initial creation of the document                     | Team 6  |
+| 2026-05-11 | 0002    | Tightened Mermaid syntax, completeness, and size     | Team 6  |
 
-## Quality Criteria for User Flow
-When evaluating a User Flow, consider the following quality criteria:
-1. **Objective & Persona Definition**: Clearly state the specific goal (e.g., checkout) and the user persona performing the action.
-2. **Entry Points**: Identify where the user starts their journey (e.g., landing page, email link).
-3. **Step & Decision Mapping**: Outline the sequence of screens, user actions (choose/input), and decision points (yes/no). Each step and decision must be clearly labeled.
-4. **Flow Types**: Specify the type of flow (chart flow, wire flow, screen flow) and ensure the diagram matches the intended detail level.
-5. **Diagram Conventions**: Use standard shapes:
-   - **Oval**: Start/End
-   - **Rectangle**: Screen/Webpage
-   - **Diamond**: Decision point
-   - **Arrow**: Direction of flow
-6. **Clarity & Simplicity**: The flow must be easy to follow, with concise labels and logical progression. Avoid unnecessary complexity.
-7. **Completeness**: All relevant steps, decisions, and possible outcomes must be included.
-8. **Relevance**: The flow must reflect the actual user journey for the defined objective and persona.
-9. **Consistency**: The flow should be logically consistent and align with related artifacts (e.g., use cases, UI wireframes).
-10. **Visual Appeal**: The diagram should be visually organized and easy to navigate. Use Mermaid's layout features to enhance readability.
-11. **Mermaid Syntax**: The diagram must use valid Mermaid flowchart syntax.
-12. **Test & Refine**: Review the flow for bottlenecks or unnecessary steps, and iterate based on feedback.
+## Quality Criteria for User Flow Diagrams
+When evaluating a UFD, consider the following quality criteria:
+1. **Clarity and Simplicity**: The flow should be easy to follow, with clear node labels, decision points, and arrows. Avoid unnecessary complexity.
+2. **Completeness**: Every step in the use case's main flow must appear as a node. Authorization failures, validation errors, and user-facing error states must be represented. Internal/technical extensions (e.g., 'database connection lost') need NOT appear since they belong in SSD.
+3. **Correctness**: The flow must accurately reflect the use case scope and the user's actual navigation experience. It must not introduce navigation paths not covered by the use case.
+4. **Consistency**: Node conventions must be applied consistently: `([rounded])` for start/end, `[rectangle]` for screens/actions, `{diamond}` for decisions.
+5. **User Perspective**: The diagram MUST describe what the user sees, clicks, and decides — NOT what the system does internally. System internals belong in SSD/SD artifacts.
+6. **Traceability**: Each node must be traceable to a step, decision, or outcome in the use case.
+7. **Mermaid Syntax**: The diagram MUST use Mermaid `flowchart TD` or `flowchart LR` syntax. Use of `sequenceDiagram` or `flowchart` without a direction modifier is incorrect.
+8. **No Implementation Details**: UFDs are navigation only. Do not include API endpoints, database operations, service names, or technical implementation details.
+9. **Branching Logic**: Decision diamonds must have clearly labeled outgoing arrows showing the condition for each branch (e.g., `|Approved|`, `|Rejected|`).
+10. **End States**: Every path must terminate in an explicit end state (success, failure, or cancellation). No dangling nodes.
+11. **Readability**: Diagrams should contain no more than 25 nodes. Larger flows must be split into multiple diagrams within the same file, one per main user journey.
+12. **Versioning and Change Log**: Every change must be logged with a version, date, and author.
+13. **Language/Translation Compliance**: If the product owner language is not English, create a separate translated file with the correct language code suffix.
 
-## Benefits of User Flows
-- **Improved UX**: Ensures a logical, intuitive path that reduces confusion.
-- **Enhanced Collaboration**: Provides a shared, visual understanding for designers, developers, and stakeholders.
-- **Efficient Development**: Identifies potential issues early, saving time during implementation.
+## Common Anti-Patterns (Do NOT do this)
+- ❌ Including technical method names like `SaveAsync()`, `Repository.Add()`, or `POST /api/policy` as node labels.
+- ❌ Showing system-internal messages (e.g., "DbContext returns success") — those belong in SSD/SD.
+- ❌ Creating an unauthenticated entry point when the use case requires authorization.
+- ❌ Omitting error/denied paths so the diagram looks "cleaner" — these paths are required for completeness.
+- ❌ Using `flowchart` without `TD` or `LR` direction modifier — produces invalid Mermaid.
+- ❌ Mixing user actions and system processes in the same node (e.g., "User saves and system validates" should be two nodes).
 
-## Example Mermaid User Flow
-```mermaid
-flowchart TD
-    Start([Start])
-    A[Landing Page]
-    B{Decision: Login?}
-    C[Dashboard]
-    D[Checkout]
-    End([End])
-    Start --> A --> B
-    B -- Yes --> C --> D --> End
-    B -- No --> End
-```
+## Relationship to Other Artifacts
+- **UC (Use Case)**: UFD visualizes the navigation derived from the use case's main flow and extensions.
+- **Wireframe**: UFD shows the journey BETWEEN screens; Wireframe shows the layout WITHIN a screen.
+- **SSD (System Sequence Diagram)**: SSD shows system-level message exchanges; UFD shows user-level navigation. They are complementary, not redundant.
+- **SD (Sequence Diagram)**: SD shows object collaborations inside the system; UFD shows the user's path outside the system.
+- **OC (Operation Contracts)**: OC defines preconditions/postconditions per system operation; UFD does not enforce these — they are validated at the SSD/SD/OC level.
+- **DCD (Domain Class Diagram)**: DCD describes the static structure of domain classes; UFD describes the user's runtime journey through the UI.
 
-## Filename Convention
-- Name files in lowercase, using digits for version, following the pattern: `userflow.uc-yyy.xxxx.md` (e.g., `userflow.uc-001.0001.md`) where `yyy` is the use case number.
+## Authoring Patterns and Templates
+For filename conventions, templates, and authoring examples, see `.github/instructions/userflow.instructions.md`.
+
+## Validation
+- Review UFDs for completeness, clarity, and correct use of the template.
+- Verify that all placeholders are replaced with project-specific content.
+- Verify the diagram covers the main flow and key extensions from the linked use case.
+- Verify that the linked use case file (`uc-<id>.usecase.md`) exists and matches the UFD's crossReference. A UFD without a matching use case is invalid.
+- Verify Mermaid syntax renders correctly — test at https://mermaid.live/ if in doubt.
+- Verify total node count is ≤ 25; if not, split into multiple diagrams within the file.
+
+## Maintenance
+- Update the version and change log for major changes.
+- Regularly review UFDs for accuracy and relevance.
+
+## Language
+- Professional
+- English
+- If product owner domain language is different, create a translated file with a language code suffix (e.g., `uc-xxx.userflow.da.md` for Danish).
+- Both files must be kept in the use case subfolder.

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.dcd.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.dcd.md
@@ -1,0 +1,558 @@
+# Domain Class Diagram (DCD) for UC-010 Ensure data security and GDPR compliance
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010.DCD |
+| crossReference | UC-010.SD UC-010.DM UC-010.SSD UC-010.OC |
+| Author         | Team 6 |
+| Version        | 0001 |
+| Date           | 2026-05-11 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+---
+
+## DCD for Domain Layer
+
+```mermaid
+classDiagram
+  direction TB
+
+  namespace Domain.Interfaces {
+    class IEntity {
+      <<interface>>
+      +Id: Guid
+    }
+  }
+
+  namespace Domain.Enums {
+    class RetentionDataCategory {
+      <<enumeration>>
+      MedicineLogs
+      ResidentNotes
+      AuditLogs
+      LoginLogs
+      InactiveUsers
+      AnonymizationTrigger
+    }
+
+    class IncidentSeverity {
+      <<enumeration>>
+      Low
+      Medium
+      High
+      Critical
+    }
+
+    class IncidentStatus {
+      <<enumeration>>
+      Open
+      UnderInvestigation
+      Closed
+      Escalated
+      BreachNotified
+    }
+
+    class AnonymizationStatus {
+      <<enumeration>>
+      Pending
+      Approved
+      Rejected
+      Postponed
+      OnHold
+      Completed
+    }
+  }
+
+  namespace Domain.Entities {
+    class RetentionPolicy {
+      +Id: Guid
+      +Category: RetentionDataCategory
+      +RetentionPeriod: TimeSpan
+      +LegalMinimum: TimeSpan
+      +EffectiveFrom: DateTime
+    }
+
+    class RetentionPolicyAudit {
+      +Id: Guid
+      +RetentionPolicyId: Guid
+      +ChangedBy: Guid
+      +PreviousPeriod: TimeSpan
+      +NewPeriod: TimeSpan
+      +ChangedAt: DateTime
+      +Reason: string
+    }
+
+    class AnonymizationCandidate {
+      +Id: Guid
+      +ResidentId: Guid
+      +RetentionPolicyId: Guid
+      +SuggestedAt: DateTime
+      +Reason: string
+      +Status: AnonymizationStatus
+    }
+
+    class SecurityIncident {
+      +Id: Guid
+      +DetectedAt: DateTime
+      +Type: string
+      +Severity: IncidentSeverity
+      +Status: IncidentStatus
+      +InvestigationNotes: string
+      +ReportedByEmployeeId: Guid?
+      +ResolvedByEmployeeId: Guid?
+    }
+
+    class Resident {
+      <<existing>>
+    }
+
+    class Employee {
+      <<existing>>
+    }
+  }
+
+  %% Entity interface implementations
+  RetentionPolicy --|> IEntity : implements
+  RetentionPolicyAudit --|> IEntity : implements
+  AnonymizationCandidate --|> IEntity : implements
+  SecurityIncident --|> IEntity : implements
+
+  %% Relationships
+  RetentionPolicy "1" --> "0..*" RetentionPolicyAudit : changes
+  RetentionPolicyAudit "0..*" --> "1" Employee : changed_by
+
+  AnonymizationCandidate "0..*" --> "1" Resident : candidate_for
+  AnonymizationCandidate "0..*" --> "1" RetentionPolicy : driven_by
+
+  SecurityIncident "0..*" --> "0..1" Employee : reported_by
+  SecurityIncident "0..*" --> "0..1" Employee : resolved_by
+
+  %% Enum usage
+  RetentionPolicy --> RetentionDataCategory : category
+  SecurityIncident --> IncidentSeverity : severity
+  SecurityIncident --> IncidentStatus : status
+  AnonymizationCandidate --> AnonymizationStatus : status
+```
+
+---
+
+## DCD for Core Layer
+
+```mermaid
+classDiagram
+  direction TB
+
+  namespace Core.DTOs.Retention {
+    class RetentionPolicyDto {
+      +Id: Guid
+      +Category: RetentionDataCategory
+      +RetentionPeriod: TimeSpan
+      +LegalMinimum: TimeSpan
+      +EffectiveFrom: DateTime
+    }
+
+    class UpdateRetentionPolicyDto {
+      +Category: RetentionDataCategory
+      +RetentionPeriod: TimeSpan
+      +Reason: string
+    }
+
+    class RetentionPolicyAuditDto {
+      +Id: Guid
+      +RetentionPolicyId: Guid
+      +ChangedBy: Guid
+      +PreviousPeriod: TimeSpan
+      +NewPeriod: TimeSpan
+      +ChangedAt: DateTime
+      +Reason: string
+    }
+  }
+
+  namespace Core.DTOs.Anonymization {
+    class AnonymizationCandidateDto {
+      +Id: Guid
+      +ResidentId: Guid
+      +RetentionPolicyId: Guid
+      +SuggestedAt: DateTime
+      +Reason: string
+      +Status: AnonymizationStatus
+    }
+
+    class ApproveAnonymizationDto {
+      +CandidateId: Guid
+    }
+
+    class AnonymizationResultDto {
+      +CandidateId: Guid
+      +CompletedAt: DateTime
+      +Outcome: string
+    }
+  }
+
+  namespace Core.DTOs.Security {
+    class SecurityIncidentDto {
+      +Id: Guid
+      +DetectedAt: DateTime
+      +Type: string
+      +Severity: IncidentSeverity
+      +Status: IncidentStatus
+      +InvestigationNotes: string
+    }
+
+    class EscalateIncidentDto {
+      +IncidentId: Guid
+      +IsBreach: bool
+    }
+
+    class AddInvestigationNotesDto {
+      +IncidentId: Guid
+      +Notes: string
+    }
+  }
+
+  namespace Core.DTOs.Sar {
+    class SarExportRequestDto {
+      +ResidentId: Guid
+      +ScopeOptions: string[]
+    }
+
+    class SarExportPackageDto {
+      +ExportId: Guid
+      +GeneratedAt: DateTime
+      +FileName: string
+    }
+
+    class SarFulfilledDto {
+      +SarId: Guid
+      +FulfilledAt: DateTime
+    }
+  }
+
+  namespace Core.Interfaces.Repositories {
+    class IRetentionPolicyRepository {
+      <<interface>>
+      +GetAllAsync(ct: CancellationToken): Task~IEnumerable~RetentionPolicy~~
+      +GetByCategoryAsync(category: RetentionDataCategory, ct: CancellationToken): Task~RetentionPolicy?~
+      +UpdateAsync(entity: RetentionPolicy, ct: CancellationToken): Task
+    }
+
+    class IAnonymizationCandidateRepository {
+      <<interface>>
+      +GetPendingAsync(ct: CancellationToken): Task~IEnumerable~AnonymizationCandidate~~
+      +GetByIdAsync(candidateId: Guid, ct: CancellationToken): Task~AnonymizationCandidate?~
+      +UpdateAsync(entity: AnonymizationCandidate, ct: CancellationToken): Task
+    }
+
+    class ISecurityIncidentRepository {
+      <<interface>>
+      +GetOpenAsync(ct: CancellationToken): Task~IEnumerable~SecurityIncident~~
+      +GetByIdAsync(incidentId: Guid, ct: CancellationToken): Task~SecurityIncident?~
+      +UpdateAsync(entity: SecurityIncident, ct: CancellationToken): Task
+    }
+  }
+
+  namespace Core.Interfaces.Managers {
+    class IRetentionPolicyManager {
+      <<interface>>
+      +GetPoliciesAsync(ct: CancellationToken): Task~Result~IEnumerable~RetentionPolicyDto~~~
+      +UpdateRetentionPolicyAsync(dto: UpdateRetentionPolicyDto, ct: CancellationToken): Task~Result~RetentionPolicyDto~~
+    }
+
+    class IAnonymizationManager {
+      <<interface>>
+      +GetCandidatesAsync(ct: CancellationToken): Task~Result~IEnumerable~AnonymizationCandidateDto~~~
+      +ApproveAnonymizationAsync(candidateId: Guid, ct: CancellationToken): Task~Result~AnonymizationResultDto~~
+      +RejectAnonymizationAsync(candidateId: Guid, reason: string, ct: CancellationToken): Task~Result~bool~~
+    }
+
+    class ISecurityIncidentManager {
+      <<interface>>
+      +GetIncidentsAsync(ct: CancellationToken): Task~Result~IEnumerable~SecurityIncidentDto~~~
+      +EscalateIncidentAsync(incidentId: Guid, isBreach: bool, ct: CancellationToken): Task~Result~SecurityIncidentDto~~
+      +AddInvestigationNotesAsync(dto: AddInvestigationNotesDto, ct: CancellationToken): Task~Result~SecurityIncidentDto~~
+    }
+
+    class ISubjectAccessRequestManager {
+      <<interface>>
+      +GenerateExportAsync(dto: SarExportRequestDto, ct: CancellationToken): Task~Result~SarExportPackageDto~~
+      +MarkFulfilledAsync(dto: SarFulfilledDto, ct: CancellationToken): Task~Result~bool~~
+    }
+  }
+
+  namespace Core.Interfaces.Services {
+    class IRetentionPolicyService {
+      <<interface>>
+      +GetPoliciesAsync(ct: CancellationToken): Task~Result~IEnumerable~RetentionPolicyDto~~~
+      +UpdateRetentionPolicyAsync(dto: UpdateRetentionPolicyDto, ct: CancellationToken): Task~Result~RetentionPolicyDto~~
+    }
+
+    class IAnonymizationService {
+      <<interface>>
+      +GetCandidatesAsync(ct: CancellationToken): Task~Result~IEnumerable~AnonymizationCandidateDto~~~
+      +ApproveAnonymizationAsync(candidateId: Guid, ct: CancellationToken): Task~Result~AnonymizationResultDto~~
+      +RejectAnonymizationAsync(candidateId: Guid, reason: string, ct: CancellationToken): Task~Result~bool~~
+    }
+
+    class ISecurityIncidentService {
+      <<interface>>
+      +GetIncidentsAsync(ct: CancellationToken): Task~Result~IEnumerable~SecurityIncidentDto~~~
+      +EscalateIncidentAsync(incidentId: Guid, isBreach: bool, ct: CancellationToken): Task~Result~SecurityIncidentDto~~
+      +AddInvestigationNotesAsync(dto: AddInvestigationNotesDto, ct: CancellationToken): Task~Result~SecurityIncidentDto~~
+    }
+
+    class ISubjectAccessRequestService {
+      <<interface>>
+      +GenerateExportAsync(dto: SarExportRequestDto, ct: CancellationToken): Task~Result~SarExportPackageDto~~
+      +MarkFulfilledAsync(dto: SarFulfilledDto, ct: CancellationToken): Task~Result~bool~~
+    }
+
+    class IArt33NotificationService {
+      <<interface>>
+      +SendNotificationAsync(incidentId: Guid, dpoEmail: string, ct: CancellationToken): Task~Result~bool~~
+    }
+  }
+
+  namespace Core.Services {
+    class RetentionPolicyService {
+      -IRetentionPolicyManager _retentionPolicyManager
+      +GetPoliciesAsync(ct: CancellationToken): Task~Result~IEnumerable~RetentionPolicyDto~~~
+      +UpdateRetentionPolicyAsync(dto: UpdateRetentionPolicyDto, ct: CancellationToken): Task~Result~RetentionPolicyDto~~
+    }
+
+    class AnonymizationService {
+      -IAnonymizationManager _anonymizationManager
+      +GetCandidatesAsync(ct: CancellationToken): Task~Result~IEnumerable~AnonymizationCandidateDto~~~
+      +ApproveAnonymizationAsync(candidateId: Guid, ct: CancellationToken): Task~Result~AnonymizationResultDto~~
+      +RejectAnonymizationAsync(candidateId: Guid, reason: string, ct: CancellationToken): Task~Result~bool~~
+    }
+
+    class SecurityIncidentService {
+      -ISecurityIncidentManager _securityIncidentManager
+      -IArt33NotificationService _art33NotificationService
+      +GetIncidentsAsync(ct: CancellationToken): Task~Result~IEnumerable~SecurityIncidentDto~~~
+      +EscalateIncidentAsync(incidentId: Guid, isBreach: bool, ct: CancellationToken): Task~Result~SecurityIncidentDto~~
+      +AddInvestigationNotesAsync(dto: AddInvestigationNotesDto, ct: CancellationToken): Task~Result~SecurityIncidentDto~~
+    }
+
+    class SubjectAccessRequestService {
+      -ISubjectAccessRequestManager _subjectAccessRequestManager
+      +GenerateExportAsync(dto: SarExportRequestDto, ct: CancellationToken): Task~Result~SarExportPackageDto~~
+      +MarkFulfilledAsync(dto: SarFulfilledDto, ct: CancellationToken): Task~Result~bool~~
+    }
+  }
+
+  namespace Core.Mappers {
+    class RetentionPolicyMapper {
+      +ToDto(entity: RetentionPolicy): RetentionPolicyDto$
+      +ToAuditDto(entity: RetentionPolicyAudit): RetentionPolicyAuditDto$
+    }
+
+    class AnonymizationCandidateMapper {
+      +ToDto(entity: AnonymizationCandidate): AnonymizationCandidateDto$
+    }
+
+    class SecurityIncidentMapper {
+      +ToDto(entity: SecurityIncident): SecurityIncidentDto$
+    }
+
+    class SarExportMapper {
+      +ToPackageDto(exportId: Guid, generatedAt: DateTime, fileName: string): SarExportPackageDto$
+    }
+  }
+
+  %% Service implementations
+  RetentionPolicyService ..|> IRetentionPolicyService : implements
+  AnonymizationService ..|> IAnonymizationService : implements
+  SecurityIncidentService ..|> ISecurityIncidentService : implements
+  SubjectAccessRequestService ..|> ISubjectAccessRequestService : implements
+
+  %% Service dependencies (Core)
+  RetentionPolicyService --> IRetentionPolicyManager : uses
+  AnonymizationService --> IAnonymizationManager : uses
+  SecurityIncidentService --> ISecurityIncidentManager : uses
+  SecurityIncidentService --> IArt33NotificationService : uses
+  SubjectAccessRequestService --> ISubjectAccessRequestManager : uses
+
+  %% Manager return types
+  IRetentionPolicyManager --> RetentionPolicyDto : returns
+  IAnonymizationManager --> AnonymizationResultDto : returns
+  ISecurityIncidentManager --> SecurityIncidentDto : returns
+  ISubjectAccessRequestManager --> SarExportPackageDto : returns
+
+  %% Mapping
+  RetentionPolicyMapper --> RetentionPolicyDto : produces
+  RetentionPolicyMapper --> RetentionPolicyAuditDto : produces
+  RetentionPolicyMapper --> RetentionPolicy : reads
+  RetentionPolicyMapper --> RetentionPolicyAudit : reads
+
+  AnonymizationCandidateMapper --> AnonymizationCandidateDto : produces
+  AnonymizationCandidateMapper --> AnonymizationCandidate : reads
+
+  SecurityIncidentMapper --> SecurityIncidentDto : produces
+  SecurityIncidentMapper --> SecurityIncident : reads
+
+  SarExportMapper --> SarExportPackageDto : produces
+
+  %% DTOs represent domain entities
+  RetentionPolicyDto ..> Domain.Entities.RetentionPolicy : represents
+  RetentionPolicyAuditDto ..> Domain.Entities.RetentionPolicyAudit : represents
+  AnonymizationCandidateDto ..> Domain.Entities.AnonymizationCandidate : represents
+  SecurityIncidentDto ..> Domain.Entities.SecurityIncident : represents
+```
+
+---
+
+## DCD for Infrastructure Layer
+
+```mermaid
+classDiagram
+  direction TB
+
+  namespace Infrastructure.Managers {
+    class RetentionPolicyManager {
+      -HttpClient _httpClient
+      +GetPoliciesAsync(ct: CancellationToken): Task~Result~IEnumerable~RetentionPolicyDto~~~
+      +UpdateRetentionPolicyAsync(dto: UpdateRetentionPolicyDto, ct: CancellationToken): Task~Result~RetentionPolicyDto~~
+    }
+
+    class AnonymizationManager {
+      -HttpClient _httpClient
+      +GetCandidatesAsync(ct: CancellationToken): Task~Result~IEnumerable~AnonymizationCandidateDto~~~
+      +ApproveAnonymizationAsync(candidateId: Guid, ct: CancellationToken): Task~Result~AnonymizationResultDto~~
+      +RejectAnonymizationAsync(candidateId: Guid, reason: string, ct: CancellationToken): Task~Result~bool~~
+    }
+
+    class SecurityIncidentManager {
+      -HttpClient _httpClient
+      +GetIncidentsAsync(ct: CancellationToken): Task~Result~IEnumerable~SecurityIncidentDto~~~
+      +EscalateIncidentAsync(incidentId: Guid, isBreach: bool, ct: CancellationToken): Task~Result~SecurityIncidentDto~~
+      +AddInvestigationNotesAsync(dto: AddInvestigationNotesDto, ct: CancellationToken): Task~Result~SecurityIncidentDto~~
+    }
+
+    class SubjectAccessRequestManager {
+      -HttpClient _httpClient
+      +GenerateExportAsync(dto: SarExportRequestDto, ct: CancellationToken): Task~Result~SarExportPackageDto~~
+      +MarkFulfilledAsync(dto: SarFulfilledDto, ct: CancellationToken): Task~Result~bool~~
+    }
+  }
+
+  namespace Infrastructure.Services {
+    class Art33NotificationService {
+      +SendNotificationAsync(incidentId: Guid, dpoEmail: string, ct: CancellationToken): Task~Result~bool~~
+    }
+  }
+
+  namespace Infrastructure.Data.Repositories {
+    class RetentionPolicyRepository {
+      -AppDbContext _dbContext
+      +GetAllAsync(ct: CancellationToken): Task~IEnumerable~RetentionPolicy~~
+      +GetByCategoryAsync(category: RetentionDataCategory, ct: CancellationToken): Task~RetentionPolicy?~
+      +UpdateAsync(entity: RetentionPolicy, ct: CancellationToken): Task
+    }
+
+    class AnonymizationCandidateRepository {
+      -AppDbContext _dbContext
+      +GetPendingAsync(ct: CancellationToken): Task~IEnumerable~AnonymizationCandidate~~
+      +GetByIdAsync(candidateId: Guid, ct: CancellationToken): Task~AnonymizationCandidate?~
+      +UpdateAsync(entity: AnonymizationCandidate, ct: CancellationToken): Task
+    }
+
+    class SecurityIncidentRepository {
+      -AppDbContext _dbContext
+      +GetOpenAsync(ct: CancellationToken): Task~IEnumerable~SecurityIncident~~
+      +GetByIdAsync(incidentId: Guid, ct: CancellationToken): Task~SecurityIncident?~
+      +UpdateAsync(entity: SecurityIncident, ct: CancellationToken): Task
+    }
+
+    class SarExportRepository {
+      -AppDbContext _dbContext
+      +AddAsync(entity: SarExportPackage, ct: CancellationToken): Task~SarExportPackage~
+    }
+
+    class SarExportPackage {
+      <<persistent>>
+      +Id: Guid
+      +ResidentId: Guid
+      +GeneratedAt: DateTime
+      +FileName: string
+    }
+  }
+
+  %% Manager implementations
+  RetentionPolicyManager ..|> Core.Interfaces.Managers.IRetentionPolicyManager : implements
+  AnonymizationManager ..|> Core.Interfaces.Managers.IAnonymizationManager : implements
+  SecurityIncidentManager ..|> Core.Interfaces.Managers.ISecurityIncidentManager : implements
+  SubjectAccessRequestManager ..|> Core.Interfaces.Managers.ISubjectAccessRequestManager : implements
+
+  %% Service implementation
+  Art33NotificationService ..|> Core.Interfaces.Services.IArt33NotificationService : implements
+
+  %% Repository implementations
+  RetentionPolicyRepository ..|> Core.Interfaces.Repositories.IRetentionPolicyRepository : implements
+  AnonymizationCandidateRepository ..|> Core.Interfaces.Repositories.IAnonymizationCandidateRepository : implements
+  SecurityIncidentRepository ..|> Core.Interfaces.Repositories.ISecurityIncidentRepository : implements
+
+  %% Data dependencies
+  RetentionPolicyRepository --> Domain.Entities.RetentionPolicy : persists
+  AnonymizationCandidateRepository --> Domain.Entities.AnonymizationCandidate : persists
+  SecurityIncidentRepository --> Domain.Entities.SecurityIncident : persists
+  SarExportRepository --> SarExportPackage : persists
+```
+
+---
+
+## DCD for WebApi Layer
+
+```mermaid
+classDiagram
+  direction TB
+
+  namespace WebApi.Controllers {
+    class RetentionPolicyController {
+      +GetPolicies(): ActionResult~IEnumerable~RetentionPolicyDto~~
+      +UpdateRetentionPolicy(dto: UpdateRetentionPolicyDto): ActionResult~RetentionPolicyDto~
+    }
+
+    class AnonymizationController {
+      +GetCandidates(): ActionResult~IEnumerable~AnonymizationCandidateDto~~
+      +ApproveAnonymization(candidateId: Guid): ActionResult~AnonymizationResultDto~
+      +RejectAnonymization(candidateId: Guid, reason: string): ActionResult~bool~
+    }
+
+    class SecurityIncidentController {
+      +GetIncidents(): ActionResult~IEnumerable~SecurityIncidentDto~~
+      +EscalateIncident(dto: EscalateIncidentDto): ActionResult~SecurityIncidentDto~
+      +AddInvestigationNotes(dto: AddInvestigationNotesDto): ActionResult~SecurityIncidentDto~
+    }
+
+    class SubjectAccessRequestController {
+      +GenerateExport(dto: SarExportRequestDto): ActionResult~SarExportPackageDto~
+      +MarkFulfilled(dto: SarFulfilledDto): ActionResult~bool~
+    }
+  }
+
+  %% WebApi depends on Core abstractions where available
+  WebApi.Controllers.RetentionPolicyController --> Core.Interfaces.Repositories.IRetentionPolicyRepository : depends on
+  WebApi.Controllers.AnonymizationController --> Core.Interfaces.Repositories.IAnonymizationCandidateRepository : depends on
+  WebApi.Controllers.SecurityIncidentController --> Core.Interfaces.Repositories.ISecurityIncidentRepository : depends on
+  WebApi.Controllers.SecurityIncidentController --> Core.Interfaces.Services.IArt33NotificationService : uses
+
+  %% SAR export persistence shown as direct dependency (no Core repository abstraction defined for this UC)
+  WebApi.Controllers.SubjectAccessRequestController --> Infrastructure.Data.Repositories.SarExportRepository : persists via
+```
+
+---
+
+## Notes
+- The diagram is split into Domain, Core, Infrastructure, and WebApi sections to reflect Clean Architecture boundaries.
+- Core defines the service/manager/repository abstractions; Infrastructure provides the concrete implementations.
+- UC-010 cross-cutting audit logging (UC-009) is handled by `AuditInterceptor` in Infrastructure.Data; it is referenced in the UC-010 Operation Contract but not expanded here.
+- DTOs are used for all cross-layer data transfer; domain entities remain inside the Domain/Infrastructure.Data boundaries.
+
+## Language Handling
+Professional English.

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.dm.da.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.dm.da.md
@@ -1,0 +1,122 @@
+# Domain Model (DM) for UC-010 Ensure data security and GDPR compliance (Danish)
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010.DM |
+| crossReference | UC-010, UC-010.UC, UC-010.Wireframe |
+| Author         | Team 6 |
+| Version        | 0001 |
+| Date           | 2026-05-11 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Diagram
+
+```mermaid
+%% Domænemodeldiagram for UC-010 GDPR-overholdelse
+classDiagram
+    %% New GDPR-specific entities (UC-010)
+    class RetentionPolicy {
+        Category
+        RetentionPeriod
+        LegalMinimum
+        EffectiveFrom
+    }
+
+    class RetentionPolicyAudit {
+        PreviousPeriod
+        NewPeriod
+        ChangedAt
+        Reason
+    }
+
+    class AnonymizationCandidate {
+        SuggestedAt
+        Reason
+        Status
+    }
+
+    class SecurityIncident {
+        DetectedAt
+        Type
+        Severity
+        Status
+        InvestigationNotes
+    }
+
+    %% Enums
+    class RetentionDataCategory <<enumeration>> {
+        MedicineLogs
+        ResidentNotes
+        AuditLogs
+        LoginLogs
+        InactiveUsers
+        AnonymizationTrigger
+    }
+
+    class IncidentSeverity <<enumeration>> {
+        Low
+        Medium
+        High
+        Critical
+    }
+
+    class IncidentStatus <<enumeration>> {
+        Open
+        UnderInvestigation
+        Closed
+        Escalated
+        BreachNotified
+    }
+
+    %% Existing entities (referenced only; defined in other artifacts)
+    class Resident
+    class Employee
+    class AuditEntry
+
+    %% Relationships
+    RetentionPolicy "1" -- "0..*" RetentionPolicyAudit : tracks_changes_for
+    RetentionPolicyAudit "0..*" -- "1" Employee : changed_by
+
+    AnonymizationCandidate "0..*" -- "1" Resident : candidate_for
+    AnonymizationCandidate "0..*" -- "1" RetentionPolicy : driven_by
+
+    SecurityIncident "0..*" -- "0..1" Employee : reported_by
+    SecurityIncident "0..*" -- "0..1" Employee : resolved_by
+
+    RetentionPolicy --> RetentionDataCategory : has
+    SecurityIncident --> IncidentSeverity : has
+    SecurityIncident --> IncidentStatus : has
+
+    %% Audit logging (UC-009)
+    RetentionPolicy ..> AuditEntry : audited_via
+    RetentionPolicyAudit ..> AuditEntry : audited_via
+    AnonymizationCandidate ..> AuditEntry : audited_via
+    SecurityIncident ..> AuditEntry : audited_via
+```
+
+## Notes
+- Denne domænemodel udvider den løsningsoverordnede domænemodel med 4 nye GDPR-specifikke entiteter.
+- Alle tilstandsændringer på UC-010-entiteter logges automatisk via AuditInterceptor (UC-009).
+- Medicine Logs i RetentionDataCategory har et låst lovpligtigt minimum på 10 år jf. Autorisationsloven §22.
+- AnonymizationCandidate foreslås af RetentionBackgroundService (ikke oprettet af bruger); Admin godkender/afviser kun.
+- SecurityIncident oprettes af IncidentDetectionService når mønstre matcher (fejlede logins, masseeksport, adgang uden for arbejdstid).
+- Detaljerede typer, lag og metoder hører til i UC-010.DCD (Domain Class Diagram), som laves i en separat opgave.
+
+## Terms Translation
+| Original Term | Danish Translation |
+|---------------|--------------------|
+| Retention policy | Retention-politik / opbevaringspolitik |
+| Legal minimum retention | Lovpligtigt minimum (opbevaring) |
+| Anonymization candidate | Anonymiseringskandidat |
+| Security incident | Sikkerhedshændelse |
+| Personal data breach | Brud på persondatasikkerheden |
+| Subject Access Request (SAR) | Indsigtsanmodning (SAR) |
+| Audit log / audit trail | Audit-log / revisionsspor |
+| Data minimization | Dataminimering |
+| Art. 33 notification | Art. 33-underretning |
+| Data Protection Officer (DPO) | Databeskyttelsesrådgiver (DPO) |

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.dm.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.dm.md
@@ -1,0 +1,108 @@
+# Domain Model (DM) for UC-010 Ensure data security and GDPR compliance
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010.DM |
+| crossReference | UC-010, UC-010.UC, UC-010.Wireframe |
+| Author         | Team 6 |
+| Version        | 0001 |
+| Date           | 2026-05-11 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Diagram
+
+```mermaid
+%% Domain Model Diagram for UC-010 GDPR Compliance
+classDiagram
+    %% New GDPR-specific entities (UC-010)
+    class RetentionPolicy {
+        Category
+        RetentionPeriod
+        LegalMinimum
+        EffectiveFrom
+    }
+
+    class RetentionPolicyAudit {
+        PreviousPeriod
+        NewPeriod
+        ChangedAt
+        Reason
+    }
+
+    class AnonymizationCandidate {
+        SuggestedAt
+        Reason
+        Status
+    }
+
+    class SecurityIncident {
+        DetectedAt
+        Type
+        Severity
+        Status
+        InvestigationNotes
+    }
+
+    %% Enums
+    class RetentionDataCategory <<enumeration>> {
+        MedicineLogs
+        ResidentNotes
+        AuditLogs
+        LoginLogs
+        InactiveUsers
+        AnonymizationTrigger
+    }
+
+    class IncidentSeverity <<enumeration>> {
+        Low
+        Medium
+        High
+        Critical
+    }
+
+    class IncidentStatus <<enumeration>> {
+        Open
+        UnderInvestigation
+        Closed
+        Escalated
+        BreachNotified
+    }
+
+    %% Existing entities (referenced only; defined in other artifacts)
+    class Resident
+    class Employee
+    class AuditEntry
+
+    %% Relationships
+    RetentionPolicy "1" -- "0..*" RetentionPolicyAudit : tracks_changes_for
+    RetentionPolicyAudit "0..*" -- "1" Employee : changed_by
+
+    AnonymizationCandidate "0..*" -- "1" Resident : candidate_for
+    AnonymizationCandidate "0..*" -- "1" RetentionPolicy : driven_by
+
+    SecurityIncident "0..*" -- "0..1" Employee : reported_by
+    SecurityIncident "0..*" -- "0..1" Employee : resolved_by
+
+    RetentionPolicy --> RetentionDataCategory : has
+    SecurityIncident --> IncidentSeverity : has
+    SecurityIncident --> IncidentStatus : has
+
+    %% Audit logging (UC-009)
+    RetentionPolicy ..> AuditEntry : audited_via
+    RetentionPolicyAudit ..> AuditEntry : audited_via
+    AnonymizationCandidate ..> AuditEntry : audited_via
+    SecurityIncident ..> AuditEntry : audited_via
+```
+
+## Notes
+- This DM extends the solution-level domain model with 4 new GDPR-specific entities.
+- All state changes on UC-010 entities are automatically captured by the AuditInterceptor (UC-009).
+- The Medicine Logs entry in RetentionDataCategory has a locked legal minimum of 10 years per Autorisationsloven §22.
+- AnonymizationCandidate is suggested by RetentionBackgroundService (not user-created); Admin only approves/rejects.
+- SecurityIncident is created by IncidentDetectionService when patterns match (failed logins, mass exports, off-hours access).
+- Detailed types, layers, and methods belong in UC-010.DCD (Domain Class Diagram), which will be created in a separate task.

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.erd.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.erd.md
@@ -1,0 +1,95 @@
+# Entity Relationship Diagram (ERD) for UC-010 Ensure data security and GDPR compliance
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010.ERD |
+| crossReference | UC-010.DM UC-010.DCD UC-010.SSD UC-010.SD UC-010.OC |
+| Author         | Team 6 |
+| Version        | 0001 |
+| Date           | 2026-05-11 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Diagram
+```mermaid
+%% ERD for UC-010 Ensure data security and GDPR compliance
+erDiagram
+    RetentionPolicy {
+        Guid Id PK
+        int Category %% RetentionDataCategory enum stored as int
+        bigint RetentionPeriodTicks %% TimeSpan stored as ticks (bigint) in MySQL
+        bigint LegalMinimumTicks
+        DateTime EffectiveFrom
+    }
+
+    RetentionPolicyAudit {
+        Guid Id PK
+        Guid RetentionPolicyId FK
+        Guid ChangedByEmployeeId FK
+        bigint PreviousPeriodTicks
+        bigint NewPeriodTicks
+        DateTime ChangedAt
+        string Reason
+    }
+
+    AnonymizationCandidate {
+        Guid Id PK
+        Guid ResidentId FK
+        Guid RetentionPolicyId FK
+        DateTime SuggestedAt
+        string Reason
+        int Status %% AnonymizationStatus enum stored as int
+    }
+
+    SecurityIncident {
+        Guid Id PK
+        DateTime DetectedAt
+        string Type
+        int Severity %% IncidentSeverity enum stored as int
+        int Status %% IncidentStatus enum stored as int
+        string InvestigationNotes
+        Guid ReportedByEmployeeId FK NULLABLE
+        Guid ResolvedByEmployeeId FK NULLABLE
+    }
+
+    %% Existing tables (stubs for FK relationships)
+    Resident {
+        Guid Id PK
+        %% other columns omitted - see UC-001 ERD
+    }
+
+    Employee {
+        Guid Id PK
+        %% other columns omitted - see UC-007 ERD
+    }
+
+    AuditEntry {
+        Guid Id PK
+        %% other columns omitted - see UC-009 ERD
+        %% Captures all UC-010 entity changes via AuditInterceptor
+    }
+
+    %% Required relationships
+    RetentionPolicy ||--o{ RetentionPolicyAudit : "tracks changes for"
+    Employee ||--o{ RetentionPolicyAudit : "changed by"
+
+    Resident ||--o{ AnonymizationCandidate : "candidate for"
+    RetentionPolicy ||--o{ AnonymizationCandidate : "driven by"
+
+    Employee ||--o{ SecurityIncident : "reported by"
+    Employee ||--o{ SecurityIncident : "resolved by"
+```
+
+## Notes
+- PK = Primary Key, FK = Foreign Key, NULLABLE = nullable foreign key.
+- Enum fields (`RetentionPolicy.Category`, `AnonymizationCandidate.Status`, `SecurityIncident.Severity`, `SecurityIncident.Status`) are stored as `int` in MySQL (EF Core default conversion).
+- TimeSpan fields are stored as `bigint` ticks (`RetentionPeriodTicks`, `LegalMinimumTicks`, `PreviousPeriodTicks`, `NewPeriodTicks`) for cross-DB portability (MySQL has no native TimeSpan).
+- All UC-010 entity changes are auto-recorded in `AuditEntry` via `AuditInterceptor` (UC-009); no direct FK relationship is required for this UC-level ERD.
+- `SecurityIncident.ReportedByEmployeeId` and `SecurityIncident.ResolvedByEmployeeId` are nullable because incidents may be auto-detected or unresolved.
+- Existing tables (Resident, Employee, AuditEntry) are defined in their respective use-case ERDs; only their PK is shown here to support FK relationships.
+- `RetentionPolicy.Category` has a UNIQUE constraint (one policy per category).
+- Default retention values are seeded via `RetentionPolicySeed` in Infrastructure.Data (see UC-010.DCD).

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.oc.da.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.oc.da.md
@@ -1,0 +1,89 @@
+# Operationskontrakt: Sikre datasikkerhed og GDPR-overholdelse
+
+## Metadata
+| Nøgle          | Værdi |
+|----------------|-------|
+| Id             | UC-010.OC |
+| crossReference | UC-010.SSD |
+| Forfatter      | Team 6 |
+| Version        | 0001 |
+| Dato           | 2026-05-11 |
+
+## Versionslog
+| Version | Dato       | Beskrivelse | Forfatter |
+|---------|------------|-------------|-----------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Operationskontrakt
+
+### openRetentionSettings
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007).
+- **Efterbetingelser**: System viser aktuelle RetentionPolicy-værdier for alle RetentionDataCategory-kategorier. Ingen domæne-entiteter ændres.
+
+### updateRetentionPolicy
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007); der findes en RetentionPolicy for den angivne kategori; newPeriod er angivet.
+- **Efterbetingelser**: Hvis ændringen er gyldig, opdateres RetentionPolicy for kategorien, der oprettes en RetentionPolicyAudit med PreviousPeriod/NewPeriod/ChangedAt/Reason, og ændringen registreres i AuditEntry via AuditInterceptor (UC-009). Hvis kategorien er MedicineLogs, forbliver retention-perioden låst til det lovpligtige minimum (10 år jf. Autorisationsloven §22). Hvis newPeriod er under lovpligtigt minimum, opdateres politikken IKKE, og System viser en errorRetention-besked. Hvis persistering fejler, opdateres politikken IKKE, og System viser en errorRetention-besked.
+
+### openAnonymizationQueue
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007).
+- **Efterbetingelser**: System viser den aktuelle liste af afventende AnonymizationCandidate-poster. Ingen domæne-entiteter ændres.
+
+### reviewCandidate
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007); den refererede AnonymizationCandidate findes.
+- **Efterbetingelser**: System viser kandidatdetaljer (inkl. reason, status og suggested tidspunkt) for den valgte AnonymizationCandidate. Ingen domæne-entiteter ændres.
+
+### approveAnonymization
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007); den refererede AnonymizationCandidate findes og er egnet (intet aktivt legal/audit hold).
+- **Efterbetingelser**: Hvis egnet, udfører systemet dataminimeringshandlinger for kandidatens tilknyttede Resident baseret på den styrende RetentionPolicy, opdaterer AnonymizationCandidate.Status til at afspejle gennemførsel, og registrerer tilstandsændringen i AuditEntry via AuditInterceptor (UC-009). MedicineLogs håndteres kun som pseudonymization (ikke fuld anonymisering) for at bevare nødvendig historik uden direkte personhenførbarhed. Hvis et aktivt hold gælder, udføres ingen anonymisering, AnonymizationCandidate.Status fremrykkes IKKE, og System viser en errorAnonymization-besked.
+
+### rejectAnonymization
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007); den refererede AnonymizationCandidate findes.
+- **Efterbetingelser**: System registrerer afvisningen (AnonymizationCandidate.Status sættes til en afvist tilstand, og den angivne grund registreres) og registrerer tilstandsændringen i AuditEntry via AuditInterceptor (UC-009).
+
+### openSecurityIncidents
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007).
+- **Efterbetingelser**: System viser aktuelle SecurityIncident-poster (inkl. status og severity). Ingen domæne-entiteter ændres.
+
+### reviewIncident
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007); den refererede SecurityIncident findes.
+- **Efterbetingelser**: System viser hændelsesdetaljer for den valgte SecurityIncident. Ingen domæne-entiteter ændres.
+
+### addInvestigationNotes
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007); den refererede SecurityIncident findes; notes-tekst er angivet.
+- **Efterbetingelser**: SecurityIncident.InvestigationNotes opdateres (og Status kan fremrykkes til UnderInvestigation), og ændringen registreres i AuditEntry via AuditInterceptor (UC-009).
+
+### closeIncident
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007); den refererede SecurityIncident findes.
+- **Efterbetingelser**: SecurityIncident.Status sættes til Closed, og tilstandsændringen registreres i AuditEntry via AuditInterceptor (UC-009).
+
+### escalateIncident
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007); den refererede SecurityIncident findes.
+- **Efterbetingelser**: Ved standard-eskalering sættes SecurityIncident.Status til Escalated, og ændringen registreres i AuditEntry via AuditInterceptor (UC-009). Hvis eskaleringen indikerer brud på persondatasikkerheden, udløser systemet Art. 33-underretningsflowet (se triggerArt33Notification), og hændelsesstatus opdateres til BreachNotified efter vellykket underretning.
+
+### triggerArt33Notification
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007); den refererede SecurityIncident findes; hændelsen opfylder kriterier for brud-underretning; en e-mail til Databeskyttelsesrådgiver (DPO) er tilgængelig.
+- **Efterbetingelser**: System sender en Art. 33-underretning til Databeskyttelsesrådgiver (DPO), sætter SecurityIncident.Status til BreachNotified (eller tilsvarende brud-underrettet tilstand), og registrerer tilstandsændringen i AuditEntry via AuditInterceptor (UC-009).
+
+### openSarView
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007).
+- **Efterbetingelser**: System viser SAR-formularen til indtastning af beboer-id og valg af eksport-scope. Ingen domæne-entiteter ændres.
+
+### searchDataSubject
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007); residentIdentifier er angivet.
+- **Efterbetingelser**: Hvis en matchende Resident findes, viser System den registreredes oplysninger og mulige scope-valg med dataminimering (fx kun initialer). Hvis ikke fundet, viser System en errorSar-besked. Ingen domæne-entiteter ændres.
+
+### generateSarExport
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007); et gyldigt residentId er angivet; scopeOptions er valgt.
+- **Efterbetingelser**: System genererer en SAR-eksportpakke for det valgte scope og returnerer/registrerer et exportId. Eksportgenerering registreres i AuditEntry via AuditInterceptor (UC-009).
+
+### markSarFulfilled
+- **Forudsætninger**: Admin er autentificeret med Admin-rolle (UC-007); sarId er angivet og refererer til en eksisterende SAR-tracking-post.
+- **Efterbetingelser**: System registrerer SAR som opfyldt (med audit-tidsstempel) og registrerer tilstandsændringen i AuditEntry via AuditInterceptor (UC-009).
+
+### denyAccess
+- **Forudsætninger**: Admin er autentificeret, men mangler den krævede Admin-rolle, eller den aktuelle forespørgsel fejler autorisation.
+- **Efterbetingelser**: System afviser adgang og anvender ingen UC-010-tilstandsændringer. Det afviste forsøg registreres i henhold til den eksisterende audit/logging-tilgang (UC-009).
+
+### errorTechnical
+- **Forudsætninger**: En teknisk fejl opstår under behandling af en UC-010-operation.
+- **Efterbetingelser**: System viser en teknisk fejlbesked med mulighed for at prøve igen, og ingen delvise tilstandsændringer committes.

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.oc.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.oc.md
@@ -1,0 +1,89 @@
+# Operation Contract: Ensure data security and GDPR compliance
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010.OC |
+| crossReference | UC-010.SSD |
+| Author         | Team 6 |
+| Version        | 0001 |
+| Date           | 2026-05-11 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Operation Contract
+
+### openRetentionSettings
+- **Preconditions**: Admin is authenticated with Admin role (UC-007).
+- **Postconditions**: System displays current RetentionPolicy values for all RetentionDataCategory entries. No domain entities are modified.
+
+### updateRetentionPolicy
+- **Preconditions**: Admin is authenticated with Admin role (UC-007); a RetentionPolicy exists for the specified category; the requested newPeriod is provided.
+- **Postconditions**: If the change is valid, RetentionPolicy for the category is updated, a RetentionPolicyAudit entry is created capturing PreviousPeriod/NewPeriod/ChangedAt/Reason, and the change is captured in AuditEntry via AuditInterceptor (UC-009). If category is MedicineLogs, the retention period remains locked at the legal minimum (10 years per Autorisationsloven §22). If newPeriod is below the legal minimum, the policy is NOT updated and System displays an errorRetention message. If persistence fails, the policy is NOT updated and System displays an errorRetention message.
+
+### openAnonymizationQueue
+- **Preconditions**: Admin is authenticated with Admin role (UC-007).
+- **Postconditions**: System displays the current list of pending AnonymizationCandidate records. No domain entities are modified.
+
+### reviewCandidate
+- **Preconditions**: Admin is authenticated with Admin role (UC-007); the referenced AnonymizationCandidate exists.
+- **Postconditions**: System displays candidate details (including reason, status, and suggested timestamp) for the selected AnonymizationCandidate. No domain entities are modified.
+
+### approveAnonymization
+- **Preconditions**: Admin is authenticated with Admin role (UC-007); the referenced AnonymizationCandidate exists and is eligible (no active legal/audit hold).
+- **Postconditions**: If eligible, the system performs data minimization actions for the candidate’s associated Resident based on the driving RetentionPolicy, updates AnonymizationCandidate.Status to reflect completion, and captures the state change in AuditEntry via AuditInterceptor (UC-009). MedicineLogs are handled as pseudonymization only (not full anonymization) to preserve required history while removing direct personal traceability. If an active hold applies, no anonymization is performed, AnonymizationCandidate.Status is NOT progressed, and System displays an errorAnonymization message.
+
+### rejectAnonymization
+- **Preconditions**: Admin is authenticated with Admin role (UC-007); the referenced AnonymizationCandidate exists.
+- **Postconditions**: System records the rejection (AnonymizationCandidate.Status is set to a rejected state and the provided reason is recorded) and captures the state change in AuditEntry via AuditInterceptor (UC-009).
+
+### openSecurityIncidents
+- **Preconditions**: Admin is authenticated with Admin role (UC-007).
+- **Postconditions**: System displays current SecurityIncident entries (including status and severity). No domain entities are modified.
+
+### reviewIncident
+- **Preconditions**: Admin is authenticated with Admin role (UC-007); the referenced SecurityIncident exists.
+- **Postconditions**: System displays incident details for the selected SecurityIncident. No domain entities are modified.
+
+### addInvestigationNotes
+- **Preconditions**: Admin is authenticated with Admin role (UC-007); the referenced SecurityIncident exists; notes text is provided.
+- **Postconditions**: SecurityIncident.InvestigationNotes is updated (and Status may progress to UnderInvestigation) and the change is captured in AuditEntry via AuditInterceptor (UC-009).
+
+### closeIncident
+- **Preconditions**: Admin is authenticated with Admin role (UC-007); the referenced SecurityIncident exists.
+- **Postconditions**: SecurityIncident.Status is set to Closed and the state change is captured in AuditEntry via AuditInterceptor (UC-009).
+
+### escalateIncident
+- **Preconditions**: Admin is authenticated with Admin role (UC-007); the referenced SecurityIncident exists.
+- **Postconditions**: If standard escalation applies, SecurityIncident.Status is set to Escalated and the change is captured in AuditEntry via AuditInterceptor (UC-009). If the escalation indicates a personal data breach, the system triggers the Art. 33 notification flow (see triggerArt33Notification) and the incident status is updated to BreachNotified upon successful notification.
+
+### triggerArt33Notification
+- **Preconditions**: Admin is authenticated with Admin role (UC-007); the referenced SecurityIncident exists; the incident meets breach-notification criteria; a DPO email address is available.
+- **Postconditions**: System sends an Art. 33 notification to the Data Protection Officer (DPO), sets SecurityIncident.Status to BreachNotified (or equivalent breach-notified state), and captures the state change in AuditEntry via AuditInterceptor (UC-009).
+
+### openSarView
+- **Preconditions**: Admin is authenticated with Admin role (UC-007).
+- **Postconditions**: System displays the SAR form for entering a resident identifier and selecting export scope. No domain entities are modified.
+
+### searchDataSubject
+- **Preconditions**: Admin is authenticated with Admin role (UC-007); a residentIdentifier is provided.
+- **Postconditions**: If a matching Resident is found, System displays the data subject’s details and available data scope options, minimizing personal identifiers (e.g., initials only). If not found, System displays an errorSar message. No domain entities are modified.
+
+### generateSarExport
+- **Preconditions**: Admin is authenticated with Admin role (UC-007); a valid residentId is provided; scopeOptions are selected.
+- **Postconditions**: System generates a SAR export package for the specified scope and returns/records an exportId. Export generation is captured in AuditEntry via AuditInterceptor (UC-009).
+
+### markSarFulfilled
+- **Preconditions**: Admin is authenticated with Admin role (UC-007); a sarId is provided and refers to an existing SAR tracking record.
+- **Postconditions**: System records the SAR as fulfilled (with an audit timestamp) and captures the fulfillment state change in AuditEntry via AuditInterceptor (UC-009).
+
+### denyAccess
+- **Preconditions**: Admin is authenticated but lacks the required Admin role, or the current request fails authorization.
+- **Postconditions**: System denies access and does not apply any UC-010 state changes. The denied attempt is recorded according to the existing audit/logging approach (UC-009).
+
+### errorTechnical
+- **Preconditions**: A technical error occurs while processing a UC-010 operation.
+- **Postconditions**: System displays a retry-capable technical error message and no partial state changes are committed.

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.sd.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.sd.md
@@ -1,0 +1,189 @@
+# UC-010 Ensure data security and GDPR compliance Sequence Diagram
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010.SD |
+| crossReference | UC-010.SSD UC-010.OC UC-010.DM |
+| Author         | Team 6 |
+| Version        | 0001 |
+| Date           | 2026-05-11 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Sequence Diagram
+
+### Presentation Layer → Application Layer (WebUI Client → Service)
+```mermaid
+sequenceDiagram
+    actor Admin as Actor
+
+    participant GdprDashboardPage as GdprDashboardPage (WebUI)
+    participant RetentionSettingsPage as RetentionSettingsPage (WebUI)
+    participant AnonymizationQueuePage as AnonymizationQueuePage (WebUI)
+    participant SecurityIncidentsPage as SecurityIncidentsPage (WebUI)
+    participant SubjectAccessRequestPage as SubjectAccessRequestPage (WebUI)
+
+    participant IRetentionPolicyService as IRetentionPolicyService (Core interface)
+    participant IAnonymizationService as IAnonymizationService (Core interface)
+    participant ISecurityIncidentService as ISecurityIncidentService (Core interface)
+    participant ISubjectAccessRequestService as ISubjectAccessRequestService (Core interface)
+
+    participant RetentionPolicyService as RetentionPolicyService (Core)
+    participant AnonymizationService as AnonymizationService (Core)
+    participant SecurityIncidentService as SecurityIncidentService (Core)
+    participant SubjectAccessRequestService as SubjectAccessRequestService (Core)
+
+    %% Retention Policy Configuration
+    Admin->>+RetentionSettingsPage: SaveRetentionPolicy(UpdateRetentionPolicyDto)
+    RetentionSettingsPage->>+IRetentionPolicyService: UpdateRetentionPolicyAsync(UpdateRetentionPolicyDto)
+    IRetentionPolicyService->>+RetentionPolicyService: UpdateRetentionPolicyAsync(UpdateRetentionPolicyDto)
+    alt UpdateRetentionPolicyAsync success
+        RetentionPolicyService-->>-IRetentionPolicyService: Result~RetentionPolicyDto~ (Success)
+        IRetentionPolicyService-->>-RetentionSettingsPage: Result~RetentionPolicyDto~ (Success)
+        RetentionSettingsPage-->>-Admin: ShowPolicyUpdated(RetentionPolicyDto)
+    else UpdateRetentionPolicyAsync error
+        RetentionPolicyService-->>-IRetentionPolicyService: Result~RetentionPolicyDto~ (Error)
+        IRetentionPolicyService-->>-RetentionSettingsPage: Result~RetentionPolicyDto~ (Error)
+        RetentionSettingsPage-->>-Admin: ShowValidationOrPersistenceError(message)
+    end
+
+    %% Anonymization Queue
+    Admin->>+AnonymizationQueuePage: ApproveCandidate(candidateId)
+    AnonymizationQueuePage->>+IAnonymizationService: ApproveAnonymizationAsync(candidateId)
+    IAnonymizationService->>+AnonymizationService: ApproveAnonymizationAsync(candidateId)
+    alt ApproveAnonymizationAsync success
+        AnonymizationService-->>-IAnonymizationService: Result~AnonymizationResultDto~ (Success)
+        IAnonymizationService-->>-AnonymizationQueuePage: Result~AnonymizationResultDto~ (Success)
+        AnonymizationQueuePage-->>-Admin: ShowAnonymizationCompleted(AnonymizationResultDto)
+    else ApproveAnonymizationAsync error
+        AnonymizationService-->>-IAnonymizationService: Result~AnonymizationResultDto~ (Error)
+        IAnonymizationService-->>-AnonymizationQueuePage: Result~AnonymizationResultDto~ (Error)
+        AnonymizationQueuePage-->>-Admin: ShowHoldOrEligibilityError(message)
+    end
+
+    %% Security Incident Handling
+    Admin->>+SecurityIncidentsPage: EscalateIncident(incidentId, isBreach)
+    SecurityIncidentsPage->>+ISecurityIncidentService: EscalateIncidentAsync(incidentId, isBreach)
+    ISecurityIncidentService->>+SecurityIncidentService: EscalateIncidentAsync(incidentId, isBreach)
+    alt EscalateIncidentAsync success
+        SecurityIncidentService-->>-ISecurityIncidentService: Result~IncidentDto~ (Success)
+        ISecurityIncidentService-->>-SecurityIncidentsPage: Result~IncidentDto~ (Success)
+        SecurityIncidentsPage-->>-Admin: ShowIncidentEscalated(IncidentDto)
+    else EscalateIncidentAsync error
+        SecurityIncidentService-->>-ISecurityIncidentService: Result~IncidentDto~ (Error)
+        ISecurityIncidentService-->>-SecurityIncidentsPage: Result~IncidentDto~ (Error)
+        SecurityIncidentsPage-->>-Admin: ShowEscalationError(message)
+    end
+
+    %% Subject Access Request (SAR)
+    Admin->>+SubjectAccessRequestPage: GenerateExport(SarExportRequestDto)
+    SubjectAccessRequestPage->>+ISubjectAccessRequestService: GenerateExportAsync(SarExportRequestDto)
+    ISubjectAccessRequestService->>+SubjectAccessRequestService: GenerateExportAsync(SarExportRequestDto)
+    alt GenerateExportAsync success
+        SubjectAccessRequestService-->>-ISubjectAccessRequestService: Result~SarExportPackageDto~ (Success)
+        ISubjectAccessRequestService-->>-SubjectAccessRequestPage: Result~SarExportPackageDto~ (Success)
+        SubjectAccessRequestPage-->>-Admin: DownloadExport(SarExportPackageDto)
+    else GenerateExportAsync error
+        SubjectAccessRequestService-->>-ISubjectAccessRequestService: Result~SarExportPackageDto~ (Error)
+        ISubjectAccessRequestService-->>-SubjectAccessRequestPage: Result~SarExportPackageDto~ (Error)
+        SubjectAccessRequestPage-->>-Admin: ShowSarError(message)
+    end
+```
+
+### WebApi Layer → Infrastructure Layer (Data Access)
+```mermaid
+sequenceDiagram
+    %% Application Layer
+    participant RetentionPolicyService as RetentionPolicyService (Core)
+    participant AnonymizationService as AnonymizationService (Core)
+    participant SecurityIncidentService as SecurityIncidentService (Core)
+    participant SubjectAccessRequestService as SubjectAccessRequestService (Core)
+
+    %% Infrastructure Layer (HTTP manager / gateway)
+    participant RetentionPolicyManager as RetentionPolicyManager (Infrastructure)
+    participant AnonymizationManager as AnonymizationManager (Infrastructure)
+    participant SecurityIncidentManager as SecurityIncidentManager (Infrastructure)
+    participant SubjectAccessRequestManager as SubjectAccessRequestManager (Infrastructure)
+
+    %% WebApi Layer
+    participant RetentionPolicyController as RetentionPolicyController (WebApi)
+    participant AnonymizationController as AnonymizationController (WebApi)
+    participant SecurityIncidentController as SecurityIncidentController (WebApi)
+    participant SubjectAccessRequestController as SubjectAccessRequestController (WebApi)
+
+    %% Infrastructure.Data Layer
+    participant RetentionPolicyRepository as RetentionPolicyRepository (Infrastructure.Data)
+    participant AnonymizationCandidateRepository as AnonymizationCandidateRepository (Infrastructure.Data)
+    participant SecurityIncidentRepository as SecurityIncidentRepository (Infrastructure.Data)
+    participant SarExportRepository as SarExportRepository (Infrastructure.Data)
+
+    %% Update retention policy
+    RetentionPolicyService->>+RetentionPolicyManager: UpdateRetentionPolicyAsync(UpdateRetentionPolicyDto)
+    RetentionPolicyManager->>+RetentionPolicyController: PUT /api/gdpr/retention (UpdateRetentionPolicyDto)
+    RetentionPolicyController->>+RetentionPolicyRepository: UpdateAsync(RetentionPolicy)
+    alt updateRetentionPolicy success
+        RetentionPolicyRepository-->>-RetentionPolicyController: RetentionPolicy
+        RetentionPolicyController-->>-RetentionPolicyManager: 200 OK (RetentionPolicyDto)
+        RetentionPolicyManager-->>-RetentionPolicyService: Result~RetentionPolicyDto~ (Success)
+    else updateRetentionPolicy error
+        RetentionPolicyRepository-->>-RetentionPolicyController: error
+        RetentionPolicyController-->>-RetentionPolicyManager: 400/409/500 (ProblemDetails)
+        RetentionPolicyManager-->>-RetentionPolicyService: Result~RetentionPolicyDto~ (Error)
+    end
+
+    %% Approve anonymization
+    AnonymizationService->>+AnonymizationManager: ApproveAnonymizationAsync(candidateId)
+    AnonymizationManager->>+AnonymizationController: POST /api/gdpr/anonymization/{candidateId}/approve
+    AnonymizationController->>+AnonymizationCandidateRepository: GetByIdAsync(candidateId)
+    alt approveAnonymization success
+        AnonymizationCandidateRepository-->>AnonymizationController: AnonymizationCandidate
+        AnonymizationController->>+AnonymizationCandidateRepository: UpdateAsync(AnonymizationCandidate)
+        AnonymizationCandidateRepository-->>-AnonymizationController: void
+        AnonymizationController-->>-AnonymizationManager: 200 OK (AnonymizationResultDto)
+        AnonymizationManager-->>-AnonymizationService: Result~AnonymizationResultDto~ (Success)
+    else approveAnonymization error
+        AnonymizationCandidateRepository-->>-AnonymizationController: error
+        AnonymizationController-->>-AnonymizationManager: 409/500 (ProblemDetails)
+        AnonymizationManager-->>-AnonymizationService: Result~AnonymizationResultDto~ (Error)
+    end
+
+    %% Escalate incident
+    SecurityIncidentService->>+SecurityIncidentManager: EscalateIncidentAsync(incidentId, isBreach)
+    SecurityIncidentManager->>+SecurityIncidentController: POST /api/security/incidents/{incidentId}/escalate (isBreach)
+    SecurityIncidentController->>+SecurityIncidentRepository: GetByIdAsync(incidentId)
+    alt escalateIncident success
+        SecurityIncidentRepository-->>SecurityIncidentController: SecurityIncident
+        SecurityIncidentController->>+SecurityIncidentRepository: UpdateAsync(SecurityIncident)
+        SecurityIncidentRepository-->>-SecurityIncidentController: void
+        SecurityIncidentController-->>-SecurityIncidentManager: 200 OK (IncidentDto)
+        SecurityIncidentManager-->>-SecurityIncidentService: Result~IncidentDto~ (Success)
+    else escalateIncident error
+        SecurityIncidentRepository-->>-SecurityIncidentController: error
+        SecurityIncidentController-->>-SecurityIncidentManager: 400/404/500 (ProblemDetails)
+        SecurityIncidentManager-->>-SecurityIncidentService: Result~IncidentDto~ (Error)
+    end
+
+    %% Generate SAR export
+    SubjectAccessRequestService->>+SubjectAccessRequestManager: GenerateExportAsync(SarExportRequestDto)
+    SubjectAccessRequestManager->>+SubjectAccessRequestController: POST /api/gdpr/sar/export (SarExportRequestDto)
+    SubjectAccessRequestController->>+SarExportRepository: AddAsync(SarExportPackage)
+    alt generateSarExport success
+        SarExportRepository-->>-SubjectAccessRequestController: SarExportPackage
+        SubjectAccessRequestController-->>-SubjectAccessRequestManager: 201 Created (SarExportPackageDto)
+        SubjectAccessRequestManager-->>-SubjectAccessRequestService: Result~SarExportPackageDto~ (Success)
+    else generateSarExport error
+        SarExportRepository-->>-SubjectAccessRequestController: error
+        SubjectAccessRequestController-->>-SubjectAccessRequestManager: 400/500 (ProblemDetails)
+        SubjectAccessRequestManager-->>-SubjectAccessRequestService: Result~SarExportPackageDto~ (Error)
+    end
+```
+
+## Notes
+- WebUI pages (Blazor) only call Core service interfaces, never managers/controllers directly.
+- Each Core service delegates HTTP communication to an Infrastructure *Manager* (gateway) to keep Infrastructure dependencies out of Core.
+- WebApi controllers perform data access through repositories in Infrastructure.Data.
+- DTOs are used for cross-layer data transfer (e.g., `UpdateRetentionPolicyDto`, `SarExportRequestDto`); domain entities are not exposed outside Infrastructure.Data.

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.ssd.da.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.ssd.da.md
@@ -1,0 +1,113 @@
+# System Sequence Diagram for Use Case UC-010: Ensure data security and GDPR compliance (Danish)
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010.SSD |
+| crossReference | UC-010 UC-010.DM UC-010.UC |
+| Author         | Team 6 |
+| Version        | 0001 |
+| Date           | 2026-05-11 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## System Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant System
+
+    %% Journey 1: Retention Policy Configuration
+    Admin ->> System: openRetentionSettings()
+    System -->> Admin: displayCurrentPolicies(policies)
+
+    Admin ->> System: updateRetentionPolicy(category, newPeriod)
+    alt success
+        System -->> Admin: confirmPolicyUpdated()
+    else belowLegalMinimum
+        System -->> Admin: errorRetention("Under lovpligtigt minimum")
+    else persistenceFailure
+        System -->> Admin: errorRetention("Gem mislykkedes")
+    end
+
+    %% Journey 2: Anonymization Queue
+    Admin ->> System: openAnonymizationQueue()
+    System -->> Admin: displayCandidates(candidates)
+
+    Admin ->> System: reviewCandidate(candidateId)
+    System -->> Admin: showCandidateDetails(details)
+
+    Admin ->> System: approveAnonymization(candidateId)
+    alt success
+        System -->> Admin: confirmAnonymized()
+    else activeHold
+        System -->> Admin: errorAnonymization("Aktivt hold forhindrer anonymisering")
+    end
+
+    Admin ->> System: rejectAnonymization(candidateId, reason)
+    System -->> Admin: confirmRejected()
+
+    %% Journey 3: Security Incident Handling
+    Admin ->> System: openSecurityIncidents()
+    System -->> Admin: displayIncidents(incidents)
+
+    Admin ->> System: reviewIncident(incidentId)
+    System -->> Admin: showIncidentDetails(details)
+
+    Admin ->> System: addInvestigationNotes(incidentId, notes)
+    System -->> Admin: confirmNotesSaved()
+
+    Admin ->> System: closeIncident(incidentId)
+    System -->> Admin: confirmIncidentClosed()
+
+    Admin ->> System: escalateIncident(incidentId)
+    alt standardEscalation
+        System -->> Admin: confirmEscalated()
+    else dataBreach
+        System -->> Admin: triggerArt33Notification(incidentId, dpoEmail)
+        System -->> Admin: confirmBreachNotified()
+    end
+
+    %% Journey 4: Subject Access Request (SAR)
+    Admin ->> System: openSarView()
+    System -->> Admin: displaySarForm()
+
+    Admin ->> System: searchDataSubject(residentIdentifier)
+    alt found
+        System -->> Admin: displaySubjectData(personalData)
+    else notFound
+        System -->> Admin: errorSar("Registreret ikke fundet")
+    end
+
+    Admin ->> System: generateSarExport(residentId, scopeOptions)
+    System -->> Admin: confirmExportGenerated(exportId)
+
+    Admin ->> System: markSarFulfilled(sarId)
+    System -->> Admin: confirmSarFulfilled()
+
+    %% Cross-cutting alternative outcomes
+    alt unauthorizedAccess (Admin-rolle mangler)
+        System -->> Admin: denyAccess()
+    else technicalError
+        System -->> Admin: errorTechnical("Prøv igen")
+    end
+```
+
+## Language Translation
+
+| English Term | Danish Translation |
+|--------------|--------------------|
+| Retention policy | Retention-politik / opbevaringspolitik |
+| Legal minimum | Lovpligtigt minimum |
+| Anonymization queue | Anonymiseringskø |
+| Hold | Hold (legal/audit hold) |
+| Security incident | Sikkerhedshændelse |
+| Data breach | Brud på persondatasikkerheden |
+| Subject Access Request (SAR) | Indsigtsanmodning (SAR) |
+| Audit log / audit trail | Audit-log / revisionsspor |
+| Art. 33 notification | Art. 33-underretning |
+| Data Protection Officer (DPO) | Databeskyttelsesrådgiver (DPO) |

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.ssd.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.ssd.md
@@ -1,0 +1,98 @@
+# System Sequence Diagram for Use Case UC-010: Ensure data security and GDPR compliance
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010.SSD |
+| crossReference | UC-010 UC-010.DM UC-010.UC |
+| Author         | Team 6 |
+| Version        | 0001 |
+| Date           | 2026-05-11 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## System Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant System
+
+    %% Journey 1: Retention Policy Configuration
+    Admin ->> System: openRetentionSettings()
+    System -->> Admin: displayCurrentPolicies(policies)
+
+    Admin ->> System: updateRetentionPolicy(category, newPeriod)
+    alt success
+        System -->> Admin: confirmPolicyUpdated()
+    else belowLegalMinimum
+        System -->> Admin: errorRetention("Below legal minimum")
+    else persistenceFailure
+        System -->> Admin: errorRetention("Save failed")
+    end
+
+    %% Journey 2: Anonymization Queue
+    Admin ->> System: openAnonymizationQueue()
+    System -->> Admin: displayCandidates(candidates)
+
+    Admin ->> System: reviewCandidate(candidateId)
+    System -->> Admin: showCandidateDetails(details)
+
+    Admin ->> System: approveAnonymization(candidateId)
+    alt success
+        System -->> Admin: confirmAnonymized()
+    else activeHold
+        System -->> Admin: errorAnonymization("Active hold prevents anonymization")
+    end
+
+    Admin ->> System: rejectAnonymization(candidateId, reason)
+    System -->> Admin: confirmRejected()
+
+    %% Journey 3: Security Incident Handling
+    Admin ->> System: openSecurityIncidents()
+    System -->> Admin: displayIncidents(incidents)
+
+    Admin ->> System: reviewIncident(incidentId)
+    System -->> Admin: showIncidentDetails(details)
+
+    Admin ->> System: addInvestigationNotes(incidentId, notes)
+    System -->> Admin: confirmNotesSaved()
+
+    Admin ->> System: closeIncident(incidentId)
+    System -->> Admin: confirmIncidentClosed()
+
+    Admin ->> System: escalateIncident(incidentId)
+    alt standardEscalation
+        System -->> Admin: confirmEscalated()
+    else dataBreach
+        System -->> Admin: triggerArt33Notification(incidentId, dpoEmail)
+        System -->> Admin: confirmBreachNotified()
+    end
+
+    %% Journey 4: Subject Access Request (SAR)
+    Admin ->> System: openSarView()
+    System -->> Admin: displaySarForm()
+
+    Admin ->> System: searchDataSubject(residentIdentifier)
+    alt found
+        System -->> Admin: displaySubjectData(personalData)
+    else notFound
+        System -->> Admin: errorSar("Subject not found")
+    end
+
+    Admin ->> System: generateSarExport(residentId, scopeOptions)
+    System -->> Admin: confirmExportGenerated(exportId)
+
+    Admin ->> System: markSarFulfilled(sarId)
+    System -->> Admin: confirmSarFulfilled()
+
+    %% Cross-cutting alternative outcomes
+    alt unauthorizedAccess (Admin role missing)
+        System -->> Admin: denyAccess()
+    else technicalError
+        System -->> Admin: errorTechnical("Try again")
+    end
+```

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.usecase.da.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.usecase.da.md
@@ -1,0 +1,185 @@
+# Use Case: Ensure data security and GDPR compliance (Danish)
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010 |
+| crossReference | BC<br/>REQ-DC-001<br/>REQ-R-003<br/>REQ-F-005 |
+| Title          | Ensure data security and GDPR compliance |
+| Author         | Team 6 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Use Case Description (Danish)
+
+## Brugerhistorie
+Som Admin vil jeg administrere retention-politikker, gennemgå anonymiseringskandidater, overvåge sikkerhedshændelser og besvare indsigtsanmodninger, så systemet overholder GDPR og dansk databeskyttelseslovgivning (Datatilsynet) og beskytter sårbare beboeres persondata.
+
+### Kort Use Case
+**Titel**: Sikre datasikkerhed og GDPR-overholdelse
+**Succesforløb**:
+Admin åbner GDPR Compliance-visningen og gennemgår de aktuelle retention-politikker og deres juridiske grundlag. Systemet viser anonymiseringskandidater foreslået af RetentionBackgroundService og giver Admin mulighed for at godkende eller afvise anonymisering. Systemet flagger mistænkelig aktivitet som sikkerhedshændelser via IncidentDetectionService, og Admin gennemgår, dokumenterer og eskalerer hændelser efter behov. Når en indsigtsanmodning (SAR) modtages, søger Admin efter den registrerede, genererer et eksportgrundlag for relevante persondata og registrerer afslutning; alle handlinger er adgangskontrollerede og audit-loggede.
+
+### Casual Use Case
+**Titel**: Sikre datasikkerhed og GDPR-overholdelse
+**Scope**: Slottets Drifttavlen (GDPR Compliance Layer — bygger videre på UC-007 autentificering og UC-009 audit logging)
+**Niveau**: Brugermål
+**Aktører**:
+- Admin (primary)
+- System (Slottets Drifttavlen)
+- RetentionBackgroundService (automated, suggests anonymization candidates)
+- IncidentDetectionService (automated, flags suspicious activity)
+
+**Hovedforløb**:
+1: Admin åbner GDPR Compliance-visningen.
+2: Systemet validerer Admin-adgang (REQ-F-005) og viser aktuelle retention-politikker og status.
+3: Admin gennemgår retention-politikker og opdaterer retention-perioder og juridisk grundlag, hvor det er relevant.
+4: Systemet validerer ændringerne, gemmer dem og registrerer ændringen i audit-loggen (REQ-R-003).
+5: Systemet viser anonymiseringskandidater foreslået af RetentionBackgroundService.
+6: Admin gennemgår kandidater og godkender anonymisering for egnede registreringer.
+7: Systemet udfører anonymisering, registrerer handlingen i audit-loggen og opdaterer registreringsstatus.
+8: Systemet viser sikkerhedshændelser flagget af IncidentDetectionService.
+9: Admin gennemgår hændelser, tilføjer undersøgelsesnoter og beslutter at lukke eller eskalere hændelser.
+10: Systemet registrerer hændelseshandlinger og beslutninger i audit-loggen.
+11: Admin registrerer en indsigtsanmodning (GDPR Art. 15) og søger efter den registrerede.
+12: Systemet genererer en eksport/rapport med den registreredes persondata og behandlingsoplysninger for det ønskede scope.
+13: Admin gennemgår eksporten for fuldstændighed og dataminimering og markerer derefter anmodningen som afsluttet.
+14: Systemet registrerer SAR-svar og afslutning i audit-loggen.
+
+**Hovedudvidelser**:
+1a: Admin er ikke autentificeret eller mangler Admin-rolle.
+    1: Systemet afviser adgang.
+    2: Systemet registrerer det afviste adgangsforsøg i audit-loggen.
+3a: Retention-ændring er ugyldig (fx kortere end lovpligtigt minimum for en registreringstype).
+    1: Systemet afviser ændringen og viser valideringsfeedback.
+    2: Systemet registrerer det afviste ændringsforsøg i audit-loggen.
+5a: RetentionBackgroundService er utilgængelig.
+    1: Systemet viser en advarsel og fortsætter uden kandidatforslag.
+    2: Systemet registrerer serviceproblemet til overvågning.
+6a: Kandidaten er ikke egnet (fx aktiv sag, uafsluttet audit/legal hold).
+    1: Systemet forhindrer anonymisering og forklarer hvorfor.
+8a: IncidentDetectionService rapporterer mistænkelig aktivitet.
+    1: Systemet opretter eller opdaterer en hændelse og fremhæver alvorlighed.
+    2: Admin eskalerer hændelsen i henhold til incident response-proceduren.
+12a: Eksport kan ikke genereres (fx teknisk fejl).
+    1: Systemet viser en fejl og giver mulighed for at prøve igen.
+    2: Systemet registrerer fejlen i audit-loggen.
+
+**Resumé**: Admin anvender retention- og anonymiseringsregler, overvåger hændelser og håndterer indsigtsanmodninger med sikker adgangskontrol og fuld audit logging.
+
+### Fuldt Udfoldet Use Case
+**Titel**: Sikre datasikkerhed og GDPR-overholdelse
+**Scope**: Slottets Drifttavlen (GDPR Compliance Layer — bygger videre på UC-007 autentificering og UC-009 audit logging)
+**Niveau**: Brugermål
+**Aktører**:
+- Admin (primary)
+- System (Slottets Drifttavlen)
+- RetentionBackgroundService (automated, suggests anonymization candidates)
+- IncidentDetectionService (automated, flags suspicious activity)
+
+**Relaterede Krav**:
+- [REQ-DC-001] GDPR-overholdelse og sikker håndtering af persondata.
+- [REQ-R-003] Audit-log for alle ændringer og brugerhandlinger.
+- [REQ-F-005] Adgangskontrol og login.
+- GDPR Art. 5(1)(e) — Opbevaringsbegrænsning (storage limitation).
+- GDPR Art. 15 — Ret til indsigt (Subject Access Request).
+- GDPR Art. 17 — Ret til sletning.
+- GDPR Art. 25 — Databeskyttelse gennem design og standardindstillinger.
+- GDPR Art. 30 — Fortegnelser over behandlingsaktiviteter.
+- GDPR Art. 32 — Sikkerhed i behandlingen.
+- GDPR Art. 33 — Anmeldelse af brud på persondatasikkerheden.
+- GDPR Art. 35 — Konsekvensanalyse (DPIA).
+- Autorisationsloven §22 (10 års opbevaring af medicindokumentation — dansk lovgivning).
+
+**Forudsætninger**:
+- Brugeren er autentificeret og har Admin-rolle.
+- Audit logging-infrastrukturen (UC-009) er i drift.
+- Baggrundsservices (RetentionBackgroundService, IncidentDetectionService) kører.
+- Standard retention-politikker er seeded i henhold til dansk lovgivning.
+
+**Default Retention Values**:
+
+| Data Category | Default | Legal Minimum | Configurable Range |
+|---|---|---|---|
+| Medicine Logs | 10 years | 10 years (Autorisationsloven §22) | Locked at 10 years |
+| Resident Notes | 5 years after discharge | None | 1–30 years |
+| Audit Logs | 2 years | None | 6 months – 10 years |
+| Login/Security Logs | 13 months | None | 3 months – 2 years |
+| Inactive User Accounts | 6 months after last login | None | 1–24 months |
+| Resident Anonymization Trigger | 90 days after discharge | None | 0–365 days |
+
+Note: For Medicine Logs, the system applies pseudonymization (replacing personal identifiers) rather than full anonymization, in order to preserve medicine history as required by Autorisationsloven §22 while removing personal traceability.
+
+**Hovedforløb**:
+1. Admin åbner GDPR Compliance-visningen.
+2. Systemet autoriserer anmodningen (REQ-F-005) og logger adgang i audit-loggen (REQ-R-003).
+3. Admin gennemgår aktuelle retention-politikker (pr. registreringstype) og deres retention-perioder.
+4. Admin opdaterer en eller flere retention-politikker, inkl. juridisk grundlag og ikrafttrædelsesdato når relevant.
+5. Systemet validerer ændringen mod lovpligtige minimumskrav (fx Autorisationsloven §22 for medicindokumentation) og eventuelle aktive holds.
+6. Systemet gemmer de opdaterede politikker og registrerer ændringen i audit-loggen.
+7. Systemet viser anonymiseringskandidater foreslået af RetentionBackgroundService, inkl. begrundelse (fx retention udløbet), registreringstype og seneste aktivitet.
+8. Admin gennemgår en kandidat og vælger handling (godkend anonymisering, afvis, udsæt eller påfør hold).
+9. Systemet udfører den valgte handling, opdaterer kandidatstatus og registrerer handlingen i audit-loggen.
+10. Systemet viser åbne sikkerhedshændelser og mistænkelig aktivitet flagget af IncidentDetectionService.
+11. Admin gennemgår en hændelse, tildeler alvorlighed, tilføjer undersøgelsesnoter og vælger handling (luk, eskalér eller underret).
+12. Systemet registrerer beslutning og eventuelle underretninger i audit-loggen.
+13. Admin registrerer en indsigtsanmodning (GDPR Art. 15) med anmoderoplysninger og scope/tidsinterval.
+14. Systemet identificerer persondata og relevante behandlingsoplysninger (GDPR Art. 30) for den registrerede.
+15. Systemet genererer en SAR-eksportpakke og logger eksportgenerering.
+16. Admin gennemgår eksporten for fuldstændighed og dataminimering og markerer SAR som opfyldt.
+17. Systemet registrerer afslutning (og eventuelle undtagelser) i audit-loggen.
+
+**Udvidelser**:
+    a: På ethvert tidspunkt, hvis autorisation fejler, afviser systemet adgang og registrerer forsøget i audit-loggen.
+    b: På ethvert tidspunkt, hvis en teknisk fejl opstår, viser systemet en fejl og registrerer fejlen i audit-loggen.
+    5a: Retention-politik bryder lovpligtigt minimum eller konfigurerede begrænsninger.
+        1: Systemet afviser ændringen og forklarer den brudte begrænsning.
+        2: Admin justerer politikken og gentager trin 4.
+    7a: RetentionBackgroundService kører ikke.
+        1: Systemet viser en advarsel om service health.
+        2: Admin fortsætter med manuel gennemgang eller planlægger et nyt forsøg.
+    7b: Der findes ingen anonymiseringskandidater.
+        1: Systemet viser en besked om, at der ikke er nogen afventende kandidater, og Admin fortsætter til incident-gennemgang.
+    9a: Anonymisering kan ikke udføres pga. et aktivt legal/audit hold.
+        1: Systemet forhindrer anonymisering og registrerer årsagen.
+        2: Admin fastholder hold og lukker kandidaten.
+    11a: Hændelsens alvorlighed indikerer muligt brud på persondatasikkerheden (GDPR Art. 33).
+        1: Admin eskalerer hændelsen og følger proceduren for brudsanmeldelse.
+        2: Systemet registrerer eskalationsbeslutning og tidsstempler.
+    15a: SAR-eksport er for stor eller scope er uklart.
+        1: Admin afgrænser scope eller deler eksporten.
+        2: Systemet regenererer eksporten.
+
+**Efterbetingelser**:
+- Retention-politikker er anvendt; ændringer og adgang er registreret i audit-loggen (REQ-R-003).
+- Anonymiseringskandidater er gennemgået, og handlinger er registreret i audit-loggen.
+- Sikkerhedshændelser er overvåget, triageret og registreret med sporbarhed.
+- Indsigtsanmodninger er håndteret med et auditerbart spor af hvad der er eksporteret og hvornår.
+
+## Vedligeholdelse
+- Opdater version og ændringslog ved større ændringer.
+- Gennemgå regelmæssigt use cases for nøjagtighed og relevans.
+- Gennemgå og godkend use cases med relevante interessenter før accept.
+
+## Implementation Notes
+- Denne use case forudsætter, at autentificering og adgangskontrol håndteres af UC-007, og at alle handlinger logges i henhold til UC-009.
+- Retention-politikker bør understøtte både lovpligtige minimumskrav (fx medicindokumentation) og operationelle holds (fx igangværende undersøgelse).
+- SAR-eksport bør være adgangskontrolleret, manipulationssikker og begrænset til det ønskede scope/tidsinterval.
+
+## Terms Translation
+| English                         | Danish |
+|---------------------------------|--------|
+| Data retention policy           | Retention-politik / opbevaringspolitik |
+| Storage limitation              | Opbevaringsbegrænsning |
+| Anonymization candidate         | Anonymiseringskandidat |
+| Audit log / audit trail         | Audit-log / revisionsspor |
+| Security incident               | Sikkerhedshændelse |
+| Suspicious activity             | Mistænkelig aktivitet |
+| Subject Access Request (SAR)    | Indsigtsanmodning |
+| Personal data breach            | Brud på persondatasikkerheden |
+| Records of processing activities| Fortegnelser over behandlingsaktiviteter |
+| Data protection by design       | Databeskyttelse gennem design |
+| DPIA                            | Konsekvensanalyse (DPIA) |

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.usecase.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.usecase.md
@@ -1,0 +1,170 @@
+# Use Case: Ensure data security and GDPR compliance
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010 |
+| crossReference | BC<br/>REQ-DC-001<br/>REQ-R-003<br/>REQ-F-005 |
+| Title          | Ensure data security and GDPR compliance |
+| Author         | Team 6 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Use Case Description
+
+## User story
+As an Admin, I want to manage data retention policies, review anonymization candidates, monitor security incidents, and respond to subject access requests, so that the system complies with GDPR and Danish data protection law (Datatilsynet) and protects vulnerable residents' personal data.
+
+### Brief Use Case
+**Title**: Ensure data security and GDPR compliance
+**Success Flow**:
+The Admin opens the GDPR Compliance view and reviews the current retention policies and their legal basis. The system shows anonymization candidates suggested by RetentionBackgroundService and allows the Admin to approve or reject anonymization actions. The system flags suspicious activity as security incidents via IncidentDetectionService, and the Admin reviews, documents, and escalates incidents when needed. When a subject access request (SAR) is received, the Admin searches for the data subject, generates an export of relevant personal data, and records completion; all actions are access-controlled and audit logged.
+
+### Casual Use Case
+**Title**: Ensure data security and GDPR compliance
+**Scope**: Slottets Drifttavlen (GDPR Compliance Layer — builds on top of UC-007 authentication and UC-009 audit logging)
+**Level**: User Goal
+**Actors**:
+- Admin (primary)
+- System (Slottets Drifttavlen)
+- RetentionBackgroundService (automated, suggests anonymization candidates)
+- IncidentDetectionService (automated, flags suspicious activity)
+
+**Main Flow**:
+1: Admin opens the GDPR Compliance view.
+2: System validates Admin access (REQ-F-005) and shows current retention policies and status.
+3: Admin reviews retention policies and updates retention periods and legal basis where applicable.
+4: System validates the retention policy changes, saves them, and records the change in the audit log (REQ-R-003).
+5: System shows anonymization candidates suggested by RetentionBackgroundService.
+6: Admin reviews candidates and approves anonymization actions for eligible records.
+7: System performs anonymization, records the action in the audit log, and updates record status.
+8: System displays security incidents flagged by IncidentDetectionService.
+9: Admin reviews incidents, adds investigation notes, and decides to close or escalate incidents.
+10: System records incident actions and decisions in the audit log.
+11: Admin registers a subject access request (GDPR Art. 15) and searches for the data subject.
+12: System generates an export/report of the data subject’s personal data and processing records for the requested scope.
+13: Admin reviews the export for completeness and minimization, then marks the request as completed.
+14: System records the SAR response and completion in the audit log.
+
+**Main Extensions**:
+1a: Admin is not authenticated or lacks the Admin role.
+    1: System denies access.
+    2: System records the denied access attempt in the audit log.
+3a: Retention policy change is invalid (e.g., shorter than legal minimum for a record type).
+    1: System rejects the change and shows validation feedback.
+    2: System records the rejected change attempt in the audit log.
+5a: RetentionBackgroundService is unavailable.
+    1: System shows a warning and continues without candidate suggestions.
+    2: System records the service health issue for monitoring.
+6a: Candidate is not eligible (e.g., active case, unresolved audit/legal hold).
+    1: System prevents anonymization and explains why.
+8a: IncidentDetectionService reports suspicious activity.
+    1: System creates or updates an incident entry and highlights severity.
+    2: Admin escalates the incident according to the incident response procedure.
+12a: Export cannot be generated (e.g., technical error).
+    1: System shows an error and offers retry.
+    2: System records the failure in the audit log.
+
+**Summary**: The Admin applies retention and anonymization rules, monitors incidents, and fulfills SARs with secure access control and full audit logging.
+
+### Fully Dressed Use Case
+**Title**: Ensure data security and GDPR compliance
+**Scope**: Slottets Drifttavlen (GDPR Compliance Layer — builds on top of UC-007 authentication and UC-009 audit logging)
+**Level**: User Goal
+**Actors**:
+- Admin (primary)
+- System (Slottets Drifttavlen)
+- RetentionBackgroundService (automated, suggests anonymization candidates)
+- IncidentDetectionService (automated, flags suspicious activity)
+
+**Related Requirements**:
+- [REQ-DC-001] GDPR compliance and secure handling of personal data.
+- [REQ-R-003] Audit log for all changes and user actions.
+- [REQ-F-005] Access control and login.
+- GDPR Art. 5(1)(e) — Storage limitation.
+- GDPR Art. 15 — Right of access (Subject Access Request).
+- GDPR Art. 17 — Right to erasure.
+- GDPR Art. 25 — Data protection by design and by default.
+- GDPR Art. 30 — Records of processing activities.
+- GDPR Art. 32 — Security of processing.
+- GDPR Art. 33 — Notification of personal data breach.
+- GDPR Art. 35 — Data protection impact assessment (DPIA).
+- Autorisationsloven §22 (10-year medicine documentation retention — Danish law).
+
+**Preconditions**:
+- User is authenticated and assigned the Admin role.
+- Audit logging infrastructure (UC-009) is operational.
+- Background services (RetentionBackgroundService, IncidentDetectionService) are running.
+- Default retention policies are seeded according to Danish law.
+
+**Default Retention Values**:
+
+| Data Category | Default | Legal Minimum | Configurable Range |
+|---|---|---|---|
+| Medicine Logs | 10 years | 10 years (Autorisationsloven §22) | Locked at 10 years |
+| Resident Notes | 5 years after discharge | None | 1–30 years |
+| Audit Logs | 2 years | None | 6 months – 10 years |
+| Login/Security Logs | 13 months | None | 3 months – 2 years |
+| Inactive User Accounts | 6 months after last login | None | 1–24 months |
+| Resident Anonymization Trigger | 90 days after discharge | None | 0–365 days |
+
+Note: For Medicine Logs, the system applies pseudonymization (replacing personal identifiers) rather than full anonymization, in order to preserve medicine history as required by Autorisationsloven §22 while removing personal traceability.
+
+**Main Flow**:
+1. Admin opens the GDPR Compliance view.
+2. System authorizes the request (REQ-F-005) and logs the access in the audit log (REQ-R-003).
+3. Admin reviews current retention policies (by record type) and their configured retention periods.
+4. Admin updates one or more retention policies, including legal basis and effective date when required.
+5. System validates the change against mandatory minimums (e.g., Autorisationsloven §22 for medicine documentation) and any active holds.
+6. System saves the updated policies and records the policy change in the audit log.
+7. System displays anonymization candidates suggested by RetentionBackgroundService, including candidate reason (e.g., retention expired), record type, and last activity.
+8. Admin reviews a candidate and selects an action (approve anonymization, reject, postpone, or apply hold).
+9. System performs the selected action, updates the candidate status, and records the action in the audit log.
+10. System displays open security incidents and suspicious activities flagged by IncidentDetectionService.
+11. Admin reviews an incident, assigns severity, adds investigation notes, and selects an action (close, escalate, or notify).
+12. System records the incident decision and any notifications in the audit log.
+13. Admin registers a Subject Access Request (GDPR Art. 15) with requester details and scope/time range.
+14. System identifies personal data and relevant processing records (GDPR Art. 30) for the data subject.
+15. System generates a SAR export package and logs the export generation.
+16. Admin reviews the export for completeness and minimization, then marks the SAR as fulfilled.
+17. System records the completion (and any exceptions) in the audit log.
+
+**Extensions**:
+    a: At any time, if authorization fails, system denies access and records the attempt in the audit log.
+    b: At any time, if a technical error occurs, system shows an error and records the failure in the audit log.
+    5a: Retention policy violates legal minimum or configured constraints.
+        1: System rejects the change and explains the violated constraint.
+        2: Admin adjusts the policy and retries step 4.
+    7a: RetentionBackgroundService is not running.
+        1: System shows a service health warning.
+        2: Admin continues with manual review or schedules a retry.
+    7b: No anonymization candidates exist.
+        1: System shows a 'No pending candidates' message and the admin proceeds to incident review.
+    9a: Anonymization cannot be applied due to an active legal/audit hold.
+        1: System prevents anonymization and records the reason.
+        2: Admin applies or maintains the hold and closes the candidate.
+    11a: Incident severity indicates a potential personal data breach (GDPR Art. 33).
+        1: Admin escalates the incident and follows the breach notification procedure.
+        2: System records the escalation decision and timestamps.
+    15a: SAR export is too large or contains ambiguous scope.
+        1: Admin narrows the scope or splits the export.
+        2: System regenerates the export.
+
+**Postconditions**:
+- Retention policies are applied; changes and access are recorded in the audit log (REQ-R-003).
+- Anonymization candidates are reviewed and actions are recorded in the audit log.
+- Security incidents are monitored, triaged, and recorded with traceability.
+- Subject access requests are fulfilled with an auditable record of what was exported and when.
+
+## Maintenance
+- Update the version and change log for major changes.
+- Regularly review use cases for accuracy and relevance.
+- Review and approve use cases with relevant stakeholders before acceptance.
+
+## Implementation Notes
+- This use case assumes authentication and access control are handled by UC-007 and that all actions are captured by the audit logging approach described in UC-009.
+- Retention policies should support legal minimums (e.g., medicine documentation) and operational holds (e.g., ongoing investigation).
+- SAR exports should be access-controlled, tamper-evident, and limited to the requested scope/time range.

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.userflow.da.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.userflow.da.md
@@ -1,0 +1,71 @@
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010.UserFlow |
+| crossReference | UC-010<br/>UC-010.UC<br/>UC-010.Wireframe |
+| Title          | Ensure data security and GDPR compliance — User Flow Diagram (Danish) |
+| Author         | Team 6 |
+| Date           | 2026-05-11 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## User Flow Diagram
+Dette brugerflow viser, hvordan en Admin navigerer i GDPR Compliance Dashboard for at konfigurere retention-politikker, gennemgå anonymiseringskandidater, overvåge og håndtere sikkerhedshændelser samt behandle indsigtsanmodninger (SAR).
+
+```mermaid
+flowchart TD
+    Start([Admin opens GDPR Dashboard]) --> Auth{Admin role?}
+
+    Auth -->|Nej| Denied([Access denied])
+    Auth -->|Ja| Dashboard[GDPR Compliance Dashboard]
+
+    %% Indgange fra dashboardet
+    Dashboard -->|Konfigurér retention-politikker| Retention[Retention-indstillinger]
+    Dashboard -->|Gennemgå anonymiseringskø| Queue[Anonymiseringskø]
+    Dashboard -->|Overvåg og håndtér sikkerhedshændelser| Incidents[Sikkerhedshændelser]
+    Dashboard -->|Behandl indsigtsanmodning - SAR| Sar[Indsigtsanmodning - SAR]
+
+    %% Flow 1: Retention-indstillinger
+    Retention -->|Redigér politik + Gem| LegalMin{Lovpligtigt minimum OK?}
+    LegalMin -->|Nej| RetentionError[Vis valideringsfejl]
+    RetentionError -->|Justér politik| Retention
+    Retention -->|Annullér| Cancelled([Cancelled])
+    LegalMin -->|Ja| Success([Action complete])
+
+    %% Flow 2: Anonymiseringskø
+    Queue -->|Vælg kandidat| QueueDecision{Godkend / Afvis / Udsæt / Påfør hold?}
+    QueueDecision -->|Godkend| Execute[Udfør handling]
+    QueueDecision -->|Afvis| Execute
+    QueueDecision -->|Udsæt| Execute
+    QueueDecision -->|Påfør hold| Execute
+    Execute -->|Udført| Success
+
+    %% Flow 3: Sikkerhedshændelser
+    Incidents -->|Vælg hændelse| IncidentDecision{Luk / Eskalér / Underret brud?}
+    IncidentDecision -->|Luk| Success
+    IncidentDecision -->|Eskalér| Success
+    IncidentDecision -->|Underret brud| Art33[Udløs Art. 33-underretning]
+    Art33 -->|Sendt| Success
+
+    %% Flow 4: Indsigtsanmodning (SAR)
+    Sar -->|Indtast beboer-id + Søg| Found{Registreret fundet?}
+    Found -->|Nej| NotFound[Vis fejl]
+    NotFound -->|Prøv igen| Sar
+    Found -->|Ja| Export[Generér eksport]
+    Export -->|Gennemgå| Review[Gennemgå for dataminimering]
+    Review -->|Markér opfyldt| Success
+
+    %% Returveje
+    Success -->|Tilbage til dashboard| Dashboard
+    Success -->|Tilbage til kø| Queue
+    Cancelled -->|Tilbage til dashboard| Dashboard
+```
+
+## Notes
+- Alle handlinger går via det eksisterende autentificerings-/autorisationslag (UC-007).
+- Alle tilstandsændringer persisteres i audit-loggen via den eksisterende `AuditInterceptor` (UC-009).
+- Baggrundsservices (RetentionBackgroundService, IncidentDetectionService) leverer anonymiseringskandidater og incident-signaler; disse er bevidst ikke visualiseret som brugertrin i diagrammet.
+- Ikke visualiseret: advarsler om service health (fx service utilgængelig), "ingen afventende kandidater" samt tekniske fejl (fx fejl ved eksportgenerering med retry) — de håndteres som fejl-/statusbeskeder i UI, men er ikke udfoldet for at holde diagrammet under nodegrænsen.

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.userflow.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.userflow.md
@@ -1,0 +1,71 @@
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010.UserFlow |
+| crossReference | UC-010<br/>UC-010.UC<br/>UC-010.Wireframe |
+| Title          | Ensure data security and GDPR compliance — User Flow Diagram |
+| Author         | Team 6 |
+| Date           | 2026-05-11 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## User Flow Diagram
+This user flow shows how an Admin navigates the GDPR Compliance Dashboard to configure retention policies, review anonymization candidates, monitor and handle security incidents, and process Subject Access Requests (SAR).
+
+```mermaid
+flowchart TD
+    Start([Admin opens GDPR Dashboard]) --> Auth{Admin role?}
+
+    Auth -->|No| Denied([Access denied])
+    Auth -->|Yes| Dashboard[GDPR Compliance Dashboard]
+
+    %% Entry points from the dashboard
+    Dashboard -->|Configure retention policies| Retention[Retention Settings]
+    Dashboard -->|Review anonymization candidates queue| Queue[Anonymization Queue]
+    Dashboard -->|Monitor and handle security incidents| Incidents[Security Incidents]
+    Dashboard -->|Process Subject Access Request - SAR| Sar[Subject Access Request]
+
+    %% Flow 1: Retention Settings
+    Retention -->|Edit policy + Save| LegalMin{Legal minimum OK?}
+    LegalMin -->|No| RetentionError[Show validation error]
+    RetentionError -->|Adjust policy| Retention
+    Retention -->|Cancel| Cancelled([Cancelled])
+    LegalMin -->|Yes| Success([Action complete])
+
+    %% Flow 2: Anonymization Queue
+    Queue -->|Select candidate| QueueDecision{Approve / Reject / Postpone / Apply hold?}
+    QueueDecision -->|Approve| Execute[Execute action]
+    QueueDecision -->|Reject| Execute
+    QueueDecision -->|Postpone| Execute
+    QueueDecision -->|Apply hold| Execute
+    Execute -->|Done| Success
+
+    %% Flow 3: Security Incidents
+    Incidents -->|Select incident| IncidentDecision{Close / Escalate / Notify breach?}
+    IncidentDecision -->|Close| Success
+    IncidentDecision -->|Escalate| Success
+    IncidentDecision -->|Notify breach| Art33[Trigger Art. 33 notification]
+    Art33 -->|Sent| Success
+
+    %% Flow 4: Subject Access Request (SAR)
+    Sar -->|Enter resident identifier + Search| Found{Resident found?}
+    Found -->|No| NotFound[Show error]
+    NotFound -->|Retry| Sar
+    Found -->|Yes| Export[Generate export]
+    Export -->|Review| Review[Review for minimization]
+    Review -->|Mark fulfilled| Success
+
+    %% Return paths
+    Success -->|Back to dashboard| Dashboard
+    Success -->|Back to queue| Queue
+    Cancelled -->|Back to dashboard| Dashboard
+```
+
+## Notes
+- All actions traverse through the existing authentication/authorization layer (UC-007).
+- All state changes are persisted to the audit log via the existing `AuditInterceptor` (UC-009).
+- Background services (RetentionBackgroundService, IncidentDetectionService) supply anonymization candidates and incident signals; these are intentionally not visualized as user-facing steps in the diagram.
+- Not visualized: service-health warnings (e.g., candidate service unavailable), “no pending candidates”, and technical failures (e.g., export generation retry) — these are handled as user-facing errors/messages in the UI but are not expanded to keep the diagram under the node limit.

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.wireframe.da.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.wireframe.da.md
@@ -1,0 +1,269 @@
+# Wireframe: UC-010 Sikre datasikkerhed og GDPR-overholdelse
+
+## Metadata
+| Nøgle          | Værdi |
+|----------------|-------|
+| Id             | UC-010.Wireframe |
+| crossReference | UC-010 UC-010.UC UC-010.UserFlow |
+| Author         | Team 6 |
+| Version        | 0001 |
+| Date           | 2026-05-11 |
+
+## Versionslog
+| Version | Dato       | Beskrivelse | Forfatter |
+|---------|------------|-------------|-----------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Wireframe
+Dette wireframe dækker det Admin-beskyttede GDPR Compliance-dashboard og de fire undersider:
+Retention-indstillinger, Anonymiseringskø, Sikkerhedshændelser og Indsigtsanmodning (SAR).
+
+## Overblik — Navigationskort
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard                                      Rolle: Admin     |
++----------------------------------------------------------------------------------+
+|  [Retention-indstillinger]  [Anonymiseringskø]   [Sikkerhedshændelser]   [SAR]   |
+|                                                                                  |
+|  Note: Badges viser aktuelle antal på dashboard-tiles.                            |
++----------------------------------------------------------------------------------+
+```
+
+## Skærm 1 — GDPR Compliance Dashboard
+
+Overview layout (hvor denne skærm ligger i navigationen):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard                                      Rolle: Admin     |
++----------------------------------------------------------------------------------+
+|  Aktuel side: GDPR Compliance Dashboard                                           |
+|  Tiles navigerer til de fire undersider                                           |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Landingsside:
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard                                      Rolle: Admin     |
++----------------------------------------------------------------------------------+
+|  +----------------------+  +----------------------+  +----------------------+     |
+|  | Retention-indst.     |  | Anonymiseringskø     |  | Sikkerhedshændelser  |     |
+|  | [Åbn]                |  | Afventer: [ 12 ]     |  | Åbne:    [  3 ]      |     |
+|  +----------------------+  +----------------------+  +----------------------+     |
+|                                                                                  |
+|  +----------------------+                                                         |
+|  | Indsigtsanmodning    |  (SAR)                                                  |
+|  | [Åbn]   [Ny SAR]     |                                                         |
+|  +----------------------+                                                         |
+|                                                                                  |
+|  Statusoversigt                                                                  |
+|  Sidste retention-run:  2026-05-10 02:00                                          |
+|  Næste planlagte run:   2026-05-12 02:00                                          |
++----------------------------------------------------------------------------------+
+```
+
+## Skærm 2 — Retention-indstillinger
+
+Overview layout (fra dashboard til denne skærm):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Retention-indstillinger            Rolle: Admin   |
++----------------------------------------------------------------------------------+
+|  [Tilbage til dashboard]   Aktuel side: Retention-indstillinger                    |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Tabel med retention-politikker:
+
+```text
++----------------------------------------------------------------------------------+
+|  Retention-indstillinger                                      Rolle: Admin       |
++----------------------------------------------------------------------------------+
+|  ADVARSEL: Ændringer logges automatisk. Medicine Logs er låst til 10 år          |
+|  jf. Autorisationsloven §22.                                                     |
++----------------------------------------------------------------------------------+
+|  Politikker                                                                       |
+|  +---------------------------+------------------+--------------+----------------+ |
+|  | Datakategori              | Aktuel retention | Lovmin.      | Interval       | |
+|  +---------------------------+------------------+--------------+----------------+ |
+|  | Medicine Logs             | 10 år (låst)     | 10 år        | låst           | |
+|  |                           |                  |              |        [Gem]   | |
+|  | Resident Notes            | [ 5 år         ] | ingen        | 1–30 år        | |
+|  |                           |                  |              |        [Gem]   | |
+|  | Audit Logs                | [ 2 år         ] | ingen        | 6m–10y         | |
+|  |                           |                  |              |        [Gem]   | |
+|  | Login/Security Logs       | [ 13 mdr       ] | ingen        | 3m–2y          | |
+|  |                           |                  |              |        [Gem]   | |
+|  | Inactive User Accounts    | [ 6 mdr        ] | ingen        | 1–24m          | |
+|  |                           |                  |              |        [Gem]   | |
+|  | Resident Anonym. Trigger  | [ 90 dage      ] | ingen        | 0–365d         | |
+|  |                           |                  |              |        [Gem]   | |
+|  +---------------------------+------------------+--------------+----------------+ |
+|                                                                                  |
+|  [Se politik-historik]  (åbner audit-log filtreret for denne entitetstype)       |
+|  [Tilbage til dashboard]                                                        |
++----------------------------------------------------------------------------------+
+```
+
+## Skærm 3 — Anonymiseringskø
+
+Overview layout (fra dashboard til denne skærm):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Anonymiseringskø                  Rolle: Admin    |
++----------------------------------------------------------------------------------+
+|  [Tilbage til dashboard]   Aktuel side: Anonymiseringskø                         |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Kø-tabel + handlinger:
+
+```text
++----------------------------------------------------------------------------------+
+|  Anonymiseringskø                                          Rolle: Admin         |
++----------------------------------------------------------------------------------+
+|  Filter:  [Alle kategorier ▼]                                                   |
+|                                                                                  |
+|  Kandidater                                                                       |
+|  +----------+------------------+----------------+--------------+----------------+ |
+|  | Beboer   | Kategori         | Begrundelse    | Senest aktiv | Handlinger     | |
+|  +----------+------------------+----------------+--------------+----------------+ |
+|  | AB       | Resident Notes   | Retention udl. | 2026-03-01   | [Godkend]      | |
+|  |          |                  |                |              | [Afvis]        | |
+|  |          |                  |                |              | [Udsæt]        | |
+|  |          |                  |                |              | [Påfør hold]   | |
+|  +----------+------------------+----------------+--------------+----------------+ |
+|                                                                                  |
+|  Tom tilstand (når ingen rækker):                                                |
+|  "Ingen afventende kandidater"                                                   |
+|                                                                                  |
+|  [Tilbage til dashboard]                                                        |
++----------------------------------------------------------------------------------+
+```
+
+Modal preview — Bekræft anonymisering:
+
+```text
++--------------------------------------------------------------+
+|  Bekræft handling                                             |
++--------------------------------------------------------------+
+|  Anonymisér beboer AB?                                        |
+|                                                              |
+|  Denne handling logges og kan ikke fortrydes for felter        |
+|  uden for Medicine Logs.                                      |
+|                                                              |
+|  [Bekræft]  [Annullér]                                        |
++--------------------------------------------------------------+
+```
+
+## Skærm 4 — Sikkerhedshændelser
+
+Overview layout (fra dashboard til denne skærm):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Sikkerhedshændelser              Rolle: Admin     |
++----------------------------------------------------------------------------------+
+|  [Tilbage til dashboard]   Aktuel side: Sikkerhedshændelser                      |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Liste + detaljepanel:
+
+```text
++----------------------------------------------------------------------------------+
+|  Sikkerhedshændelser                                      Rolle: Admin           |
++----------------------------------------------------------------------------------+
+|  Filtre:  [Alvorlighed ▼]  [Status ▼]  [Datointerval: ________ til ________]     |
+|                                                                                  |
+|  Hændelser                                                                        |
+|  +------+------------+------------------+----------+----------+---------+         |
+|  | ID   | Registreret| Type             | Alvorl.  | Status   | [Vis]   |         |
+|  +------+------------+------------------+----------+----------+---------+         |
+|  | INC1 | 2026-05-10 | Mistænkelig login| Høj      | Åben     | [Vis]   |         |
+|  +------+------------+------------------+----------+----------+---------+         |
+|                                                                                  |
+|  Valgt hændelse (detaljer)                                                       |
+|  ID: INC1      Registreret: 2026-05-10   Type: Mistænkelig login                 |
+|  Alvorlighed: Høj      Status: Åben                                            |
+|                                                                                  |
+|  Undersøgelsesnoter:                                                             |
+|  [                                                                            ]  |
+|  [                                                                            ]  |
+|  [                                                                            ]  |
+|                                                                                  |
+|  Handlinger:  [Luk]  [Eskalér]  [Underret brud (Art. 33)]                        |
+|                                                                                  |
+|  [Tilbage til dashboard]                                                        |
++----------------------------------------------------------------------------------+
+```
+
+Modal preview — Underret brud (Art. 33):
+
+```text
++--------------------------------------------------------------+
+|  Underret brud (Art. 33)                                     |
++--------------------------------------------------------------+
+|  Hændelse:    INC1                                           |
+|  Tidsstempel: 2026-05-11 10:30                                |
+|  Modtager:    dpo@slottet.local                               |
+|                                                              |
+|  [Bekræft underretning]  [Annullér]                            |
++--------------------------------------------------------------+
+```
+
+## Skærm 5 — Indsigtsanmodning (SAR)
+
+Overview layout (fra dashboard til denne skærm):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Indsigtsanmodning (SAR)           Rolle: Admin    |
++----------------------------------------------------------------------------------+
+|  [Tilbage til dashboard]   Aktuel side: Indsigtsanmodning (SAR)                   |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Søgning + eksport + afslutning:
+
+```text
++----------------------------------------------------------------------------------+
+|  Indsigtsanmodning (SAR)                                Rolle: Admin            |
++----------------------------------------------------------------------------------+
+|  Søg beboer                                                                       |
+|  Beboer-id:  [______________]   [Søg]                                             |
+|                                                                                  |
+|  Søgeresultat                                                                     |
+|  Beboer: AB (kun initialer)      Registreringsdato: 2024-01-12                    |
+|                                                                                  |
+|  Eksportvalg                                                                      |
+|  [✓] Resident Notes                                                               |
+|  [✓] Medicine Logs                                                                |
+|  [✓] Audit-log / revisionsspor                                                    |
+|  [✓] Telefon-tildelinger                                                          |
+|                                                                                  |
+|  [Generér eksport]  Fremdrift: [##########------]  60%                             |
+|                                                                                  |
+|  Downloads                                                                        |
+|  [Download .json]   [Download .pdf]                                               |
+|                                                                                  |
+|  Gennemgang + afslutning                                                          |
+|  [Markér som opfyldt]                                                             |
+|                                                                                  |
+|  [Tilbage til dashboard]                                                        |
++----------------------------------------------------------------------------------+
+```
+
+## Notes
+- Alle sider er kun for Admin og beskyttet af eksisterende UC-007 autentificering.
+- Alle handlinger, der ændrer tilstand, registreres via eksisterende UC-009 AuditInterceptor.
+- Beboer-id vises kun som initialer (REQ-DC-001 / GDPR dataminimering).
+- Anonymiseringskøen udfyldes asynkront af RetentionBackgroundService (ikke bruger-drevet).
+- Sikkerhedshændelser udfyldes asynkront af IncidentDetectionService.
+- Bekræftelsesmodaler kræves for destruktive handlinger (anonymisering, brud-underretning).
+- SAR-eksporter skal gennemgås før udlevering for at sikre dataminimering jf. GDPR Art. 12(3).

--- a/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.wireframe.md
+++ b/docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/uc-010.wireframe.md
@@ -1,0 +1,269 @@
+# Wireframe: UC-010 Ensure data security and GDPR compliance
+
+## Metadata
+| Key            | Value |
+|----------------|-------|
+| Id             | UC-010.Wireframe |
+| crossReference | UC-010 UC-010.UC UC-010.UserFlow |
+| Author         | Team 6 |
+| Version        | 0001 |
+| Date           | 2026-05-11 |
+
+## Version Log
+| Version | Date       | Description | Author |
+|---------|------------|-------------|--------|
+| 0001    | 2026-05-11 | Initial     | Team 6 |
+
+## Wireframe
+This wireframe covers the Admin-only GDPR Compliance Dashboard and its four sub-pages: Retention Settings,
+Anonymization Queue, Security Incidents, and Subject Access Request (SAR).
+
+## Overview — Navigation Map
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard                                      Role: Admin      |
++----------------------------------------------------------------------------------+
+|  [Retention Settings]   [Anonymization Queue]   [Security Incidents]   [SAR]     |
+|                                                                                  |
+|  Notes: Badges show current counts on the dashboard tiles.                        |
++----------------------------------------------------------------------------------+
+```
+
+## Screen 1 — GDPR Compliance Dashboard
+
+Overview layout (where this screen sits in navigation):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard                                      Role: Admin      |
++----------------------------------------------------------------------------------+
+|  Current page: GDPR Compliance Dashboard                                          |
+|  Tiles navigate to the four sub-pages                                             |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Landing page:
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard                                      Role: Admin      |
++----------------------------------------------------------------------------------+
+|  +----------------------+  +----------------------+  +----------------------+     |
+|  | Retention Settings   |  | Anonymization Queue  |  | Security Incidents   |     |
+|  | [Open]               |  | Pending:  [ 12 ]     |  | Open:     [  3 ]     |     |
+|  +----------------------+  +----------------------+  +----------------------+     |
+|                                                                                  |
+|  +----------------------+                                                         |
+|  | Subject Access Req.  |  (SAR)                                                  |
+|  | [Open]     [New SAR] |                                                         |
+|  +----------------------+                                                         |
+|                                                                                  |
+|  Status summary                                                                   |
+|  Last retention run:  2026-05-10 02:00                                            |
+|  Next scheduled run:  2026-05-12 02:00                                            |
++----------------------------------------------------------------------------------+
+```
+
+## Screen 2 — Retention Settings
+
+Overview layout (from dashboard to this screen):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Retention Settings                 Role: Admin    |
++----------------------------------------------------------------------------------+
+|  [Back to Dashboard]   Current page: Retention Settings                             |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Retention policies table:
+
+```text
++----------------------------------------------------------------------------------+
+|  Retention Settings                                            Role: Admin       |
++----------------------------------------------------------------------------------+
+|  WARNING: Changes are logged automatically. Medicine Logs are locked at 10 years |
+|  per Autorisationsloven §22.                                                      |
++----------------------------------------------------------------------------------+
+|  Policies                                                                         |
+|  +---------------------------+------------------+--------------+----------------+ |
+|  | Data Category             | Current Retention| Legal Minimum| Range          | |
+|  +---------------------------+------------------+--------------+----------------+ |
+|  | Medicine Logs             | 10 years (locked)| 10 years     | locked         | |
+|  |                           |                  |              |        [Save]  | |
+|  | Resident Notes            | [ 5 years      ] | none         | 1–30 years     | |
+|  |                           |                  |              |        [Save]  | |
+|  | Audit Logs                | [ 2 years      ] | none         | 6m–10y         | |
+|  |                           |                  |              |        [Save]  | |
+|  | Login/Security Logs       | [ 13 months    ] | none         | 3m–2y          | |
+|  |                           |                  |              |        [Save]  | |
+|  | Inactive User Accounts    | [ 6 months     ] | none         | 1–24m          | |
+|  |                           |                  |              |        [Save]  | |
+|  | Resident Anonym. Trigger  | [ 90 days      ] | none         | 0–365d         | |
+|  |                           |                  |              |        [Save]  | |
+|  +---------------------------+------------------+--------------+----------------+ |
+|                                                                                  |
+|  [View Policy History]  (opens audit log filtered for retention policy changes)  |
+|  [Back to Dashboard]                                                             |
++----------------------------------------------------------------------------------+
+```
+
+## Screen 3 — Anonymization Queue
+
+Overview layout (from dashboard to this screen):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Anonymization Queue               Role: Admin     |
++----------------------------------------------------------------------------------+
+|  [Back to Dashboard]   Current page: Anonymization Queue                           |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Queue table + actions:
+
+```text
++----------------------------------------------------------------------------------+
+|  Anonymization Queue                                         Role: Admin         |
++----------------------------------------------------------------------------------+
+|  Filter:  [All categories ▼]                                                      |
+|                                                                                  |
+|  Candidates                                                                       |
+|  +----------+------------------+----------------+--------------+----------------+ |
+|  | Resident | Category         | Reason         | Last Activity| Actions        | |
+|  +----------+------------------+----------------+--------------+----------------+ |
+|  | AB       | Resident Notes   | Retention exp. | 2026-03-01   | [Approve]      | |
+|  |          |                  |                |              | [Reject]       | |
+|  |          |                  |                |              | [Postpone]     | |
+|  |          |                  |                |              | [Apply Hold]   | |
+|  +----------+------------------+----------------+--------------+----------------+ |
+|                                                                                  |
+|  Empty state (when no rows):                                                     |
+|  "No pending candidates"                                                         |
+|                                                                                  |
+|  [Back to Dashboard]                                                             |
++----------------------------------------------------------------------------------+
+```
+
+Modal preview — Confirm anonymization:
+
+```text
++--------------------------------------------------------------+
+|  Confirm action                                               |
++--------------------------------------------------------------+
+|  Anonymize resident AB?                                       |
+|                                                              |
+|  This action is logged and cannot be undone for fields        |
+|  outside Medicine Logs.                                       |
+|                                                              |
+|  [Confirm]  [Cancel]                                          |
++--------------------------------------------------------------+
+```
+
+## Screen 4 — Security Incidents
+
+Overview layout (from dashboard to this screen):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Security Incidents               Role: Admin      |
++----------------------------------------------------------------------------------+
+|  [Back to Dashboard]   Current page: Security Incidents                           |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — List + detail panel:
+
+```text
++----------------------------------------------------------------------------------+
+|  Security Incidents                                         Role: Admin          |
++----------------------------------------------------------------------------------+
+|  Filters:  [Severity ▼]  [Status ▼]  [Date range: ________ to ________]          |
+|                                                                                  |
+|  Incidents                                                                        |
+|  +------+------------+------------------+----------+----------+---------+         |
+|  | ID   | Detected   | Type             | Severity | Status   | [View]  |         |
+|  +------+------------+------------------+----------+----------+---------+         |
+|  | INC1 | 2026-05-10 | Suspicious login | High     | Open     | [View]  |         |
+|  +------+------------+------------------+----------+----------+---------+         |
+|                                                                                  |
+|  Selected incident (detail)                                                      |
+|  ID: INC1      Detected: 2026-05-10     Type: Suspicious login                   |
+|  Severity: High      Status: Open                                              |
+|                                                                                  |
+|  Investigation notes:                                                            |
+|  [                                                                            ]  |
+|  [                                                                            ]  |
+|  [                                                                            ]  |
+|                                                                                  |
+|  Actions:  [Close]  [Escalate]  [Notify Breach (Art. 33)]                        |
+|                                                                                  |
+|  [Back to Dashboard]                                                             |
++----------------------------------------------------------------------------------+
+```
+
+Modal preview — Notify breach (Art. 33):
+
+```text
++--------------------------------------------------------------+
+|  Notify breach (Art. 33)                                     |
++--------------------------------------------------------------+
+|  Incident:   INC1                                            |
+|  Timestamp:  2026-05-11 10:30                                 |
+|  Recipient:  dpo@slottet.local                                |
+|                                                              |
+|  [Confirm notification]  [Cancel]                             |
++--------------------------------------------------------------+
+```
+
+## Screen 5 — Subject Access Request (SAR)
+
+Overview layout (from dashboard to this screen):
+
+```text
++----------------------------------------------------------------------------------+
+|  GDPR Compliance Dashboard  >  Subject Access Request (SAR)     Role: Admin      |
++----------------------------------------------------------------------------------+
+|  [Back to Dashboard]   Current page: Subject Access Request (SAR)                  |
++----------------------------------------------------------------------------------+
+```
+
+Detail layout — Search + export + fulfillment:
+
+```text
++----------------------------------------------------------------------------------+
+|  Subject Access Request (SAR)                               Role: Admin          |
++----------------------------------------------------------------------------------+
+|  Search resident                                                                   |
+|  Resident identifier:  [______________]   [Search]                                 |
+|                                                                                  |
+|  Search result                                                                    |
+|  Resident: AB (initials only)      Registration date: 2024-01-12                  |
+|                                                                                  |
+|  Export options                                                                    |
+|  [✓] Resident Notes                                                               |
+|  [✓] Medicine Logs                                                                |
+|  [✓] Audit Trail                                                                  |
+|  [✓] Phone Assignments                                                            |
+|                                                                                  |
+|  [Generate Export]   Progress:  [##########------]  60%                            |
+|                                                                                  |
+|  Downloads                                                                        |
+|  [Download .json]   [Download .pdf]                                               |
+|                                                                                  |
+|  Review + completion                                                              |
+|  [Mark as Fulfilled]                                                              |
+|                                                                                  |
+|  [Back to Dashboard]                                                             |
++----------------------------------------------------------------------------------+
+```
+
+## Notes
+- All pages are Admin-only and protected by existing UC-007 authentication.
+- All state-changing actions are recorded via existing UC-009 AuditInterceptor.
+- Resident identifiers shown as initials only (REQ-DC-001 / GDPR data minimization).
+- The Anonymization Queue is populated asynchronously by RetentionBackgroundService (not user-driven).
+- Security Incidents are populated asynchronously by IncidentDetectionService.
+- Confirmation modals are required for destructive actions (anonymization, breach notification).
+- SAR exports must be reviewed before delivery to ensure data minimization per GDPR Art. 12(3).

--- a/src/Api/BackgroundServices/IncidentDetectionService.cs
+++ b/src/Api/BackgroundServices/IncidentDetectionService.cs
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.Interfaces.Repositories;
+
+namespace Api.BackgroundServices;
+
+/// <summary>
+/// Periodically scans audit logs for suspicious patterns (failed logins, mass exports,
+/// off-hours access) and creates SecurityIncident records for Admin review (UC-010).
+/// </summary>
+/// <remarks>
+/// Runs every 15 minutes by default. Detected incidents enter the SecurityIncident
+/// queue with Status=Open and require manual Admin investigation.
+/// </remarks>
+public class IncidentDetectionService : BackgroundService
+{
+    #region Fields
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<IncidentDetectionService> _logger;
+    private readonly TimeSpan _interval = TimeSpan.FromMinutes(15);
+
+    #endregion
+
+    #region Constructors
+
+    public IncidentDetectionService(
+        IServiceProvider serviceProvider,
+        ILogger<IncidentDetectionService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(logger);
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    #endregion
+
+    #region Methods
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("IncidentDetectionService started.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await DetectIncidentsAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in incident detection loop.");
+            }
+
+            await Task.Delay(_interval, stoppingToken);
+        }
+
+        _logger.LogInformation("IncidentDetectionService stopped.");
+    }
+
+    /// <summary>
+    /// Scans audit entries for suspicious patterns and creates SecurityIncident records.
+    /// </summary>
+    /// <remarks>
+    /// STUB: production should evaluate audit entries for failed logins, mass exports,
+    /// off-hours admin access, etc. For now logs the scan for traceability.
+    /// </remarks>
+    private Task DetectIncidentsAsync(CancellationToken cancellationToken)
+    {
+        using IServiceScope scope = _serviceProvider.CreateScope();
+        ISecurityIncidentRepository repository = scope.ServiceProvider.GetRequiredService<ISecurityIncidentRepository>();
+
+        _logger.LogInformation("Incident detection scan completed at {Timestamp}.", DateTime.UtcNow);
+        return Task.CompletedTask;
+    }
+
+    #endregion
+}

--- a/src/Api/BackgroundServices/RetentionBackgroundService.cs
+++ b/src/Api/BackgroundServices/RetentionBackgroundService.cs
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.Interfaces.Repositories;
+
+using Domain.Entities;
+using Domain.Enums;
+
+namespace Api.BackgroundServices;
+
+/// <summary>
+/// Periodically scans for residents whose data has exceeded its retention period
+/// and creates AnonymizationCandidate records for Admin review (UC-010).
+/// </summary>
+/// <remarks>
+/// Runs once every 24 hours by default. Does NOT anonymize data directly —
+/// always requires Admin approval through the Anonymization Queue.
+/// </remarks>
+public class RetentionBackgroundService : BackgroundService
+{
+    #region Fields
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<RetentionBackgroundService> _logger;
+    private readonly TimeSpan _interval = TimeSpan.FromHours(24);
+
+    #endregion
+
+    #region Constructors
+
+    public RetentionBackgroundService(
+        IServiceProvider serviceProvider,
+        ILogger<RetentionBackgroundService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(logger);
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    #endregion
+
+    #region Methods
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("RetentionBackgroundService started.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ScanForCandidatesAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in retention scan loop.");
+            }
+
+            await Task.Delay(_interval, stoppingToken);
+        }
+
+        _logger.LogInformation("RetentionBackgroundService stopped.");
+    }
+
+    /// <summary>
+    /// Scans residents against retention policies and creates pending anonymization candidates.
+    /// </summary>
+    /// <remarks>
+    /// STUB: production should evaluate per-resident inactivity against retention periods
+    /// and add AnonymizationCandidate entries via repository. For now logs the scan for traceability.
+    /// </remarks>
+    private async Task ScanForCandidatesAsync(CancellationToken cancellationToken)
+    {
+        using IServiceScope scope = _serviceProvider.CreateScope();
+        IRetentionPolicyRepository repository = scope.ServiceProvider.GetRequiredService<IRetentionPolicyRepository>();
+
+        IEnumerable<RetentionPolicy> policies = await repository.GetAllAsync(cancellationToken);
+        _logger.LogInformation(
+            "Retention scan completed. Loaded {Count} active retention policies.",
+            policies.Count());
+    }
+
+    #endregion
+}

--- a/src/Core/DTOs/Anonymization/AnonymizationCandidateDto.cs
+++ b/src/Core/DTOs/Anonymization/AnonymizationCandidateDto.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Domain.Enums;
+
+namespace Core.DTOs.Anonymization;
+
+/// <summary>
+/// Data transfer object representing an anonymization candidate awaiting review (UC-010).
+/// </summary>
+public class AnonymizationCandidateDto
+{
+    public Guid Id { get; set; }
+    public Guid ResidentId { get; set; }
+    public Guid RetentionPolicyId { get; set; }
+    public DateTime SuggestedAt { get; set; }
+    public string Reason { get; set; } = string.Empty;
+    public AnonymizationStatus Status { get; set; }
+}

--- a/src/Core/DTOs/Anonymization/AnonymizationResultDto.cs
+++ b/src/Core/DTOs/Anonymization/AnonymizationResultDto.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+namespace Core.DTOs.Anonymization;
+
+/// <summary>
+/// Result of an anonymization operation (UC-010).
+/// </summary>
+public class AnonymizationResultDto
+{
+    public Guid CandidateId { get; set; }
+    public DateTime CompletedAt { get; set; }
+    public string Outcome { get; set; } = string.Empty;
+}

--- a/src/Core/DTOs/Anonymization/ApproveAnonymizationDto.cs
+++ b/src/Core/DTOs/Anonymization/ApproveAnonymizationDto.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+namespace Core.DTOs.Anonymization;
+
+/// <summary>
+/// Request payload for approving anonymization of a candidate (UC-010).
+/// </summary>
+public class ApproveAnonymizationDto
+{
+    public Guid CandidateId { get; set; }
+}

--- a/src/Core/DTOs/Retention/RetentionPolicyAuditDto.cs
+++ b/src/Core/DTOs/Retention/RetentionPolicyAuditDto.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+namespace Core.DTOs.Retention;
+
+/// <summary>
+/// Audit record of a retention policy change (UC-010).
+/// </summary>
+public class RetentionPolicyAuditDto
+{
+    public Guid Id { get; set; }
+    public Guid RetentionPolicyId { get; set; }
+    public Guid ChangedByEmployeeId { get; set; }
+    public TimeSpan PreviousPeriod { get; set; }
+    public TimeSpan NewPeriod { get; set; }
+    public DateTime ChangedAt { get; set; }
+    public string Reason { get; set; } = string.Empty;
+}

--- a/src/Core/DTOs/Retention/RetentionPolicyDto.cs
+++ b/src/Core/DTOs/Retention/RetentionPolicyDto.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Domain.Enums;
+
+namespace Core.DTOs.Retention;
+
+/// <summary>
+/// Data transfer object representing a GDPR retention policy (UC-010).
+/// </summary>
+public class RetentionPolicyDto
+{
+    public Guid Id { get; set; }
+    public RetentionDataCategory Category { get; set; }
+    public TimeSpan RetentionPeriod { get; set; }
+    public TimeSpan LegalMinimum { get; set; }
+    public DateTime EffectiveFrom { get; set; }
+}

--- a/src/Core/DTOs/Retention/UpdateRetentionPolicyDto.cs
+++ b/src/Core/DTOs/Retention/UpdateRetentionPolicyDto.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Domain.Enums;
+
+namespace Core.DTOs.Retention;
+
+/// <summary>
+/// Request payload for updating a retention policy (UC-010).
+/// </summary>
+public class UpdateRetentionPolicyDto
+{
+    public RetentionDataCategory Category { get; set; }
+    public TimeSpan RetentionPeriod { get; set; }
+    public string Reason { get; set; } = string.Empty;
+}

--- a/src/Core/DTOs/Sar/SarExportPackageDto.cs
+++ b/src/Core/DTOs/Sar/SarExportPackageDto.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+namespace Core.DTOs.Sar;
+
+/// <summary>
+/// Generated SAR export package metadata (UC-010, GDPR Art. 15).
+/// </summary>
+public class SarExportPackageDto
+{
+    public Guid ExportId { get; set; }
+    public DateTime GeneratedAt { get; set; }
+    public string FileName { get; set; } = string.Empty;
+}

--- a/src/Core/DTOs/Sar/SarExportRequestDto.cs
+++ b/src/Core/DTOs/Sar/SarExportRequestDto.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+namespace Core.DTOs.Sar;
+
+/// <summary>
+/// Request payload for generating a GDPR Subject Access Request export (Art. 15).
+/// </summary>
+public class SarExportRequestDto
+{
+    public Guid ResidentId { get; set; }
+    public string[] ScopeOptions { get; set; } = [];
+}

--- a/src/Core/DTOs/Sar/SarFulfilledDto.cs
+++ b/src/Core/DTOs/Sar/SarFulfilledDto.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+namespace Core.DTOs.Sar;
+
+/// <summary>
+/// Marks a SAR as fulfilled with audit timestamp (UC-010).
+/// </summary>
+public class SarFulfilledDto
+{
+    public Guid SarId { get; set; }
+    public DateTime FulfilledAt { get; set; }
+}

--- a/src/Core/DTOs/Security/AddInvestigationNotesDto.cs
+++ b/src/Core/DTOs/Security/AddInvestigationNotesDto.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+namespace Core.DTOs.Security;
+
+/// <summary>
+/// Request payload for appending investigation notes to a security incident (UC-010).
+/// </summary>
+public class AddInvestigationNotesDto
+{
+    public Guid IncidentId { get; set; }
+    public string Notes { get; set; } = string.Empty;
+}

--- a/src/Core/DTOs/Security/EscalateIncidentDto.cs
+++ b/src/Core/DTOs/Security/EscalateIncidentDto.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+namespace Core.DTOs.Security;
+
+/// <summary>
+/// Request payload for escalating a security incident (UC-010).
+/// Setting IsBreach=true triggers GDPR Art. 33 notification to the DPO.
+/// </summary>
+public class EscalateIncidentDto
+{
+    public Guid IncidentId { get; set; }
+    public bool IsBreach { get; set; }
+}

--- a/src/Core/DTOs/Security/SecurityIncidentDto.cs
+++ b/src/Core/DTOs/Security/SecurityIncidentDto.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Domain.Enums;
+
+namespace Core.DTOs.Security;
+
+/// <summary>
+/// Data transfer object representing a detected security incident (UC-010).
+/// </summary>
+public class SecurityIncidentDto
+{
+    public Guid Id { get; set; }
+    public DateTime DetectedAt { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public IncidentSeverity Severity { get; set; }
+    public IncidentStatus Status { get; set; }
+    public string InvestigationNotes { get; set; } = string.Empty;
+}

--- a/src/Core/DependencyInjection.cs
+++ b/src/Core/DependencyInjection.cs
@@ -31,6 +31,13 @@ public static class DependencyInjection
         // Register the DatabaseConnectionStateProvider as a singleton to maintain a single instance across the application
         _ = services.AddSingleton<IDatabaseConnectionStateProvider, DatabaseConnectionStateProvider>();
 
+
+        // UC-010 GDPR compliance services
+        _ = services.AddScoped<IRetentionPolicyService, RetentionPolicyService>();
+        _ = services.AddScoped<IAnonymizationService, AnonymizationService>();
+        _ = services.AddScoped<ISecurityIncidentService, SecurityIncidentService>();
+        _ = services.AddScoped<ISubjectAccessRequestService, SubjectAccessRequestService>();
+        _ = services.AddScoped<IArt33NotificationService, Art33NotificationService>();
         return services;
     }
 }

--- a/src/Core/Interfaces/Managers/IAnonymizationManager.cs
+++ b/src/Core/Interfaces/Managers/IAnonymizationManager.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Anonymization;
+
+namespace Core.Interfaces.Managers;
+
+/// <summary>
+/// Defines a contract for managing anonymization candidates (UC-010).
+/// </summary>
+public interface IAnonymizationManager
+{
+    Task<IEnumerable<AnonymizationCandidateDto>> GetCandidatesAsync(CancellationToken cancellationToken);
+    Task<AnonymizationResultDto> ApproveAnonymizationAsync(Guid candidateId, CancellationToken cancellationToken);
+    Task<bool> RejectAnonymizationAsync(Guid candidateId, string reason, CancellationToken cancellationToken);
+}

--- a/src/Core/Interfaces/Managers/IRetentionPolicyManager.cs
+++ b/src/Core/Interfaces/Managers/IRetentionPolicyManager.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Retention;
+
+namespace Core.Interfaces.Managers;
+
+/// <summary>
+/// Defines a contract for managing retention policies (UC-010).
+/// </summary>
+public interface IRetentionPolicyManager
+{
+    Task<IEnumerable<RetentionPolicyDto>> GetPoliciesAsync(CancellationToken cancellationToken);
+    Task<RetentionPolicyDto> UpdateRetentionPolicyAsync(UpdateRetentionPolicyDto dto, Guid changedByEmployeeId, CancellationToken cancellationToken);
+}

--- a/src/Core/Interfaces/Managers/ISecurityIncidentManager.cs
+++ b/src/Core/Interfaces/Managers/ISecurityIncidentManager.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Security;
+
+namespace Core.Interfaces.Managers;
+
+/// <summary>
+/// Defines a contract for managing security incidents (UC-010).
+/// </summary>
+public interface ISecurityIncidentManager
+{
+    Task<IEnumerable<SecurityIncidentDto>> GetIncidentsAsync(CancellationToken cancellationToken);
+    Task<SecurityIncidentDto> EscalateIncidentAsync(Guid incidentId, bool isBreach, CancellationToken cancellationToken);
+    Task<SecurityIncidentDto> AddInvestigationNotesAsync(AddInvestigationNotesDto dto, CancellationToken cancellationToken);
+    Task<SecurityIncidentDto> CloseIncidentAsync(Guid incidentId, CancellationToken cancellationToken);
+}

--- a/src/Core/Interfaces/Managers/ISubjectAccessRequestManager.cs
+++ b/src/Core/Interfaces/Managers/ISubjectAccessRequestManager.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Sar;
+
+namespace Core.Interfaces.Managers;
+
+/// <summary>
+/// Defines a contract for managing GDPR Subject Access Requests (UC-010, Art. 15).
+/// </summary>
+public interface ISubjectAccessRequestManager
+{
+    Task<SarExportPackageDto> GenerateExportAsync(SarExportRequestDto dto, CancellationToken cancellationToken);
+    Task<bool> MarkFulfilledAsync(SarFulfilledDto dto, CancellationToken cancellationToken);
+}

--- a/src/Core/Interfaces/Repositories/IAnonymizationCandidateRepository.cs
+++ b/src/Core/Interfaces/Repositories/IAnonymizationCandidateRepository.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Domain.Entities;
+
+namespace Core.Interfaces.Repositories;
+
+/// <summary>
+/// Defines a contract for repository operations specific to <see cref="AnonymizationCandidate"/> entities (UC-010).
+/// </summary>
+public interface IAnonymizationCandidateRepository : IRepository<AnonymizationCandidate>
+{
+}

--- a/src/Core/Interfaces/Repositories/IRetentionPolicyRepository.cs
+++ b/src/Core/Interfaces/Repositories/IRetentionPolicyRepository.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Domain.Entities;
+
+namespace Core.Interfaces.Repositories;
+
+/// <summary>
+/// Defines a contract for repository operations specific to <see cref="RetentionPolicy"/> entities (UC-010).
+/// </summary>
+public interface IRetentionPolicyRepository : IRepository<RetentionPolicy>
+{
+}

--- a/src/Core/Interfaces/Repositories/ISecurityIncidentRepository.cs
+++ b/src/Core/Interfaces/Repositories/ISecurityIncidentRepository.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Domain.Entities;
+
+namespace Core.Interfaces.Repositories;
+
+/// <summary>
+/// Defines a contract for repository operations specific to <see cref="SecurityIncident"/> entities (UC-010).
+/// </summary>
+public interface ISecurityIncidentRepository : IRepository<SecurityIncident>
+{
+}

--- a/src/Core/Interfaces/Services/IAnonymizationService.cs
+++ b/src/Core/Interfaces/Services/IAnonymizationService.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Anonymization;
+
+namespace Core.Interfaces.Services;
+
+/// <summary>
+/// Defines a contract for the anonymization service (UC-010).
+/// </summary>
+public interface IAnonymizationService
+{
+    Task<IEnumerable<AnonymizationCandidateDto>> GetCandidatesAsync(CancellationToken cancellationToken);
+    Task<AnonymizationResultDto> ApproveAnonymizationAsync(Guid candidateId, CancellationToken cancellationToken);
+    Task<bool> RejectAnonymizationAsync(Guid candidateId, string reason, CancellationToken cancellationToken);
+}

--- a/src/Core/Interfaces/Services/IArt33NotificationService.cs
+++ b/src/Core/Interfaces/Services/IArt33NotificationService.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+namespace Core.Interfaces.Services;
+
+/// <summary>
+/// Defines a contract for sending GDPR Article 33 breach notifications to the DPO (UC-010).
+/// </summary>
+/// <remarks>
+/// Implementation lives in Infrastructure layer (SMTP-based notification).
+/// </remarks>
+public interface IArt33NotificationService
+{
+    Task<bool> SendNotificationAsync(Guid incidentId, string dpoEmail, CancellationToken cancellationToken);
+}

--- a/src/Core/Interfaces/Services/IRetentionPolicyService.cs
+++ b/src/Core/Interfaces/Services/IRetentionPolicyService.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Retention;
+
+namespace Core.Interfaces.Services;
+
+/// <summary>
+/// Defines a contract for the retention policy service (UC-010).
+/// </summary>
+public interface IRetentionPolicyService
+{
+    Task<IEnumerable<RetentionPolicyDto>> GetPoliciesAsync(CancellationToken cancellationToken);
+    Task<RetentionPolicyDto> UpdateRetentionPolicyAsync(UpdateRetentionPolicyDto dto, Guid changedByEmployeeId, CancellationToken cancellationToken);
+}

--- a/src/Core/Interfaces/Services/ISecurityIncidentService.cs
+++ b/src/Core/Interfaces/Services/ISecurityIncidentService.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Security;
+
+namespace Core.Interfaces.Services;
+
+/// <summary>
+/// Defines a contract for the security incident service (UC-010).
+/// </summary>
+public interface ISecurityIncidentService
+{
+    Task<IEnumerable<SecurityIncidentDto>> GetIncidentsAsync(CancellationToken cancellationToken);
+    Task<SecurityIncidentDto> EscalateIncidentAsync(Guid incidentId, bool isBreach, CancellationToken cancellationToken);
+    Task<SecurityIncidentDto> AddInvestigationNotesAsync(AddInvestigationNotesDto dto, CancellationToken cancellationToken);
+    Task<SecurityIncidentDto> CloseIncidentAsync(Guid incidentId, CancellationToken cancellationToken);
+}

--- a/src/Core/Interfaces/Services/ISubjectAccessRequestService.cs
+++ b/src/Core/Interfaces/Services/ISubjectAccessRequestService.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Sar;
+
+namespace Core.Interfaces.Services;
+
+/// <summary>
+/// Defines a contract for the GDPR Subject Access Request service (UC-010, Art. 15).
+/// </summary>
+public interface ISubjectAccessRequestService
+{
+    Task<SarExportPackageDto> GenerateExportAsync(SarExportRequestDto dto, CancellationToken cancellationToken);
+    Task<bool> MarkFulfilledAsync(SarFulfilledDto dto, CancellationToken cancellationToken);
+}

--- a/src/Core/Mappers/AnonymizationCandidateMapper.cs
+++ b/src/Core/Mappers/AnonymizationCandidateMapper.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Anonymization;
+
+using Domain.Entities;
+
+namespace Core.Mappers;
+
+/// <summary>
+/// Static mapper between <see cref="AnonymizationCandidate"/> entities and DTOs (UC-010).
+/// </summary>
+public static class AnonymizationCandidateMapper
+{
+    public static AnonymizationCandidateDto ToDto(AnonymizationCandidate entity) => new()
+    {
+        Id = entity.Id,
+        ResidentId = entity.ResidentId,
+        RetentionPolicyId = entity.RetentionPolicyId,
+        SuggestedAt = entity.SuggestedAt,
+        Reason = entity.Reason,
+        Status = entity.Status
+    };
+}

--- a/src/Core/Mappers/RetentionPolicyMapper.cs
+++ b/src/Core/Mappers/RetentionPolicyMapper.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Retention;
+
+using Domain.Entities;
+
+namespace Core.Mappers;
+
+/// <summary>
+/// Static mapper between <see cref="RetentionPolicy"/> entities and DTOs (UC-010).
+/// </summary>
+public static class RetentionPolicyMapper
+{
+    public static RetentionPolicyDto ToDto(RetentionPolicy entity) => new()
+    {
+        Id = entity.Id,
+        Category = entity.Category,
+        RetentionPeriod = entity.RetentionPeriod,
+        LegalMinimum = entity.LegalMinimum,
+        EffectiveFrom = entity.EffectiveFrom
+    };
+
+    public static RetentionPolicyAuditDto ToAuditDto(RetentionPolicyAudit entity) => new()
+    {
+        Id = entity.Id,
+        RetentionPolicyId = entity.RetentionPolicyId,
+        ChangedByEmployeeId = entity.ChangedByEmployeeId,
+        PreviousPeriod = entity.PreviousPeriod,
+        NewPeriod = entity.NewPeriod,
+        ChangedAt = entity.ChangedAt,
+        Reason = entity.Reason
+    };
+}

--- a/src/Core/Mappers/SarExportMapper.cs
+++ b/src/Core/Mappers/SarExportMapper.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Sar;
+
+namespace Core.Mappers;
+
+/// <summary>
+/// Static mapper for assembling SAR export package DTOs (UC-010, GDPR Art. 15).
+/// </summary>
+/// <remarks>
+/// SAR exports aggregate data from multiple sources; the package metadata DTO is built
+/// from the export ID, generation timestamp, and file name produced by the manager.
+/// </remarks>
+public static class SarExportMapper
+{
+    public static SarExportPackageDto ToPackageDto(Guid exportId, DateTime generatedAt, string fileName) => new()
+    {
+        ExportId = exportId,
+        GeneratedAt = generatedAt,
+        FileName = fileName
+    };
+}

--- a/src/Core/Mappers/SecurityIncidentMapper.cs
+++ b/src/Core/Mappers/SecurityIncidentMapper.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Security;
+
+using Domain.Entities;
+
+namespace Core.Mappers;
+
+/// <summary>
+/// Static mapper between <see cref="SecurityIncident"/> entities and DTOs (UC-010).
+/// </summary>
+public static class SecurityIncidentMapper
+{
+    public static SecurityIncidentDto ToDto(SecurityIncident entity) => new()
+    {
+        Id = entity.Id,
+        DetectedAt = entity.DetectedAt,
+        Type = entity.Type,
+        Severity = entity.Severity,
+        Status = entity.Status,
+        InvestigationNotes = entity.InvestigationNotes
+    };
+}

--- a/src/Core/Services/AnonymizationService.cs
+++ b/src/Core/Services/AnonymizationService.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Anonymization;
+using Core.Interfaces.Managers;
+using Core.Interfaces.Services;
+
+namespace Core.Services;
+
+/// <summary>
+/// Service for managing GDPR anonymization candidates (UC-010).
+/// </summary>
+/// <remarks>
+/// MedicineLogs are pseudonymized rather than fully anonymized per Autorisationsloven §22.
+/// </remarks>
+public class AnonymizationService : IAnonymizationService
+{
+    private readonly IAnonymizationManager _anonymizationManager;
+
+    public AnonymizationService(IAnonymizationManager anonymizationManager)
+    {
+        ArgumentNullException.ThrowIfNull(anonymizationManager);
+        _anonymizationManager = anonymizationManager;
+    }
+
+    public Task<IEnumerable<AnonymizationCandidateDto>> GetCandidatesAsync(CancellationToken cancellationToken)
+        => _anonymizationManager.GetCandidatesAsync(cancellationToken);
+
+    public Task<AnonymizationResultDto> ApproveAnonymizationAsync(Guid candidateId, CancellationToken cancellationToken)
+        => _anonymizationManager.ApproveAnonymizationAsync(candidateId, cancellationToken);
+
+    public Task<bool> RejectAnonymizationAsync(Guid candidateId, string reason, CancellationToken cancellationToken)
+        => _anonymizationManager.RejectAnonymizationAsync(candidateId, reason, cancellationToken);
+}

--- a/src/Core/Services/Art33NotificationService.cs
+++ b/src/Core/Services/Art33NotificationService.cs
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.Interfaces.Services;
+
+using Microsoft.Extensions.Logging;
+
+namespace Core.Services;
+
+/// <summary>
+/// Stub implementation of GDPR Article 33 breach notification to the DPO (UC-010).
+/// </summary>
+/// <remarks>
+/// Logs the notification event to ILogger. Audit trail of the corresponding
+/// SecurityIncident state change (Status → BreachNotified) is captured automatically
+/// by the AuditInterceptor when the SecurityIncident entity is updated via SaveChanges.
+/// 
+/// Production implementation should send actual email via SMTP (MailKit) — to be added in a follow-up branch.
+/// </remarks>
+public class Art33NotificationService : IArt33NotificationService
+{
+    #region Fields
+
+    private readonly ILogger<Art33NotificationService> _logger;
+
+    #endregion
+
+    #region Constructors
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Art33NotificationService"/> class.
+    /// </summary>
+    /// <param name="logger">Logger for breach notification events.</param>
+    /// <exception cref="ArgumentNullException">The <paramref name="logger"/> parameter is <see langword="null"/>.</exception>
+    public Art33NotificationService(ILogger<Art33NotificationService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
+    }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Sends an Art. 33 breach notification to the Data Protection Officer.
+    /// </summary>
+    /// <param name="incidentId">The unique identifier of the security incident being notified.</param>
+    /// <param name="dpoEmail">The DPO's email address.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns><see langword="true"/> if the notification was logged successfully; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// Current stub logs to ILogger only. Production SMTP implementation pending.
+    /// </remarks>
+    public Task<bool> SendNotificationAsync(Guid incidentId, string dpoEmail, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(dpoEmail))
+        {
+            _logger.LogError(
+                "Cannot send Art. 33 notification for incident {IncidentId}: DPO email is missing.",
+                incidentId);
+            return Task.FromResult(false);
+        }
+
+        // STUB: production should send via SMTP (e.g., MailKit).
+        // The SecurityIncident status change to BreachNotified is automatically
+        // captured by AuditInterceptor for Datatilsynet traceability (UC-009).
+        _logger.LogWarning(
+            "GDPR Art. 33 BREACH NOTIFICATION (STUB) — Incident: {IncidentId}, DPO: {DpoEmail}, Timestamp: {Timestamp}",
+            incidentId, dpoEmail, DateTime.UtcNow);
+
+        return Task.FromResult(true);
+    }
+
+    #endregion
+}

--- a/src/Core/Services/RetentionPolicyService.cs
+++ b/src/Core/Services/RetentionPolicyService.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Retention;
+using Core.Interfaces.Managers;
+using Core.Interfaces.Services;
+
+namespace Core.Services;
+
+/// <summary>
+/// Service for managing GDPR retention policies (UC-010).
+/// </summary>
+/// <remarks>
+/// Delegates all operations to the injected <see cref="IRetentionPolicyManager"/>.
+/// Manager handles legal-minimum validation (e.g., Autorisationsloven §22 for MedicineLogs).
+/// </remarks>
+public class RetentionPolicyService : IRetentionPolicyService
+{
+    private readonly IRetentionPolicyManager _retentionPolicyManager;
+
+    public RetentionPolicyService(IRetentionPolicyManager retentionPolicyManager)
+    {
+        ArgumentNullException.ThrowIfNull(retentionPolicyManager);
+        _retentionPolicyManager = retentionPolicyManager;
+    }
+
+    public Task<IEnumerable<RetentionPolicyDto>> GetPoliciesAsync(CancellationToken cancellationToken)
+        => _retentionPolicyManager.GetPoliciesAsync(cancellationToken);
+
+    public Task<RetentionPolicyDto> UpdateRetentionPolicyAsync(
+        UpdateRetentionPolicyDto dto,
+        Guid changedByEmployeeId,
+        CancellationToken cancellationToken)
+        => _retentionPolicyManager.UpdateRetentionPolicyAsync(dto, changedByEmployeeId, cancellationToken);
+}

--- a/src/Core/Services/SecurityIncidentService.cs
+++ b/src/Core/Services/SecurityIncidentService.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Security;
+using Core.Interfaces.Managers;
+using Core.Interfaces.Services;
+
+namespace Core.Services;
+
+/// <summary>
+/// Service for managing security incidents (UC-010).
+/// </summary>
+/// <remarks>
+/// Escalation with isBreach=true triggers GDPR Art. 33 notification flow via <see cref="IArt33NotificationService"/>.
+/// </remarks>
+public class SecurityIncidentService : ISecurityIncidentService
+{
+    private readonly ISecurityIncidentManager _securityIncidentManager;
+    private readonly IArt33NotificationService _art33NotificationService;
+
+    public SecurityIncidentService(
+        ISecurityIncidentManager securityIncidentManager,
+        IArt33NotificationService art33NotificationService)
+    {
+        ArgumentNullException.ThrowIfNull(securityIncidentManager);
+        ArgumentNullException.ThrowIfNull(art33NotificationService);
+        _securityIncidentManager = securityIncidentManager;
+        _art33NotificationService = art33NotificationService;
+    }
+
+    public Task<IEnumerable<SecurityIncidentDto>> GetIncidentsAsync(CancellationToken cancellationToken)
+        => _securityIncidentManager.GetIncidentsAsync(cancellationToken);
+
+    public Task<SecurityIncidentDto> EscalateIncidentAsync(Guid incidentId, bool isBreach, CancellationToken cancellationToken)
+        => _securityIncidentManager.EscalateIncidentAsync(incidentId, isBreach, cancellationToken);
+
+    public Task<SecurityIncidentDto> AddInvestigationNotesAsync(AddInvestigationNotesDto dto, CancellationToken cancellationToken)
+        => _securityIncidentManager.AddInvestigationNotesAsync(dto, cancellationToken);
+
+    public Task<SecurityIncidentDto> CloseIncidentAsync(Guid incidentId, CancellationToken cancellationToken)
+        => _securityIncidentManager.CloseIncidentAsync(incidentId, cancellationToken);
+}

--- a/src/Core/Services/SubjectAccessRequestService.cs
+++ b/src/Core/Services/SubjectAccessRequestService.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Sar;
+using Core.Interfaces.Managers;
+using Core.Interfaces.Services;
+
+namespace Core.Services;
+
+/// <summary>
+/// Service for handling GDPR Subject Access Requests (UC-010, Art. 15).
+/// </summary>
+public class SubjectAccessRequestService : ISubjectAccessRequestService
+{
+    private readonly ISubjectAccessRequestManager _subjectAccessRequestManager;
+
+    public SubjectAccessRequestService(ISubjectAccessRequestManager subjectAccessRequestManager)
+    {
+        ArgumentNullException.ThrowIfNull(subjectAccessRequestManager);
+        _subjectAccessRequestManager = subjectAccessRequestManager;
+    }
+
+    public Task<SarExportPackageDto> GenerateExportAsync(SarExportRequestDto dto, CancellationToken cancellationToken)
+        => _subjectAccessRequestManager.GenerateExportAsync(dto, cancellationToken);
+
+    public Task<bool> MarkFulfilledAsync(SarFulfilledDto dto, CancellationToken cancellationToken)
+        => _subjectAccessRequestManager.MarkFulfilledAsync(dto, cancellationToken);
+}

--- a/src/Domain/Entities/AnonymizationCandidate.cs
+++ b/src/Domain/Entities/AnonymizationCandidate.cs
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+using Domain.Enums;
+using Domain.Interfaces;
+
+namespace Domain.Entities;
+
+/// <summary>
+/// Represents a resident whose data has reached the retention threshold and awaits
+/// Admin review for anonymization or pseudonymization (UC-010).
+/// </summary>
+/// <remarks>
+/// Created by RetentionBackgroundService, not by direct user action.
+/// MedicineLogs are pseudonymized (not fully anonymized) per Autorisationsloven §22.
+/// </remarks>
+public class AnonymizationCandidate : IEntity
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    [Required]
+    [ForeignKey(nameof(Resident))]
+    public Guid ResidentId { get; set; }
+
+    [Required]
+    [ForeignKey(nameof(RetentionPolicy))]
+    public Guid RetentionPolicyId { get; set; }
+
+    [Required]
+    public DateTime SuggestedAt { get; set; }
+
+    [Required]
+    [MaxLength(500)]
+    public string Reason { get; set; } = string.Empty;
+
+    [Required]
+    public AnonymizationStatus Status { get; set; } = AnonymizationStatus.Pending;
+
+    public virtual Resident? Resident { get; set; }
+    public virtual RetentionPolicy? RetentionPolicy { get; set; }
+}

--- a/src/Domain/Entities/RetentionPolicy.cs
+++ b/src/Domain/Entities/RetentionPolicy.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System.ComponentModel.DataAnnotations;
+
+using Domain.Enums;
+using Domain.Interfaces;
+
+namespace Domain.Entities;
+
+/// <summary>
+/// Represents a GDPR retention policy for a specific data category (UC-010).
+/// </summary>
+/// <remarks>
+/// MedicineLogs has a locked legal minimum of 10 years per Autorisationsloven §22.
+/// Other categories may be configured by Admin within reasonable bounds.
+/// </remarks>
+public class RetentionPolicy : IEntity
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    [Required]
+    public RetentionDataCategory Category { get; set; }
+
+    [Required]
+    public TimeSpan RetentionPeriod { get; set; }
+
+    [Required]
+    public TimeSpan LegalMinimum { get; set; }
+
+    [Required]
+    public DateTime EffectiveFrom { get; set; }
+
+    public virtual ICollection<RetentionPolicyAudit> AuditHistory { get; set; } = [];
+    public virtual ICollection<AnonymizationCandidate> Candidates { get; set; } = [];
+}

--- a/src/Domain/Entities/RetentionPolicyAudit.cs
+++ b/src/Domain/Entities/RetentionPolicyAudit.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+using Domain.Interfaces;
+
+namespace Domain.Entities;
+
+/// <summary>
+/// Records every change to a RetentionPolicy with previous and new values (UC-010).
+/// </summary>
+/// <remarks>
+/// Created automatically by RetentionPolicyManager when a policy is updated.
+/// Provides full traceability for Datatilsynet inspection of retention configuration history.
+/// </remarks>
+public class RetentionPolicyAudit : IEntity
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    [Required]
+    [ForeignKey(nameof(RetentionPolicy))]
+    public Guid RetentionPolicyId { get; set; }
+
+    [Required]
+    public Guid ChangedByEmployeeId { get; set; }
+
+    [Required]
+    public TimeSpan PreviousPeriod { get; set; }
+
+    [Required]
+    public TimeSpan NewPeriod { get; set; }
+
+    [Required]
+    public DateTime ChangedAt { get; set; }
+
+    [MaxLength(500)]
+    public string Reason { get; set; } = string.Empty;
+
+    public virtual RetentionPolicy? RetentionPolicy { get; set; }
+}

--- a/src/Domain/Entities/SecurityIncident.cs
+++ b/src/Domain/Entities/SecurityIncident.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System.ComponentModel.DataAnnotations;
+
+using Domain.Enums;
+using Domain.Interfaces;
+
+namespace Domain.Entities;
+
+/// <summary>
+/// Represents a detected security incident that may indicate a personal data breach (UC-010).
+/// </summary>
+/// <remarks>
+/// Created by IncidentDetectionService when suspicious patterns match (e.g., failed logins,
+/// mass exports, off-hours access). Admin reviews and may escalate to GDPR Art. 33 breach
+/// notification to the Data Protection Officer.
+/// </remarks>
+public class SecurityIncident : IEntity
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    [Required]
+    public DateTime DetectedAt { get; set; }
+
+    [Required]
+    [MaxLength(200)]
+    public string Type { get; set; } = string.Empty;
+
+    [Required]
+    public IncidentSeverity Severity { get; set; }
+
+    [Required]
+    public IncidentStatus Status { get; set; } = IncidentStatus.Open;
+
+    [MaxLength(2000)]
+    public string InvestigationNotes { get; set; } = string.Empty;
+
+    public Guid? ReportedByEmployeeId { get; set; }
+
+    public Guid? ResolvedByEmployeeId { get; set; }
+}

--- a/src/Domain/Enums/AnonymizationStatus.cs
+++ b/src/Domain/Enums/AnonymizationStatus.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+namespace Domain.Enums;
+
+/// <summary>
+/// Lifecycle status of an anonymization candidate awaiting Admin review (UC-010).
+/// </summary>
+public enum AnonymizationStatus
+{
+    Pending,
+    Approved,
+    Rejected,
+    Postponed,
+    OnHold,
+    Completed
+}

--- a/src/Domain/Enums/IncidentSeverity.cs
+++ b/src/Domain/Enums/IncidentSeverity.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+namespace Domain.Enums;
+
+/// <summary>
+/// Severity classification for security incidents (UC-010).
+/// </summary>
+public enum IncidentSeverity
+{
+    Low,
+    Medium,
+    High,
+    Critical
+}

--- a/src/Domain/Enums/IncidentStatus.cs
+++ b/src/Domain/Enums/IncidentStatus.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+namespace Domain.Enums;
+
+/// <summary>
+/// Lifecycle status of a security incident (UC-010).
+/// BreachNotified indicates that the GDPR Article 33 notification has been sent to the DPO.
+/// </summary>
+public enum IncidentStatus
+{
+    Open,
+    UnderInvestigation,
+    Closed,
+    Escalated,
+    BreachNotified
+}

--- a/src/Domain/Enums/RetentionDataCategory.cs
+++ b/src/Domain/Enums/RetentionDataCategory.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+namespace Domain.Enums;
+
+/// <summary>
+/// Categories of personal data managed by GDPR retention policies (UC-010).
+/// </summary>
+public enum RetentionDataCategory
+{
+    MedicineLogs,
+    ResidentNotes,
+    AuditLogs,
+    LoginLogs,
+    InactiveUsers,
+    AnonymizationTrigger
+}

--- a/src/Infrastructure.Data/Migrations/20260511122037_AddUC010GdprEntities.Designer.cs
+++ b/src/Infrastructure.Data/Migrations/20260511122037_AddUC010GdprEntities.Designer.cs
@@ -4,6 +4,7 @@ using Infrastructure.Data.Persistent;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infrastructure.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260511122037_AddUC010GdprEntities")]
+    partial class AddUC010GdprEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure.Data/Migrations/20260511122037_AddUC010GdprEntities.cs
+++ b/src/Infrastructure.Data/Migrations/20260511122037_AddUC010GdprEntities.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUC010GdprEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RetentionPolicies",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    Category = table.Column<int>(type: "int", nullable: false),
+                    RetentionPeriod = table.Column<TimeSpan>(type: "time(6)", nullable: false),
+                    LegalMinimum = table.Column<TimeSpan>(type: "time(6)", nullable: false),
+                    EffectiveFrom = table.Column<DateTime>(type: "datetime(6)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RetentionPolicies", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "SecurityIncidents",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    DetectedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    Type = table.Column<string>(type: "varchar(200)", maxLength: 200, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Severity = table.Column<int>(type: "int", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    InvestigationNotes = table.Column<string>(type: "varchar(2000)", maxLength: 2000, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    ReportedByEmployeeId = table.Column<Guid>(type: "char(36)", nullable: true, collation: "ascii_general_ci"),
+                    ResolvedByEmployeeId = table.Column<Guid>(type: "char(36)", nullable: true, collation: "ascii_general_ci")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SecurityIncidents", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AnonymizationCandidates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    ResidentId = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    RetentionPolicyId = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    SuggestedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    Reason = table.Column<string>(type: "varchar(500)", maxLength: 500, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AnonymizationCandidates", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AnonymizationCandidates_Residents_ResidentId",
+                        column: x => x.ResidentId,
+                        principalTable: "Residents",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AnonymizationCandidates_RetentionPolicies_RetentionPolicyId",
+                        column: x => x.RetentionPolicyId,
+                        principalTable: "RetentionPolicies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "RetentionPolicyAudits",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    RetentionPolicyId = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    ChangedByEmployeeId = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    PreviousPeriod = table.Column<TimeSpan>(type: "time(6)", nullable: false),
+                    NewPeriod = table.Column<TimeSpan>(type: "time(6)", nullable: false),
+                    ChangedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    Reason = table.Column<string>(type: "varchar(500)", maxLength: 500, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RetentionPolicyAudits", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RetentionPolicyAudits_RetentionPolicies_RetentionPolicyId",
+                        column: x => x.RetentionPolicyId,
+                        principalTable: "RetentionPolicies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.InsertData(
+                table: "RetentionPolicies",
+                columns: new[] { "Id", "Category", "EffectiveFrom", "LegalMinimum", "RetentionPeriod" },
+                values: new object[,]
+                {
+                    { new Guid("a1111111-0000-0000-0000-000000000001"), 0, new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), new TimeSpan(3650, 0, 0, 0, 0), new TimeSpan(3650, 0, 0, 0, 0) },
+                    { new Guid("a1111111-0000-0000-0000-000000000002"), 1, new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), new TimeSpan(730, 0, 0, 0, 0), new TimeSpan(1825, 0, 0, 0, 0) },
+                    { new Guid("a1111111-0000-0000-0000-000000000003"), 2, new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), new TimeSpan(365, 0, 0, 0, 0), new TimeSpan(1095, 0, 0, 0, 0) },
+                    { new Guid("a1111111-0000-0000-0000-000000000004"), 3, new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), new TimeSpan(90, 0, 0, 0, 0), new TimeSpan(180, 0, 0, 0, 0) },
+                    { new Guid("a1111111-0000-0000-0000-000000000005"), 4, new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), new TimeSpan(180, 0, 0, 0, 0), new TimeSpan(365, 0, 0, 0, 0) },
+                    { new Guid("a1111111-0000-0000-0000-000000000006"), 5, new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), new TimeSpan(7, 0, 0, 0, 0), new TimeSpan(30, 0, 0, 0, 0) }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AnonymizationCandidates_ResidentId",
+                table: "AnonymizationCandidates",
+                column: "ResidentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AnonymizationCandidates_RetentionPolicyId",
+                table: "AnonymizationCandidates",
+                column: "RetentionPolicyId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RetentionPolicies_Category",
+                table: "RetentionPolicies",
+                column: "Category",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RetentionPolicyAudits_RetentionPolicyId",
+                table: "RetentionPolicyAudits",
+                column: "RetentionPolicyId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AnonymizationCandidates");
+
+            migrationBuilder.DropTable(
+                name: "RetentionPolicyAudits");
+
+            migrationBuilder.DropTable(
+                name: "SecurityIncidents");
+
+            migrationBuilder.DropTable(
+                name: "RetentionPolicies");
+        }
+    }
+}

--- a/src/Infrastructure.Data/Persistent/AppDbContext.cs
+++ b/src/Infrastructure.Data/Persistent/AppDbContext.cs
@@ -26,6 +26,13 @@ public partial class AppDbContext(DbContextOptions<AppDbContext> options) : Iden
     public DbSet<StaffAssignment> StaffAssignments { get; set; }
     public DbSet<Employee> Employees { get; set; }
 
+
+    // UC-010 GDPR compliance entities
+    public DbSet<RetentionPolicy> RetentionPolicies { get; set; }
+    public DbSet<RetentionPolicyAudit> RetentionPolicyAudits { get; set; }
+    public DbSet<AnonymizationCandidate> AnonymizationCandidates { get; set; }
+    public DbSet<SecurityIncident> SecurityIncidents { get; set; }
+
     // Identity-related DbSet for refresh tokens
     public DbSet<RefreshToken> RefreshTokens { get; set; }
 
@@ -55,6 +62,7 @@ public partial class AppDbContext(DbContextOptions<AppDbContext> options) : Iden
         _ = modelBuilder.ApplyConfiguration(new Configurations.PainkillerRecordConfiguration());
         _ = modelBuilder.ApplyConfiguration(new Configurations.ChangeDetailConfiguration());
         _ = modelBuilder.ApplyConfiguration(new Configurations.EmployeeConfiguration());
+        _ = modelBuilder.ApplyConfiguration(new Configurations.RetentionPolicyConfiguration());
 
         _ = modelBuilder.Entity<MedicineStatusView>()
             .HasNoKey()

--- a/src/Infrastructure.Data/Persistent/Configurations/RetentionPolicyConfiguration.cs
+++ b/src/Infrastructure.Data/Persistent/Configurations/RetentionPolicyConfiguration.cs
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Domain.Entities;
+using Domain.Enums;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Data.Persistent.Configurations;
+
+/// <summary>
+/// Provides configuration for the <see cref="RetentionPolicy"/> entity using Entity Framework Core (UC-010).
+/// Includes seed data with legal minimum retention periods per Autorisationsloven §22.
+/// </summary>
+public class RetentionPolicyConfiguration : IEntityTypeConfiguration<RetentionPolicy>
+{
+    public void Configure(EntityTypeBuilder<RetentionPolicy> builder)
+    {
+        // Unique constraint: only one active policy per data category
+        _ = builder.HasIndex(p => p.Category).IsUnique();
+
+        // Relationships
+        _ = builder.HasMany(p => p.AuditHistory)
+            .WithOne(a => a.RetentionPolicy)
+            .HasForeignKey(a => a.RetentionPolicyId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        _ = builder.HasMany(p => p.Candidates)
+            .WithOne(c => c.RetentionPolicy)
+            .HasForeignKey(c => c.RetentionPolicyId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        SeedingData(builder);
+    }
+
+    /// <summary>
+    /// Seeds default retention policies with legal minimums per Autorisationsloven §22 and GDPR best practice.
+    /// </summary>
+    private static void SeedingData(EntityTypeBuilder<RetentionPolicy> builder)
+    {
+        DateTime effectiveFrom = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        _ = builder.HasData(
+            new RetentionPolicy
+            {
+                Id = Guid.Parse("a1111111-0000-0000-0000-000000000001"),
+                Category = RetentionDataCategory.MedicineLogs,
+                RetentionPeriod = TimeSpan.FromDays(365 * 10), // 10 years (Autorisationsloven §22)
+                LegalMinimum = TimeSpan.FromDays(365 * 10),
+                EffectiveFrom = effectiveFrom
+            },
+            new RetentionPolicy
+            {
+                Id = Guid.Parse("a1111111-0000-0000-0000-000000000002"),
+                Category = RetentionDataCategory.ResidentNotes,
+                RetentionPeriod = TimeSpan.FromDays(365 * 5), // 5 years default
+                LegalMinimum = TimeSpan.FromDays(365 * 2), // 2 years minimum
+                EffectiveFrom = effectiveFrom
+            },
+            new RetentionPolicy
+            {
+                Id = Guid.Parse("a1111111-0000-0000-0000-000000000003"),
+                Category = RetentionDataCategory.AuditLogs,
+                RetentionPeriod = TimeSpan.FromDays(365 * 3), // 3 years default
+                LegalMinimum = TimeSpan.FromDays(365 * 1), // 1 year minimum (GDPR Art. 30)
+                EffectiveFrom = effectiveFrom
+            },
+            new RetentionPolicy
+            {
+                Id = Guid.Parse("a1111111-0000-0000-0000-000000000004"),
+                Category = RetentionDataCategory.LoginLogs,
+                RetentionPeriod = TimeSpan.FromDays(180), // 6 months default
+                LegalMinimum = TimeSpan.FromDays(90), // 3 months minimum
+                EffectiveFrom = effectiveFrom
+            },
+            new RetentionPolicy
+            {
+                Id = Guid.Parse("a1111111-0000-0000-0000-000000000005"),
+                Category = RetentionDataCategory.InactiveUsers,
+                RetentionPeriod = TimeSpan.FromDays(365), // 1 year default
+                LegalMinimum = TimeSpan.FromDays(180), // 6 months minimum
+                EffectiveFrom = effectiveFrom
+            },
+            new RetentionPolicy
+            {
+                Id = Guid.Parse("a1111111-0000-0000-0000-000000000006"),
+                Category = RetentionDataCategory.AnonymizationTrigger,
+                RetentionPeriod = TimeSpan.FromDays(30), // 30 days review window
+                LegalMinimum = TimeSpan.FromDays(7), // 7 days minimum
+                EffectiveFrom = effectiveFrom
+            }
+        );
+    }
+}

--- a/src/Infrastructure.Data/Repositories/AnonymizationCandidateRepository.cs
+++ b/src/Infrastructure.Data/Repositories/AnonymizationCandidateRepository.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.Interfaces.Repositories;
+
+using Domain.Entities;
+
+using Infrastructure.Data.Persistent;
+
+namespace Infrastructure.Data.Repositories;
+
+/// <summary>
+/// Repository implementation for <see cref="AnonymizationCandidate"/> entities (UC-010).
+/// </summary>
+/// <remarks>
+/// Provides EF Core data access for anonymization candidates pending Admin review.
+/// </remarks>
+public class AnonymizationCandidateRepository(AppDbContext context) : Repository<AnonymizationCandidate>(context), IAnonymizationCandidateRepository
+{
+}

--- a/src/Infrastructure.Data/Repositories/RetentionPolicyRepository.cs
+++ b/src/Infrastructure.Data/Repositories/RetentionPolicyRepository.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.Interfaces.Repositories;
+
+using Domain.Entities;
+
+using Infrastructure.Data.Persistent;
+
+namespace Infrastructure.Data.Repositories;
+
+/// <summary>
+/// Repository implementation for <see cref="RetentionPolicy"/> entities (UC-010).
+/// </summary>
+/// <remarks>
+/// Provides EF Core data access for retention policies. Inherits generic CRUD
+/// operations from <see cref="Repository{RetentionPolicy}"/>.
+/// </remarks>
+public class RetentionPolicyRepository(AppDbContext context) : Repository<RetentionPolicy>(context), IRetentionPolicyRepository
+{
+}

--- a/src/Infrastructure.Data/Repositories/SecurityIncidentRepository.cs
+++ b/src/Infrastructure.Data/Repositories/SecurityIncidentRepository.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using Core.Interfaces.Repositories;
+
+using Domain.Entities;
+
+using Infrastructure.Data.Persistent;
+
+namespace Infrastructure.Data.Repositories;
+
+/// <summary>
+/// Repository implementation for <see cref="SecurityIncident"/> entities (UC-010).
+/// </summary>
+/// <remarks>
+/// Provides EF Core data access for detected security incidents.
+/// </remarks>
+public class SecurityIncidentRepository(AppDbContext context) : Repository<SecurityIncident>(context), ISecurityIncidentRepository
+{
+}

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -47,6 +47,14 @@ public static class DependencyInjection
 
         _ = services.AddScoped<IDatabaseConnectionManager, DatabaseConnectionManager>();
 
+
+        // UC-010 GDPR compliance — Manager HTTP clients
+        _ = services.AddScoped<IRetentionPolicyManager, RetentionPolicyManager>();
+        _ = services.AddScoped<IAnonymizationManager, AnonymizationManager>();
+        _ = services.AddScoped<ISecurityIncidentManager, SecurityIncidentManager>();
+        _ = services.AddScoped<ISubjectAccessRequestManager, SubjectAccessRequestManager>();
+
+
         return services;
     }
 }

--- a/src/Infrastructure/Managers/AnonymizationManager.cs
+++ b/src/Infrastructure/Managers/AnonymizationManager.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System.Net.Http.Json;
+
+using Core.DTOs.Anonymization;
+using Core.Interfaces.Managers;
+
+namespace Infrastructure.Managers;
+
+/// <summary>
+/// Provides operations for managing anonymization candidates by communicating with the backend API over HTTP (UC-010).
+/// </summary>
+public class AnonymizationManager : IAnonymizationManager
+{
+    #region Fields
+
+    private readonly HttpClient _httpClient;
+
+    #endregion
+
+    #region Constructors
+
+    public AnonymizationManager(IHttpClientFactory httpClientFactory)
+    {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        _httpClient = httpClientFactory.CreateClient("SlottetApi")
+            ?? throw new InvalidOperationException("Failed to create HttpClient.");
+    }
+
+    #endregion
+
+    #region Methods
+
+    public async Task<IEnumerable<AnonymizationCandidateDto>> GetCandidatesAsync(CancellationToken cancellationToken)
+    {
+        return await _httpClient.GetFromJsonAsync<IEnumerable<AnonymizationCandidateDto>>(
+            "anonymization/candidates", cancellationToken) ?? [];
+    }
+
+    public async Task<AnonymizationResultDto> ApproveAnonymizationAsync(Guid candidateId, CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = await _httpClient.PostAsJsonAsync(
+            $"anonymization/{candidateId}/approve", new { }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<AnonymizationResultDto>(cancellationToken)
+            ?? throw new InvalidOperationException("Failed to deserialize anonymization result.");
+    }
+
+    public async Task<bool> RejectAnonymizationAsync(Guid candidateId, string reason, CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = await _httpClient.PostAsJsonAsync(
+            $"anonymization/{candidateId}/reject", new { Reason = reason }, cancellationToken);
+        return response.IsSuccessStatusCode;
+    }
+
+    #endregion
+}

--- a/src/Infrastructure/Managers/RetentionPolicyManager.cs
+++ b/src/Infrastructure/Managers/RetentionPolicyManager.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System.Net.Http.Json;
+
+using Core.DTOs.Retention;
+using Core.Interfaces.Managers;
+
+namespace Infrastructure.Managers;
+
+/// <summary>
+/// Provides operations for managing retention policies by communicating with the backend API over HTTP (UC-010).
+/// </summary>
+/// <remarks>
+/// Implements <see cref="IRetentionPolicyManager"/> using <see cref="HttpClient"/> to call the WebApi.
+/// Keeps all HTTP communication out of Core — Core only knows the interface contract.
+/// </remarks>
+public class RetentionPolicyManager : IRetentionPolicyManager
+{
+    #region Fields
+
+    private readonly HttpClient _httpClient;
+
+    #endregion
+
+    #region Constructors
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RetentionPolicyManager"/> class.
+    /// </summary>
+    /// <param name="httpClientFactory">The factory used to create the named <see cref="HttpClient"/> for the API.</param>
+    /// <exception cref="InvalidOperationException">The named HttpClient 'SlottetApi' could not be created.</exception>
+    public RetentionPolicyManager(IHttpClientFactory httpClientFactory)
+    {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        _httpClient = httpClientFactory.CreateClient("SlottetApi")
+            ?? throw new InvalidOperationException("Failed to create HttpClient.");
+    }
+
+    #endregion
+
+    #region Methods
+
+    public async Task<IEnumerable<RetentionPolicyDto>> GetPoliciesAsync(CancellationToken cancellationToken)
+    {
+        return await _httpClient.GetFromJsonAsync<IEnumerable<RetentionPolicyDto>>(
+            "retentionpolicy", cancellationToken) ?? [];
+    }
+
+    public async Task<RetentionPolicyDto> UpdateRetentionPolicyAsync(
+        UpdateRetentionPolicyDto dto,
+        Guid changedByEmployeeId,
+        CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = await _httpClient.PutAsJsonAsync(
+            $"retentionpolicy?changedByEmployeeId={changedByEmployeeId}", dto, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<RetentionPolicyDto>(cancellationToken)
+            ?? throw new InvalidOperationException("Failed to deserialize updated retention policy.");
+    }
+
+    #endregion
+}

--- a/src/Infrastructure/Managers/SecurityIncidentManager.cs
+++ b/src/Infrastructure/Managers/SecurityIncidentManager.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System.Net.Http.Json;
+
+using Core.DTOs.Security;
+using Core.Interfaces.Managers;
+
+namespace Infrastructure.Managers;
+
+/// <summary>
+/// Provides operations for managing security incidents by communicating with the backend API over HTTP (UC-010).
+/// </summary>
+/// <remarks>
+/// Escalation with isBreach=true triggers GDPR Art. 33 notification on the server side.
+/// </remarks>
+public class SecurityIncidentManager : ISecurityIncidentManager
+{
+    #region Fields
+
+    private readonly HttpClient _httpClient;
+
+    #endregion
+
+    #region Constructors
+
+    public SecurityIncidentManager(IHttpClientFactory httpClientFactory)
+    {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        _httpClient = httpClientFactory.CreateClient("SlottetApi")
+            ?? throw new InvalidOperationException("Failed to create HttpClient.");
+    }
+
+    #endregion
+
+    #region Methods
+
+    public async Task<IEnumerable<SecurityIncidentDto>> GetIncidentsAsync(CancellationToken cancellationToken)
+    {
+        return await _httpClient.GetFromJsonAsync<IEnumerable<SecurityIncidentDto>>(
+            "securityincident", cancellationToken) ?? [];
+    }
+
+    public async Task<SecurityIncidentDto> EscalateIncidentAsync(Guid incidentId, bool isBreach, CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = await _httpClient.PostAsJsonAsync(
+            $"securityincident/{incidentId}/escalate", new { IsBreach = isBreach }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<SecurityIncidentDto>(cancellationToken)
+            ?? throw new InvalidOperationException("Failed to deserialize escalated incident.");
+    }
+
+    public async Task<SecurityIncidentDto> AddInvestigationNotesAsync(AddInvestigationNotesDto dto, CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = await _httpClient.PostAsJsonAsync(
+            $"securityincident/{dto.IncidentId}/notes", dto, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<SecurityIncidentDto>(cancellationToken)
+            ?? throw new InvalidOperationException("Failed to deserialize incident with notes.");
+    }
+
+    public async Task<SecurityIncidentDto> CloseIncidentAsync(Guid incidentId, CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = await _httpClient.PostAsJsonAsync(
+            $"securityincident/{incidentId}/close", new { }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<SecurityIncidentDto>(cancellationToken)
+            ?? throw new InvalidOperationException("Failed to deserialize closed incident.");
+    }
+
+    #endregion
+}

--- a/src/Infrastructure/Managers/SubjectAccessRequestManager.cs
+++ b/src/Infrastructure/Managers/SubjectAccessRequestManager.cs
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Team6. All rights reserved. 
+//  No warranty, explicit or implicit, provided.
+
+using System.Net.Http.Json;
+
+using Core.DTOs.Sar;
+using Core.Interfaces.Managers;
+
+namespace Infrastructure.Managers;
+
+/// <summary>
+/// Provides operations for handling GDPR Subject Access Requests by communicating with the backend API over HTTP (UC-010, Art. 15).
+/// </summary>
+public class SubjectAccessRequestManager : ISubjectAccessRequestManager
+{
+    #region Fields
+
+    private readonly HttpClient _httpClient;
+
+    #endregion
+
+    #region Constructors
+
+    public SubjectAccessRequestManager(IHttpClientFactory httpClientFactory)
+    {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        _httpClient = httpClientFactory.CreateClient("SlottetApi")
+            ?? throw new InvalidOperationException("Failed to create HttpClient.");
+    }
+
+    #endregion
+
+    #region Methods
+
+    public async Task<SarExportPackageDto> GenerateExportAsync(SarExportRequestDto dto, CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = await _httpClient.PostAsJsonAsync(
+            "subjectaccessrequest/export", dto, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<SarExportPackageDto>(cancellationToken)
+            ?? throw new InvalidOperationException("Failed to deserialize SAR export package.");
+    }
+
+    public async Task<bool> MarkFulfilledAsync(SarFulfilledDto dto, CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = await _httpClient.PostAsJsonAsync(
+            "subjectaccessrequest/fulfilled", dto, cancellationToken);
+        return response.IsSuccessStatusCode;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Stacked PR series for UC-010 — depends on PR #532.

## What
3 commits making up the full infrastructure layer:
1. Infrastructure.Data — 3 Repositories + RetentionPolicyConfiguration with 6 seed policies + AppDbContext update
2. Infrastructure/Managers/ — 4 HTTP-client Managers + Core Art33NotificationService + 2 Api/BackgroundServices
3. EF Core migration — 20260511122037_AddUC010GdprEntities (4 tables, FKs, indexes, seed data)

## Seed data — legal minimums (Autorisationsloven §22 + GDPR Art. 30)
- MedicineLogs: 10 years (locked)
- ResidentNotes: 5 years (min 2)
- AuditLogs: 3 years (min 1, GDPR Art. 30)
- LoginLogs: 6 months (min 3)
- InactiveUsers: 1 year (min 6 months)
- AnonymizationTrigger: 30 days (min 7)

## Architecture
- Managers HTTP-only (no AppDbContext leakage)
- Art33NotificationService in Core (ILogger stub)
- BackgroundServices in Api (host-orchestrated)
- Clean Architecture grænser respekteret

## Apply migration
\`\`\`bash
dotnet ef database update --project src/Infrastructure.Data --startup-project src/Api
\`\`\`

Closes #441
Refs UC-010.DCD Infrastructure, UC-010.ERD