### PR TITLE
Add GDPR Compliance link to the Administration dropdown

### DIFF
--- a/src/WebUI/WebUI.Client/Components/NavItemAdministration.razor
+++ b/src/WebUI/WebUI.Client/Components/NavItemAdministration.razor
@@ -22,6 +22,12 @@ else
         <li>
           <NavLink class="dropdown-item" href="/management/residents" Match="NavLinkMatch.All">Beboere</NavLink>
         </li>
+        <li><hr class="dropdown-divider" /></li>
+        <li>
+          <NavLink class="dropdown-item" href="/admin/gdpr" Match="NavLinkMatch.Prefix">
+            🛡️ GDPR Compliance
+          </NavLink>
+        </li>
       </ul>
     </li>
     </Authorized>


### PR DESCRIPTION
The /admin/gdpr pages (Dashboard, RetentionSettings, AnonymizationQueue, SecurityIncidents, SubjectAccessRequest) were protected by [Authorize(Roles = "admin")] but had no entry point in the navigation, so the only way an Admin could reach them was by typing the URL.

Add a "GDPR Compliance" item to the existing admin-only Administration dropdown so the feature is discoverable. Match=NavLinkMatch.Prefix keeps the link highlighted on every sub-route under /admin/gdpr.