### PR TITLE
Move GDPR pages to WebUI.Client and persist retention policy audit

### DIFF
--- a/src/Api/Controllers/RetentionPolicyController.cs
+++ b/src/Api/Controllers/RetentionPolicyController.cs
@@ -27,6 +27,7 @@ public class RetentionPolicyController : ControllerBase
     #region Fields
 
     private readonly IRetentionPolicyRepository _retentionPolicyRepository;
+    private readonly IRetentionPolicyAuditRepository _retentionPolicyAuditRepository;
 
     #endregion
 
@@ -36,11 +37,16 @@ public class RetentionPolicyController : ControllerBase
     /// Initializes a new instance of the <see cref="RetentionPolicyController"/> class.
     /// </summary>
     /// <param name="retentionPolicyRepository">The retention policy repository.</param>
-    /// <exception cref="ArgumentNullException">The <paramref name="retentionPolicyRepository"/> parameter is <see langword="null"/>.</exception>
-    public RetentionPolicyController(IRetentionPolicyRepository retentionPolicyRepository)
+    /// <param name="retentionPolicyAuditRepository">The retention policy audit repository.</param>
+    /// <exception cref="ArgumentNullException">A parameter is <see langword="null"/>.</exception>
+    public RetentionPolicyController(
+        IRetentionPolicyRepository retentionPolicyRepository,
+        IRetentionPolicyAuditRepository retentionPolicyAuditRepository)
     {
         ArgumentNullException.ThrowIfNull(retentionPolicyRepository);
+        ArgumentNullException.ThrowIfNull(retentionPolicyAuditRepository);
         _retentionPolicyRepository = retentionPolicyRepository;
+        _retentionPolicyAuditRepository = retentionPolicyAuditRepository;
     }
 
     #endregion
@@ -97,8 +103,17 @@ public class RetentionPolicyController : ControllerBase
 
         await _retentionPolicyRepository.UpdateAsync(policy, cancellationToken);
 
-        // AuditInterceptor (UC-009) automatically captures the change via SaveChanges
-        // RetentionPolicyAudit record creation is a future enhancement (separate repository)
+        RetentionPolicyAudit auditRecord = new()
+        {
+            Id = Guid.NewGuid(),
+            RetentionPolicyId = policy.Id,
+            ChangedByEmployeeId = changedByEmployeeId,
+            PreviousPeriod = previousPeriod,
+            NewPeriod = dto.RetentionPeriod,
+            ChangedAt = DateTime.UtcNow,
+            Reason = dto.Reason ?? string.Empty
+        };
+        await _retentionPolicyAuditRepository.CreateAsync(auditRecord, cancellationToken);
 
         return Ok(RetentionPolicyMapper.ToDto(policy));
     }

--- a/src/Core/Interfaces/Repositories/IRetentionPolicyAuditRepository.cs
+++ b/src/Core/Interfaces/Repositories/IRetentionPolicyAuditRepository.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+//  No warranty, explicit or implicit, provided.
+
+using Domain.Entities;
+
+namespace Core.Interfaces.Repositories;
+
+/// <summary>
+/// Defines a contract for repository operations specific to <see cref="RetentionPolicyAudit"/> entities (UC-010).
+/// </summary>
+public interface IRetentionPolicyAuditRepository : IRepository<RetentionPolicyAudit>
+{
+}

--- a/src/Infrastructure.Data/DependencyInjection.cs
+++ b/src/Infrastructure.Data/DependencyInjection.cs
@@ -31,6 +31,7 @@ public static class DependencyInjection
 
         // UC-010 GDPR compliance repositories
         _ = services.AddScoped<IRetentionPolicyRepository, RetentionPolicyRepository>();
+        _ = services.AddScoped<IRetentionPolicyAuditRepository, RetentionPolicyAuditRepository>();
         _ = services.AddScoped<IAnonymizationCandidateRepository, AnonymizationCandidateRepository>();
         _ = services.AddScoped<ISecurityIncidentRepository, SecurityIncidentRepository>();
 

--- a/src/Infrastructure.Data/Repositories/RetentionPolicyAuditRepository.cs
+++ b/src/Infrastructure.Data/Repositories/RetentionPolicyAuditRepository.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+//  No warranty, explicit or implicit, provided.
+
+using Core.Interfaces.Repositories;
+
+using Domain.Entities;
+
+using Infrastructure.Data.Persistent;
+
+namespace Infrastructure.Data.Repositories;
+
+/// <summary>
+/// Repository implementation for <see cref="RetentionPolicyAudit"/> entities (UC-010).
+/// </summary>
+/// <remarks>
+/// Persists immutable audit records each time a retention policy is changed,
+/// preserving full traceability for Datatilsynet inspections.
+/// </remarks>
+public class RetentionPolicyAuditRepository(AppDbContext context)
+    : Repository<RetentionPolicyAudit>(context), IRetentionPolicyAuditRepository
+{
+}

--- a/src/WebUI/WebUI.Client/Components/Pages/Gdpr/AnonymizationQueuePage.razor
+++ b/src/WebUI/WebUI.Client/Components/Pages/Gdpr/AnonymizationQueuePage.razor
@@ -1,7 +1,7 @@
 @* UC-010 - Anonymization Queue (Admin only) *@
 
 @page "/admin/gdpr/anonymization"
-@rendermode InteractiveServer
+@rendermode InteractiveAuto
 @attribute [Microsoft.AspNetCore.Authorization.Authorize(Roles = "admin")]
 
 @using Core.DTOs.Anonymization

--- a/src/WebUI/WebUI.Client/Components/Pages/Gdpr/AnonymizationQueuePage.razor.cs
+++ b/src/WebUI/WebUI.Client/Components/Pages/Gdpr/AnonymizationQueuePage.razor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 
 using Core.DTOs.Anonymization;
@@ -8,7 +8,7 @@ using Domain.Enums;
 
 using Microsoft.AspNetCore.Components;
 
-namespace WebUI.Components.Pages.Gdpr;
+namespace WebUI.Client.Components.Pages.Gdpr;
 
 /// <summary>
 /// Anonymization Queue page — Admin reviews candidates and approves/rejects anonymization (UC-010).

--- a/src/WebUI/WebUI.Client/Components/Pages/Gdpr/GdprDashboardPage.razor
+++ b/src/WebUI/WebUI.Client/Components/Pages/Gdpr/GdprDashboardPage.razor
@@ -1,7 +1,7 @@
 @* UC-010 - GDPR Compliance Dashboard (Admin only) *@
 
 @page "/admin/gdpr"
-@rendermode InteractiveServer
+@rendermode InteractiveAuto
 @attribute [Microsoft.AspNetCore.Authorization.Authorize(Roles = "admin")]
 
 <PageTitle>GDPR Compliance</PageTitle>
@@ -61,4 +61,11 @@
             </div>
         </div>
     </div>
+
+    @if (!string.IsNullOrEmpty(_loadError))
+    {
+        <div class="alert alert-warning mt-4 mb-0" role="alert">
+            Could not load dashboard counters: @_loadError
+        </div>
+    }
 </main>

--- a/src/WebUI/WebUI.Client/Components/Pages/Gdpr/GdprDashboardPage.razor.cs
+++ b/src/WebUI/WebUI.Client/Components/Pages/Gdpr/GdprDashboardPage.razor.cs
@@ -1,11 +1,11 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 
 using Core.Interfaces.Services;
 
 using Microsoft.AspNetCore.Components;
 
-namespace WebUI.Components.Pages.Gdpr;
+namespace WebUI.Client.Components.Pages.Gdpr;
 
 /// <summary>
 /// GDPR Compliance Dashboard — central hub for Admin to access all UC-010 features.
@@ -26,6 +26,7 @@ public partial class GdprDashboardPage : ComponentBase
 
     private int _pendingCandidates;
     private int _openIncidents;
+    private string? _loadError;
 
     #endregion
 
@@ -54,11 +55,11 @@ public partial class GdprDashboardPage : ComponentBase
                 i.Status == Domain.Enums.IncidentStatus.Open ||
                 i.Status == Domain.Enums.IncidentStatus.UnderInvestigation);
         }
-        catch
+        catch (Exception ex)
         {
-            // Counters default to 0 if API unavailable — page still renders
             _pendingCandidates = 0;
             _openIncidents = 0;
+            _loadError = ex.Message;
         }
     }
 

--- a/src/WebUI/WebUI.Client/Components/Pages/Gdpr/RetentionSettingsPage.razor
+++ b/src/WebUI/WebUI.Client/Components/Pages/Gdpr/RetentionSettingsPage.razor
@@ -1,7 +1,7 @@
 @* UC-010 - Retention Policy Settings (Admin only) *@
 
 @page "/admin/gdpr/retention"
-@rendermode InteractiveServer
+@rendermode InteractiveAuto
 @attribute [Microsoft.AspNetCore.Authorization.Authorize(Roles = "admin")]
 
 @using Core.DTOs.Retention

--- a/src/WebUI/WebUI.Client/Components/Pages/Gdpr/RetentionSettingsPage.razor.cs
+++ b/src/WebUI/WebUI.Client/Components/Pages/Gdpr/RetentionSettingsPage.razor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 
 using Core.DTOs.Retention;
@@ -8,7 +8,7 @@ using Domain.Enums;
 
 using Microsoft.AspNetCore.Components;
 
-namespace WebUI.Components.Pages.Gdpr;
+namespace WebUI.Client.Components.Pages.Gdpr;
 
 /// <summary>
 /// Retention Settings page — Admin configures GDPR retention periods (UC-010).

--- a/src/WebUI/WebUI.Client/Components/Pages/Gdpr/SecurityIncidentsPage.razor
+++ b/src/WebUI/WebUI.Client/Components/Pages/Gdpr/SecurityIncidentsPage.razor
@@ -1,7 +1,7 @@
 @* UC-010 - Security Incidents Management (Admin only) *@
 
 @page "/admin/gdpr/incidents"
-@rendermode InteractiveServer
+@rendermode InteractiveAuto
 @attribute [Microsoft.AspNetCore.Authorization.Authorize(Roles = "admin")]
 
 @using Core.DTOs.Security

--- a/src/WebUI/WebUI.Client/Components/Pages/Gdpr/SecurityIncidentsPage.razor.cs
+++ b/src/WebUI/WebUI.Client/Components/Pages/Gdpr/SecurityIncidentsPage.razor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 
 using Core.DTOs.Security;
@@ -8,7 +8,7 @@ using Domain.Enums;
 
 using Microsoft.AspNetCore.Components;
 
-namespace WebUI.Components.Pages.Gdpr;
+namespace WebUI.Client.Components.Pages.Gdpr;
 
 /// <summary>
 /// Security Incidents page — Admin investigates, escalates, and closes security incidents (UC-010).
@@ -55,7 +55,6 @@ public partial class SecurityIncidentsPage : ComponentBase
         {
             IEnumerable<SecurityIncidentDto> result = await SecurityIncidentService.GetIncidentsAsync(CancellationToken.None);
             _incidents = [.. result];
-            // Re-select after reload if previous selection still exists
             if (_selectedIncident is not null)
             {
                 _selectedIncident = _incidents.FirstOrDefault(i => i.Id == _selectedIncident.Id);

--- a/src/WebUI/WebUI.Client/Components/Pages/Gdpr/SubjectAccessRequestPage.razor
+++ b/src/WebUI/WebUI.Client/Components/Pages/Gdpr/SubjectAccessRequestPage.razor
@@ -1,7 +1,7 @@
 @* UC-010 - Subject Access Request (GDPR Art. 15) — Admin only *@
 
 @page "/admin/gdpr/sar"
-@rendermode InteractiveServer
+@rendermode InteractiveAuto
 @attribute [Microsoft.AspNetCore.Authorization.Authorize(Roles = "admin")]
 
 @using Core.DTOs.Sar

--- a/src/WebUI/WebUI.Client/Components/Pages/Gdpr/SubjectAccessRequestPage.razor.cs
+++ b/src/WebUI/WebUI.Client/Components/Pages/Gdpr/SubjectAccessRequestPage.razor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 
 using Core.DTOs.Sar;
@@ -6,7 +6,7 @@ using Core.Interfaces.Services;
 
 using Microsoft.AspNetCore.Components;
 
-namespace WebUI.Components.Pages.Gdpr;
+namespace WebUI.Client.Components.Pages.Gdpr;
 
 /// <summary>
 /// Subject Access Request page — Admin generates GDPR Article 15 data exports (UC-010).


### PR DESCRIPTION
The five GDPR pages (Dashboard, RetentionSettings, AnonymizationQueue, SecurityIncidents, SubjectAccessRequest) were hosted in the server-side WebUI project with @rendermode InteractiveServer, which broke the pattern used by every other data page (Residents, Dashboard, AuditHistory, etc.) of living in WebUI.Client with @rendermode InteractiveAuto. The practical consequence: server-side HTTP calls to the API went through an SlottetApi HttpClient with no JWT message handlers attached (those handlers are only registered in WebUI.Client/Program.cs), so every request was rejected with 401 and the silent catch blocks rendered the pages as empty lists.

Moves the five pages and their code-behinds to
src/WebUI/WebUI.Client/Components/Pages/Gdpr/ and changes their render mode to InteractiveAuto. The dashboard's silent catch now surfaces load errors as a warning banner instead of swallowing them.

Adds IRetentionPolicyAuditRepository and a generic implementation following the existing Repository<T> pattern, registers it in Infrastructure.Data DI, and writes a RetentionPolicyAudit row from RetentionPolicyController.Update with the previous period, new period, changing employee, and reason — closing the audit gap flagged by the "future enhancement" TODO.

Background services (retention scanning, incident detection) and the anonymization / SAR controllers remain stubs by design; those need business-level decisions on inactivity triggers, anonymization fields, incident thresholds, and SAR scope before implementation.