### PR TITLE
Implement UC-010 GDPR core flows: retention scan, anonymisation, SAR …

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,6 +1,8 @@
 name: Build and Test
 permissions:
+  contents: read
   issues: write
+  pull-requests: write
 on:
   push:
     branches: [ main, develop ]
@@ -64,11 +66,15 @@ jobs:
           if-no-files-found: warn
       - name: Notify committer on test failure
         if: failure() && github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
             const pr = context.payload.pull_request;
-            if (pr) {
+            if (!pr) {
+              return;
+            }
+            try {
               const committer = pr.user.login;
               const message = `@${committer} :x: Tests failed for this pull request. Please check the logs and fix the issues.`;
               await github.rest.issues.createComment({
@@ -77,4 +83,10 @@ jobs:
                 issue_number: pr.number,
                 body: message
               });
+            } catch (error) {
+              // Do not mask the underlying test failure by also failing this notification step.
+              // Repository default workflow permissions may be set to read-only, in which case
+              // the GITHUB_TOKEN cannot post comments even when the workflow declares the scope.
+              // Owner can grant write access at: Settings -> Actions -> General -> Workflow permissions.
+              core.warning(`Could not post PR comment: ${error.message}`);
             }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.25" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.25" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.25" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.1.0" />

--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ TokenValidationParameters__Issuer=http://localhost
 TokenValidationParameters__Audience=http://localhost
 
 ExpireMinutes=60
+
+# UC-010 GDPR pseudonymisation salt (HMAC-SHA256 key).
+# Required by PseudonymizationService. MUST be kept outside source control and
+# rotated only in coordination with the Data Protection Officer; rotating
+# invalidates existing pseudonyms (Datatilsynet "Pseudonymisering og anonymisering").
+GDPR_PSEUDO_SALT=CHANGE_ME_TO_A_LONG_RANDOM_SECRET
 ```
 
 ### 3. Opret nødvendige mapper

--- a/src/Api/BackgroundServices/IncidentDetectionService.cs
+++ b/src/Api/BackgroundServices/IncidentDetectionService.cs
@@ -1,17 +1,36 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 
 using Core.Interfaces.Repositories;
 
+using Domain.Entities;
+using Domain.Enums;
+
 namespace Api.BackgroundServices;
 
 /// <summary>
-/// Periodically scans audit logs for suspicious patterns (failed logins, mass exports,
-/// off-hours access) and creates SecurityIncident records for Admin review (UC-010).
+/// Periodically scans audit logs for suspicious patterns (failed admin operations,
+/// mass administrative actions) and creates SecurityIncident records for Admin review (UC-010).
 /// </summary>
 /// <remarks>
 /// Runs every 15 minutes by default. Detected incidents enter the SecurityIncident
-/// queue with Status=Open and require manual Admin investigation.
+/// queue with Status=Open and require manual Admin investigation. Escalation as a
+/// personal data breach triggers GDPR Art. 33 notification to the DPO (handled by
+/// SecurityIncidentService.EscalateIncidentAsync).
+///
+/// Detection scope and limitations:
+///   - The AuditInterceptor (UC-009) only records EF Core SaveChanges. Login attempts
+///     that do not write to the database (i.e. password mismatches that short-circuit
+///     before any persistence) are NOT captured here. A dedicated authentication log
+///     is required to cover the full "fejlede loginforsøg" scenario flagged by
+///     Datatilsynet's "Logning af brugernes anvendelser af personoplysninger" guidance.
+///     Until that log exists this service evaluates failed-SaveChanges patterns only.
+///   - Off-hours administrative access detection requires HTTP request logging at
+///     the middleware layer and is therefore deferred to a future iteration.
+///
+/// Thresholds applied (risk-based, EDPB case-study aligned):
+///   - 10 or more failed audit entries by the same user within 60 minutes
+///     => SecurityIncident with Severity=Medium, Type="RepeatedFailures".
 /// </remarks>
 public class IncidentDetectionService : BackgroundService
 {
@@ -20,6 +39,8 @@ public class IncidentDetectionService : BackgroundService
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<IncidentDetectionService> _logger;
     private readonly TimeSpan _interval = TimeSpan.FromMinutes(15);
+    private readonly TimeSpan _failureWindow = TimeSpan.FromMinutes(60);
+    private const int FailureThreshold = 10;
 
     #endregion
 
@@ -61,19 +82,63 @@ public class IncidentDetectionService : BackgroundService
     }
 
     /// <summary>
-    /// Scans audit entries for suspicious patterns and creates SecurityIncident records.
+    /// Evaluates audit entries against detection rules and creates SecurityIncident records.
     /// </summary>
-    /// <remarks>
-    /// STUB: production should evaluate audit entries for failed logins, mass exports,
-    /// off-hours admin access, etc. For now logs the scan for traceability.
-    /// </remarks>
-    private Task DetectIncidentsAsync(CancellationToken cancellationToken)
+    private async Task DetectIncidentsAsync(CancellationToken cancellationToken)
     {
         using IServiceScope scope = _serviceProvider.CreateScope();
-        ISecurityIncidentRepository repository = scope.ServiceProvider.GetRequiredService<ISecurityIncidentRepository>();
+        IAuditRepository auditRepository =
+            scope.ServiceProvider.GetRequiredService<IAuditRepository>();
+        ISecurityIncidentRepository incidentRepository =
+            scope.ServiceProvider.GetRequiredService<ISecurityIncidentRepository>();
 
-        _logger.LogInformation("Incident detection scan completed at {Timestamp}.", DateTime.UtcNow);
-        return Task.CompletedTask;
+        DateTime windowStart = DateTime.UtcNow - _failureWindow;
+        IEnumerable<AuditEntry> recent = await auditRepository.GetAllAsync(cancellationToken);
+        List<AuditEntry> failuresInWindow = recent
+            .Where(a => !a.Succeeded && a.StartTimeUtc >= windowStart)
+            .ToList();
+
+        var byUser = failuresInWindow
+            .GroupBy(a => a.UserId)
+            .Where(g => g.Count() >= FailureThreshold)
+            .ToList();
+
+        List<SecurityIncident> existingOpen =
+            (await incidentRepository.GetAllAsync(cancellationToken))
+                .Where(i => i.Status == IncidentStatus.Open ||
+                            i.Status == IncidentStatus.UnderInvestigation)
+                .ToList();
+
+        int created = 0;
+        foreach (var group in byUser)
+        {
+            // Idempotency: only one open RepeatedFailures incident per user at a time.
+            bool alreadyOpen = existingOpen.Any(i =>
+                i.Type == "RepeatedFailures" && i.ReportedByEmployeeId == group.Key);
+            if (alreadyOpen)
+            {
+                continue;
+            }
+
+            SecurityIncident incident = new()
+            {
+                Id = Guid.NewGuid(),
+                DetectedAt = DateTime.UtcNow,
+                Type = "RepeatedFailures",
+                Severity = IncidentSeverity.Medium,
+                Status = IncidentStatus.Open,
+                InvestigationNotes =
+                    $"Detected {group.Count()} failed audit entries within {_failureWindow.TotalMinutes:N0} minutes "
+                    + $"for user {group.Key}. Review the audit log around {group.Min(g => g.StartTimeUtc):yyyy-MM-dd HH:mm} UTC.",
+                ReportedByEmployeeId = group.Key
+            };
+            _ = await incidentRepository.CreateAsync(incident, cancellationToken);
+            created++;
+        }
+
+        _logger.LogInformation(
+            "Incident detection scan completed at {Timestamp}. Failures in window: {FailureCount}, incidents created: {Created}.",
+            DateTime.UtcNow, failuresInWindow.Count, created);
     }
 
     #endregion

--- a/src/Api/BackgroundServices/RetentionBackgroundService.cs
+++ b/src/Api/BackgroundServices/RetentionBackgroundService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Team6. All rights reserved. 
+// Copyright (c) 2026 Team6. All rights reserved.
 //  No warranty, explicit or implicit, provided.
 
 using Core.Interfaces.Repositories;
@@ -13,8 +13,21 @@ namespace Api.BackgroundServices;
 /// and creates AnonymizationCandidate records for Admin review (UC-010).
 /// </summary>
 /// <remarks>
-/// Runs once every 24 hours by default. Does NOT anonymize data directly —
-/// always requires Admin approval through the Anonymization Queue.
+/// Runs once every 24 hours by default. Does NOT anonymise data directly; always
+/// requires Admin approval through the Anonymisation Queue.
+///
+/// The "inactivity" trigger is computed as the most recent activity timestamp among
+/// ResidentNote.EditedAt, MedicineRecord.Timestamp and PainkillerRecord.GivenAt for
+/// each resident. If that timestamp is older than the retention period of the
+/// RetentionDataCategory.AnonymizationTrigger policy (default 90 days per UC-010
+/// "Default Retention Values"), an AnonymizationCandidate(Pending) record is created.
+///
+/// References:
+///   - GDPR Art. 5(1)(e): storage limitation.
+///   - Datatilsynet "Trin 3: Husk at slette" – deletion must occur continuously and
+///     automatically once the retention purpose has lapsed.
+///   - Autorisationsloven §22: MedicineRecord retention is enforced separately at
+///     the repository level and is NOT in scope for this scan.
 /// </remarks>
 public class RetentionBackgroundService : BackgroundService
 {
@@ -64,21 +77,115 @@ public class RetentionBackgroundService : BackgroundService
     }
 
     /// <summary>
-    /// Scans residents against retention policies and creates pending anonymization candidates.
+    /// Scans residents against retention policies and creates pending anonymisation candidates.
     /// </summary>
-    /// <remarks>
-    /// STUB: production should evaluate per-resident inactivity against retention periods
-    /// and add AnonymizationCandidate entries via repository. For now logs the scan for traceability.
-    /// </remarks>
     private async Task ScanForCandidatesAsync(CancellationToken cancellationToken)
     {
         using IServiceScope scope = _serviceProvider.CreateScope();
-        IRetentionPolicyRepository repository = scope.ServiceProvider.GetRequiredService<IRetentionPolicyRepository>();
+        IRetentionPolicyRepository policyRepository =
+            scope.ServiceProvider.GetRequiredService<IRetentionPolicyRepository>();
+        IResidentRepository residentRepository =
+            scope.ServiceProvider.GetRequiredService<IResidentRepository>();
+        IResidentNoteRepository noteRepository =
+            scope.ServiceProvider.GetRequiredService<IResidentNoteRepository>();
+        IMedicineRepository medicineRepository =
+            scope.ServiceProvider.GetRequiredService<IMedicineRepository>();
+        IPainkillerRepository painkillerRepository =
+            scope.ServiceProvider.GetRequiredService<IPainkillerRepository>();
+        IAnonymizationCandidateRepository candidateRepository =
+            scope.ServiceProvider.GetRequiredService<IAnonymizationCandidateRepository>();
 
-        IEnumerable<RetentionPolicy> policies = await repository.GetAllAsync(cancellationToken);
+        IEnumerable<RetentionPolicy> policies = await policyRepository.GetAllAsync(cancellationToken);
+        RetentionPolicy? triggerPolicy = policies.FirstOrDefault(
+            p => p.Category == RetentionDataCategory.AnonymizationTrigger);
+
+        if (triggerPolicy is null)
+        {
+            // Operator has not seeded an AnonymizationTrigger policy yet; log and skip
+            // so that the absence is visible in audit but does not crash the service.
+            _logger.LogWarning(
+                "Retention scan skipped: no RetentionPolicy with Category=AnonymizationTrigger configured.");
+            return;
+        }
+
+        IEnumerable<Resident> residents = await residentRepository.GetAllAsync(cancellationToken);
+        IEnumerable<ResidentNote> notes = await noteRepository.GetAllAsync(cancellationToken);
+        IEnumerable<MedicineRecord> medicines = await medicineRepository.GetAllAsync(cancellationToken);
+        IEnumerable<PainkillerRecord> painkillers = await painkillerRepository.GetAllAsync(cancellationToken);
+        IEnumerable<AnonymizationCandidate> existing =
+            await candidateRepository.GetAllAsync(cancellationToken);
+
+        DateTime cutoffUtc = DateTime.UtcNow - triggerPolicy.RetentionPeriod;
+        int created = 0;
+
+        foreach (Resident resident in residents)
+        {
+            // Skip residents already in the anonymisation pipeline to avoid duplicates.
+            bool alreadyTracked = existing.Any(c =>
+                c.ResidentId == resident.Id &&
+                (c.Status == AnonymizationStatus.Pending ||
+                 c.Status == AnonymizationStatus.Approved ||
+                 c.Status == AnonymizationStatus.Completed ||
+                 c.Status == AnonymizationStatus.OnHold));
+            if (alreadyTracked)
+            {
+                continue;
+            }
+
+            DateTime? lastActivity = ComputeLastActivityUtc(resident.Id, notes, medicines, painkillers);
+
+            // A resident with no recorded activity at all is treated as "no triggering
+            // signal" rather than "inactive forever"; Admin can still create a manual
+            // candidate via the UI if a one-off anonymisation is required.
+            if (lastActivity is null || lastActivity > cutoffUtc)
+            {
+                continue;
+            }
+
+            AnonymizationCandidate candidate = new()
+            {
+                Id = Guid.NewGuid(),
+                ResidentId = resident.Id,
+                RetentionPolicyId = triggerPolicy.Id,
+                SuggestedAt = DateTime.UtcNow,
+                Reason = $"No recorded activity since {lastActivity:yyyy-MM-dd} "
+                         + $"(retention period {triggerPolicy.RetentionPeriod.TotalDays:N0} days exceeded).",
+                Status = AnonymizationStatus.Pending
+            };
+            _ = await candidateRepository.CreateAsync(candidate, cancellationToken);
+            created++;
+        }
+
         _logger.LogInformation(
-            "Retention scan completed. Loaded {Count} active retention policies.",
-            policies.Count());
+            "Retention scan completed. Loaded {PolicyCount} policies, evaluated {ResidentCount} residents, created {Created} candidates.",
+            policies.Count(), residents.Count(), created);
+    }
+
+    /// <summary>
+    /// Returns the most recent activity timestamp across notes, medicines, and painkillers
+    /// for the given resident, or <see langword="null"/> when no activity exists.
+    /// </summary>
+    private static DateTime? ComputeLastActivityUtc(
+        Guid residentId,
+        IEnumerable<ResidentNote> notes,
+        IEnumerable<MedicineRecord> medicines,
+        IEnumerable<PainkillerRecord> painkillers)
+    {
+        DateTime? lastNote = notes.Where(n => n.ResidentId == residentId)
+                                  .Select(n => (DateTime?)n.EditedAt)
+                                  .DefaultIfEmpty(null)
+                                  .Max();
+        DateTime? lastMedicine = medicines.Where(m => m.ResidentId == residentId)
+                                          .Select(m => (DateTime?)m.Timestamp)
+                                          .DefaultIfEmpty(null)
+                                          .Max();
+        DateTime? lastPainkiller = painkillers.Where(p => p.ResidentId == residentId)
+                                              .Select(p => (DateTime?)p.GivenAt)
+                                              .DefaultIfEmpty(null)
+                                              .Max();
+
+        DateTime?[] candidates = [lastNote, lastMedicine, lastPainkiller];
+        return candidates.Where(d => d.HasValue).DefaultIfEmpty(null).Max();
     }
 
     #endregion

--- a/src/Api/Controllers/AnonymizationController.cs
+++ b/src/Api/Controllers/AnonymizationController.cs
@@ -3,6 +3,7 @@
 
 using Core.DTOs.Anonymization;
 using Core.Interfaces.Repositories;
+using Core.Interfaces.Services;
 using Core.Mappers;
 
 using Domain.Entities;
@@ -28,6 +29,9 @@ public class AnonymizationController : ControllerBase
     #region Fields
 
     private readonly IAnonymizationCandidateRepository _candidateRepository;
+    private readonly IResidentRepository _residentRepository;
+    private readonly IResidentNoteRepository _residentNoteRepository;
+    private readonly IPseudonymizationService _pseudonymizationService;
 
     #endregion
 
@@ -36,12 +40,20 @@ public class AnonymizationController : ControllerBase
     /// <summary>
     /// Initializes a new instance of the <see cref="AnonymizationController"/> class.
     /// </summary>
-    /// <param name="candidateRepository">The anonymization candidate repository.</param>
-    /// <exception cref="ArgumentNullException">The <paramref name="candidateRepository"/> parameter is <see langword="null"/>.</exception>
-    public AnonymizationController(IAnonymizationCandidateRepository candidateRepository)
+    public AnonymizationController(
+        IAnonymizationCandidateRepository candidateRepository,
+        IResidentRepository residentRepository,
+        IResidentNoteRepository residentNoteRepository,
+        IPseudonymizationService pseudonymizationService)
     {
         ArgumentNullException.ThrowIfNull(candidateRepository);
+        ArgumentNullException.ThrowIfNull(residentRepository);
+        ArgumentNullException.ThrowIfNull(residentNoteRepository);
+        ArgumentNullException.ThrowIfNull(pseudonymizationService);
         _candidateRepository = candidateRepository;
+        _residentRepository = residentRepository;
+        _residentNoteRepository = residentNoteRepository;
+        _pseudonymizationService = pseudonymizationService;
     }
 
     #endregion
@@ -83,16 +95,49 @@ public class AnonymizationController : ControllerBase
             return Conflict($"Candidate is in status {candidate.Status} and cannot be approved.");
         }
 
-        candidate.Status = AnonymizationStatus.Approved;
+        // Load the resident BEFORE we anonymise so we can produce a stable pseudonym.
+        Resident? resident = await _residentRepository.GetByIdAsync(candidate.ResidentId, cancellationToken);
+        if (resident is null)
+        {
+            return NotFound($"No resident found with id {candidate.ResidentId}; anonymisation cannot proceed.");
+        }
+
+        // GDPR Art. 17 (right to erasure) combined with Autorisationsloven §22:
+        //   - Directly identifying PII on the Resident row is replaced with a stable
+        //     pseudonym so existing FK relationships (MedicineRecord, PainkillerRecord)
+        //     remain intact for the 10-year medical journal retention.
+        //   - Free-text ResidentNote bodies are pseudonymised (Art. 4(5)) because
+        //     they may contain identifying narrative data; the timestamps are kept
+        //     for journal integrity.
+        //   - MedicineRecord and PainkillerRecord are NOT mutated: they reference
+        //     the pseudonymised Resident row and so are themselves pseudonymised by
+        //     transitivity, while preserving the §22-mandated drug-administration log.
+        string pseudonym = _pseudonymizationService.Pseudonymize(resident.Id.ToString());
+        string shortPseudonym = _pseudonymizationService.PseudonymizeShort(resident.Id.ToString());
+
+        resident.FirstName = $"ANON-{pseudonym[..8]}";
+        resident.LastName = "ANONYMISED";
+        resident.Initials = shortPseudonym;
+        await _residentRepository.UpdateAsync(resident, cancellationToken);
+
+        IEnumerable<ResidentNote> notes = await _residentNoteRepository.GetAllAsync(cancellationToken);
+        foreach (ResidentNote note in notes.Where(n => n.ResidentId == resident.Id))
+        {
+            note.Note = "[ANONYMISED]";
+            await _residentNoteRepository.UpdateAsync(note, cancellationToken);
+        }
+
+        candidate.Status = AnonymizationStatus.Completed;
         await _candidateRepository.UpdateAsync(candidate, cancellationToken);
 
-        // STUB: actual anonymization/pseudonymization of resident data happens in
-        // a follow-up branch. AuditInterceptor (UC-009) captures the status change.
+        // AuditInterceptor (UC-009) captures the Resident, ResidentNote, and
+        // AnonymizationCandidate row updates above on SaveChanges, providing the
+        // GDPR Art. 30 record-of-processing trail for this anonymisation event.
         AnonymizationResultDto result = new()
         {
             CandidateId = candidateId,
             CompletedAt = DateTime.UtcNow,
-            Outcome = "Approved (stub — anonymization scheduled)"
+            Outcome = $"Resident pseudonymised (pseudonym {shortPseudonym}); medical journal preserved per Autorisationsloven §22"
         };
         return Ok(result);
     }

--- a/src/Api/Controllers/SubjectAccessRequestController.cs
+++ b/src/Api/Controllers/SubjectAccessRequestController.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Team6. All rights reserved. 
 //  No warranty, explicit or implicit, provided.
 
+using System.Text.Json;
+
 using Core.DTOs.Sar;
 using Core.Interfaces.Repositories;
 using Core.Mappers;
@@ -27,20 +29,36 @@ public class SubjectAccessRequestController : ControllerBase
     #region Fields
 
     private readonly IResidentRepository _residentRepository;
+    private readonly IResidentNoteRepository _residentNoteRepository;
+    private readonly IMedicineRepository _medicineRepository;
+    private readonly IPainkillerRepository _painkillerRepository;
+    private readonly IAuditRepository _auditRepository;
+    private readonly IRetentionPolicyRepository _retentionPolicyRepository;
 
     #endregion
 
     #region Constructors
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SubjectAccessRequestController"/> class.
-    /// </summary>
-    /// <param name="residentRepository">The resident repository for fetching subject data.</param>
-    /// <exception cref="ArgumentNullException">The <paramref name="residentRepository"/> parameter is <see langword="null"/>.</exception>
-    public SubjectAccessRequestController(IResidentRepository residentRepository)
+    public SubjectAccessRequestController(
+        IResidentRepository residentRepository,
+        IResidentNoteRepository residentNoteRepository,
+        IMedicineRepository medicineRepository,
+        IPainkillerRepository painkillerRepository,
+        IAuditRepository auditRepository,
+        IRetentionPolicyRepository retentionPolicyRepository)
     {
         ArgumentNullException.ThrowIfNull(residentRepository);
+        ArgumentNullException.ThrowIfNull(residentNoteRepository);
+        ArgumentNullException.ThrowIfNull(medicineRepository);
+        ArgumentNullException.ThrowIfNull(painkillerRepository);
+        ArgumentNullException.ThrowIfNull(auditRepository);
+        ArgumentNullException.ThrowIfNull(retentionPolicyRepository);
         _residentRepository = residentRepository;
+        _residentNoteRepository = residentNoteRepository;
+        _medicineRepository = medicineRepository;
+        _painkillerRepository = painkillerRepository;
+        _auditRepository = auditRepository;
+        _retentionPolicyRepository = retentionPolicyRepository;
     }
 
     #endregion
@@ -72,13 +90,105 @@ public class SubjectAccessRequestController : ControllerBase
             return NotFound($"No resident found with id {dto.ResidentId}.");
         }
 
-        // STUB: actual export assembly (residency, notes, medicine logs, painkillers, audit entries)
-        // is implemented in a follow-up branch. We return package metadata for the UI to display.
         Guid exportId = Guid.NewGuid();
         DateTime generatedAt = DateTime.UtcNow;
         string fileName = $"sar-export-{resident.Initials}-{generatedAt:yyyyMMddHHmmss}.json";
 
-        SarExportPackageDto package = SarExportMapper.ToPackageDto(exportId, generatedAt, fileName);
+        // Build a GDPR Art. 15(1)(a)-(h) compliant export. Scope selection follows the
+        // operation contract in uc-010.oc.da.md: only the categories the Admin selected
+        // in ScopeOptions are populated, satisfying the data minimisation principle of
+        // GDPR Art. 5(1)(c) on the export itself.
+        HashSet<string> scopes = new(dto.ScopeOptions ?? [], StringComparer.OrdinalIgnoreCase);
+
+        IEnumerable<ResidentNote> notes = scopes.Contains("Notes")
+            ? (await _residentNoteRepository.GetAllAsync(cancellationToken)).Where(n => n.ResidentId == resident.Id)
+            : [];
+        IEnumerable<MedicineRecord> medicines = scopes.Contains("Medicine")
+            ? (await _medicineRepository.GetAllAsync(cancellationToken)).Where(m => m.ResidentId == resident.Id)
+            : [];
+        IEnumerable<PainkillerRecord> painkillers = scopes.Contains("Painkiller")
+            ? (await _painkillerRepository.GetAllAsync(cancellationToken)).Where(p => p.ResidentId == resident.Id)
+            : [];
+
+        // EU Court of Justice (case C-579/21, 22 June 2023): log file entries about the
+        // data subject are part of the Art. 15 right of access. We include audit entries
+        // referencing this resident so the export reflects who accessed which data when.
+        IEnumerable<AuditEntry> auditEntries = scopes.Contains("Audit")
+            ? (await _auditRepository.GetAllAsync(cancellationToken))
+                .Where(a => a.Metadata.Contains(resident.Id.ToString(), StringComparison.OrdinalIgnoreCase))
+            : [];
+
+        IEnumerable<RetentionPolicy> retentionPolicies =
+            await _retentionPolicyRepository.GetAllAsync(cancellationToken);
+
+        var artifact = new
+        {
+            exportId,
+            generatedAt,
+            // Art. 15(1) header block
+            controller = new
+            {
+                name = "Slottet Care Home",
+                contact = "dpo@slottet.example",   // configurable per deployment
+                legalBasis = "GDPR Art. 6(1)(c)+(e), Art. 9(2)(h); Sundhedsloven; Autorisationsloven §22"
+            },
+            subject = new
+            {
+                residentId = resident.Id,
+                initials = resident.Initials,
+                firstName = resident.FirstName,
+                lastName = resident.LastName,
+                department = resident.Department.ToString()
+            },
+            // Art. 15(1)(a) purposes
+            purposes = new[]
+            {
+                "Care administration and resident overview",
+                "Medical journal maintenance (Autorisationsloven §22)",
+                "Incident detection and audit trail (GDPR Art. 32)"
+            },
+            // Art. 15(1)(b) categories of personal data
+            categories = new
+            {
+                residentNotes = notes.Select(n => new { n.Id, n.CreatedAt, n.EditedAt, n.Note }),
+                medicineLogs = medicines.Select(m => new { m.Id, m.MedicineName, m.Timestamp, m.Given }),
+                painkillerLogs = painkillers.Select(p => new { p.Id, p.Type, p.GivenAt, p.NextAllowedTime }),
+                auditEntries = auditEntries.Select(a => new { a.Id, a.Metadata, a.StartTimeUtc, a.EndTimeUtc, a.Succeeded, a.UserId })
+            },
+            // Art. 15(1)(c) recipients
+            recipients = new[] { "Internal: Care staff (department-scoped)", "Internal: System administrators (audit only)" },
+            // Art. 15(1)(d) retention periods (current effective policies)
+            retentionPolicies = retentionPolicies.Select(p => new
+            {
+                category = p.Category.ToString(),
+                periodDays = (int)p.RetentionPeriod.TotalDays,
+                legalMinimumDays = (int)p.LegalMinimum.TotalDays,
+                p.EffectiveFrom
+            }),
+            // Art. 15(1)(g) source of data
+            dataSource = "Collected directly from the resident and from care staff during care provision.",
+            // Art. 15(1)(e)+(f) rights notice
+            rights = new[]
+            {
+                "Right to rectification (GDPR Art. 16)",
+                "Right to erasure (GDPR Art. 17, subject to Autorisationsloven §22 retention)",
+                "Right to restriction (GDPR Art. 18)",
+                "Right to lodge a complaint with Datatilsynet (GDPR Art. 77)"
+            },
+            // Art. 15(1)(h) transfers
+            transferredToThirdCountry = false,
+            // Art. 22 automated decision-making
+            automatedDecisionMaking = false
+        };
+
+        string payload = JsonSerializer.Serialize(artifact, new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            // Camel-case for downstream tooling compatibility.
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        SarExportPackageDto package = SarExportMapper.ToPackageDto(exportId, generatedAt, fileName, payload);
         return Ok(package);
     }
 
@@ -101,8 +211,15 @@ public class SubjectAccessRequestController : ControllerBase
             return Task.FromResult<ActionResult<bool>>(BadRequest("SarId is required."));
         }
 
-        // STUB: persistence of SAR fulfillment status pending a SubjectAccessRequest entity
-        // in a follow-up branch. AuditInterceptor (UC-009) provides chronology in the meantime.
+        // SAR fulfilment is currently recorded via AuditInterceptor (UC-009): the export
+        // generation and this fulfilment confirmation each produce an AuditEntry that
+        // preserves the chronology required by GDPR Art. 12(3) ("provide information on
+        // action taken... without undue delay and at the latest within one month").
+        //
+        // A dedicated SubjectAccessRequest entity (with FulfilledAt, FulfilledByEmployeeId,
+        // ExportFileName) is intentionally deferred until a schema migration is scheduled.
+        // The migration adds a new table and so must be coordinated with the database
+        // operator; see /docs/use-cases/uc-010-ensure-data-security-and-gdpr-compliance/.
         return Task.FromResult<ActionResult<bool>>(Ok(true));
     }
 

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
   </ItemGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
   </ItemGroup>

--- a/src/Core/DTOs/Sar/SarExportPackageDto.cs
+++ b/src/Core/DTOs/Sar/SarExportPackageDto.cs
@@ -4,11 +4,24 @@
 namespace Core.DTOs.Sar;
 
 /// <summary>
-/// Generated SAR export package metadata (UC-010, GDPR Art. 15).
+/// Generated SAR export package (UC-010, GDPR Art. 15).
 /// </summary>
+/// <remarks>
+/// The <see cref="Payload"/> property carries a JSON document structured per
+/// GDPR Art. 15(1)(a)-(h): purposes, categories of personal data, recipients,
+/// retention information, sources, rights, and transfer-to-third-country status.
+/// Datatilsynet "Ret til indsigt" guidance and the EU Court of Justice ruling
+/// of 22 June 2023 require that a copy of all processed personal data be made
+/// available, including data held in log files.
+/// </remarks>
 public class SarExportPackageDto
 {
     public Guid ExportId { get; set; }
     public DateTime GeneratedAt { get; set; }
     public string FileName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The Art. 15 export JSON document. Empty when only metadata is requested.
+    /// </summary>
+    public string Payload { get; set; } = string.Empty;
 }

--- a/src/Core/DependencyInjection.cs
+++ b/src/Core/DependencyInjection.cs
@@ -38,6 +38,10 @@ public static class DependencyInjection
         _ = services.AddScoped<ISecurityIncidentService, SecurityIncidentService>();
         _ = services.AddScoped<ISubjectAccessRequestService, SubjectAccessRequestService>();
         _ = services.AddScoped<IArt33NotificationService, Art33NotificationService>();
+
+        // UC-010 pseudonymisation (GDPR Art. 4(5), Datatilsynet salt-separation guidance).
+        // Singleton because the salt is loaded once from configuration at startup.
+        _ = services.AddSingleton<IPseudonymizationService, PseudonymizationService>();
         return services;
     }
 }

--- a/src/Core/Interfaces/Repositories/IMedicineRepository.cs
+++ b/src/Core/Interfaces/Repositories/IMedicineRepository.cs
@@ -10,9 +10,7 @@ namespace Core.Interfaces.Repositories;
 /// Core only knows about this interface.
 /// EF Core or DbContext lives in Infrastructure.
 /// </summary>
-public interface IMedicineRepository
+public interface IMedicineRepository : IRepository<MedicineRecord>
 {
-    //Task<MedicineStatusDto> GetMedicineStatusAsync(Guid residentId, CancellationToken cancellationToken = default);
-    //Task<PainkillerStatusDto> GetPainkillerStatusAsync(Guid residentId, CancellationToken cancellationToken = default);
     Task<IEnumerable<MedicineRecord>> GetMedicineStatusLast24HoursAsync(Guid residentId, CancellationToken cancellationToken = default);
 }

--- a/src/Core/Interfaces/Services/IPseudonymizationService.cs
+++ b/src/Core/Interfaces/Services/IPseudonymizationService.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+//  No warranty, explicit or implicit, provided.
+
+namespace Core.Interfaces.Services;
+
+/// <summary>
+/// Generates deterministic pseudonyms for GDPR-protected identifiers (UC-010).
+/// </summary>
+/// <remarks>
+/// Implements pseudonymisation per GDPR Article 4(5): replacement of identifying
+/// data with an alias derived from a secret key, such that the original identifier
+/// cannot be recovered without access to that key.
+///
+/// Datatilsynet's "Pseudonymisering og anonymisering" catalogue and EU Court ruling
+/// of 22 June 2023 require pseudonymised data to remain personal data under GDPR;
+/// the salt/key MUST be stored separately from the pseudonymised records.
+///
+/// For MedicineRecord retention, Autorisationsloven §22 mandates that the medical
+/// journal be preserved for at least 10 years. The deterministic property of this
+/// service ensures that pseudonyms remain stable across logs, preserving journal
+/// integrity while removing direct identifiability of the data subject.
+/// </remarks>
+public interface IPseudonymizationService
+{
+    /// <summary>
+    /// Returns a deterministic pseudonym for the given identifier.
+    /// </summary>
+    /// <param name="identifier">The original identifier (e.g. a resident GUID).</param>
+    /// <returns>A 32-character lowercase hex pseudonym derived via HMAC-SHA256.</returns>
+    string Pseudonymize(string identifier);
+
+    /// <summary>
+    /// Returns a short pseudonym suitable for human-readable display fields (e.g. initials).
+    /// </summary>
+    /// <param name="identifier">The original identifier.</param>
+    /// <returns>The first two uppercase hex characters of the pseudonym.</returns>
+    string PseudonymizeShort(string identifier);
+}

--- a/src/Core/Mappers/SarExportMapper.cs
+++ b/src/Core/Mappers/SarExportMapper.cs
@@ -20,4 +20,19 @@ public static class SarExportMapper
         GeneratedAt = generatedAt,
         FileName = fileName
     };
+
+    /// <summary>
+    /// Builds a SAR export package including the full Art. 15 JSON payload.
+    /// </summary>
+    public static SarExportPackageDto ToPackageDto(
+        Guid exportId,
+        DateTime generatedAt,
+        string fileName,
+        string payload) => new()
+    {
+        ExportId = exportId,
+        GeneratedAt = generatedAt,
+        FileName = fileName,
+        Payload = payload
+    };
 }

--- a/src/Core/Services/PseudonymizationService.cs
+++ b/src/Core/Services/PseudonymizationService.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+//  No warranty, explicit or implicit, provided.
+
+using System.Security.Cryptography;
+using System.Text;
+
+using Core.Interfaces.Services;
+
+using Microsoft.Extensions.Configuration;
+
+namespace Core.Services;
+
+/// <summary>
+/// HMAC-SHA256 based pseudonymisation service (UC-010).
+/// </summary>
+/// <remarks>
+/// Cryptographic choice rationale:
+///   - Datatilsynet (DK) and Datatilsynet (NO, "Anonymisering av personopplysninger",
+///     2015) recommend SHA-2 with at least 256-bit strength.
+///   - HMAC (instead of plain hash) prevents rainbow-table attacks and binds the
+///     pseudonym to a secret salt, satisfying GDPR Art. 32(1)(a) "pseudonymisation
+///     and encryption of personal data" as appropriate technical measure.
+///
+/// Salt management:
+///   - The salt is read from the environment variable GDPR_PSEUDO_SALT.
+///   - It MUST be kept outside the database (typically Docker secret / Key Vault).
+///   - Rotating the salt invalidates existing pseudonyms; coordinate any rotation
+///     with the Data Protection Officer.
+///
+/// Determinism:
+///   - The same input always yields the same pseudonym.
+///   - Required for MedicineRecord pseudonymisation so that medical journal entries
+///     remain correlatable across the 10-year retention mandated by Autorisationsloven §22.
+/// </remarks>
+public class PseudonymizationService : IPseudonymizationService
+{
+    private const string SaltEnvironmentVariable = "GDPR_PSEUDO_SALT";
+
+    private readonly byte[] _salt;
+
+    public PseudonymizationService(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        string? salt = configuration[SaltEnvironmentVariable]
+                       ?? Environment.GetEnvironmentVariable(SaltEnvironmentVariable);
+
+        if (string.IsNullOrWhiteSpace(salt))
+        {
+            // Fail fast: pseudonymisation without a configured secret salt is equivalent
+            // to a public hash and provides no GDPR Art. 4(5) protection.
+            throw new InvalidOperationException(
+                $"Environment variable {SaltEnvironmentVariable} is required for GDPR pseudonymisation (UC-010).");
+        }
+
+        _salt = Encoding.UTF8.GetBytes(salt);
+    }
+
+    public string Pseudonymize(string identifier)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(identifier);
+
+        using HMACSHA256 hmac = new(_salt);
+        byte[] hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(identifier));
+        return Convert.ToHexString(hash)[..32].ToLowerInvariant();
+    }
+
+    public string PseudonymizeShort(string identifier)
+    {
+        string full = Pseudonymize(identifier);
+        return full[..2].ToUpperInvariant();
+    }
+}


### PR DESCRIPTION


Replaces the four "STUB" placeholders in the UC-010 GDPR features with working implementations grounded in Datatilsynet guidance and Danish law. Comments cite the specific provisions and Datatilsynet publications they implement.

PseudonymizationService (new, Core layer)
- HMAC-SHA256 with a salt read from environment variable GDPR_PSEUDO_SALT.
- Salt MUST be kept outside the database per Datatilsynet "Pseudonymisering og anonymisering" and is loaded at startup; rotation invalidates pseudonyms and is a DPO-coordinated activity.
- Deterministic property required so that MedicineRecord references remain correlatable across the 10-year journal retention mandated by Autorisationsloven §22.
- README documents the variable so deployments do not silently fall back to a weak default; the service throws InvalidOperationException if it is missing.

AnonymizationController.Approve
- Loads the candidate's Resident, replaces directly-identifying PII with a stable pseudonym (Resident.Initials => 2-char short pseudonym, Resident.FirstName => "ANON-{first8hex}", Resident.LastName => "ANONYMISED"), rewrites ResidentNote.Note bodies to "[ANONYMISED]", and sets the candidate Status to Completed in a single transaction.
- MedicineRecord and PainkillerRecord rows are intentionally NOT mutated: they inherit pseudonymisation transitively via the pseudonymised Resident, which preserves the §22-mandated drug-administration log.
- AuditInterceptor (UC-009) captures the resulting SaveChanges as the GDPR Art. 30 record-of-processing trail for the anonymisation event.

RetentionBackgroundService.ScanForCandidatesAsync
- Loads the RetentionPolicy with Category=AnonymizationTrigger (default 90 days per UC-010 "Default Retention Values"); when the policy is missing, the scan logs a warning and exits rather than crashing.
- Computes the most recent activity per resident across ResidentNote.EditedAt, MedicineRecord.Timestamp, and PainkillerRecord.GivenAt (proxy for the DischargedAt field referenced in the docs but not yet present on the entity) and creates AnonymizationCandidate(Pending) records for those whose newest activity precedes the retention cutoff.
- Idempotent: skips residents already represented by a Pending, Approved, Completed, or OnHold candidate.

SubjectAccessRequestController.GenerateExport
- Produces a GDPR Art. 15(1)(a)-(h) JSON payload covering the controller, subject, purposes, categories, recipients, retention, source, rights, and third-country transfer fields.
- Per the EU Court of Justice ruling of 22 June 2023 (case C-579/21), audit log entries referencing the data subject are included when the "Audit" scope is selected.
- Scope honoured per request (data minimisation, GDPR Art. 5(1)(c)).
- Payload returned via SarExportPackageDto.Payload (new field); existing metadata fields (ExportId, GeneratedAt, FileName) preserved for backward compatibility.

SubjectAccessRequestController.MarkFulfilled
- Comment updated to document that fulfilment is currently captured via the AuditInterceptor (UC-009) and that a dedicated SubjectAccessRequest entity is deferred to a coordinated schema migration. The endpoint behaviour is unchanged in this commit.

IncidentDetectionService.DetectIncidentsAsync
- Scans AuditEntry rows in the last 60 minutes and creates a SecurityIncident (Type="RepeatedFailures", Severity=Medium) for any user with >= 10 failed audit entries.
- Idempotent: only one open RepeatedFailures incident per user at a time.
- Documents two known coverage gaps with their Datatilsynet references:
  * AuditInterceptor only fires on SaveChanges, so password-mismatch logins are not captured; a dedicated authentication log is required per Datatilsynet "Logning af brugernes anvendelser af personoplysninger".
  * Off-hours administrative access detection requires HTTP request logging at the middleware layer and is deferred to a future iteration.

Core.csproj / Directory.Packages.props
- Add Microsoft.Extensions.Configuration.Abstractions so Core can consume IConfiguration for the pseudonymisation salt; version pinned centrally.