### PR TITLE
Adopt GdprDashboardPage's OnAfterRenderAsync pattern across Anonymiza…

### DIFF
--- a/src/WebUI/WebUI.Client/Components/Pages/Gdpr/AnonymizationQueuePage.razor.cs
+++ b/src/WebUI/WebUI.Client/Components/Pages/Gdpr/AnonymizationQueuePage.razor.cs
@@ -7,6 +7,7 @@ using Core.Interfaces.Services;
 using Domain.Enums;
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
 
 namespace WebUI.Client.Components.Pages.Gdpr;
 
@@ -19,6 +20,8 @@ public partial class AnonymizationQueuePage : ComponentBase
 
     [Inject]
     private IAnonymizationService AnonymizationService { get; set; } = default!;
+    [Inject]
+    private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
 
     #endregion
 
@@ -36,9 +39,27 @@ public partial class AnonymizationQueuePage : ComponentBase
 
     #region Lifecycle
 
-    protected override async Task OnInitializedAsync()
+    /// <inheritdoc />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (!firstRender)
+        {
+            return;
+        }
+        // Ensure the WASM auth state has been materialised from localStorage before
+        // invoking API calls, so JwtAuthorizationMessageHandler can attach the
+        // Bearer token. OnInitializedAsync would run during InteractiveAuto's
+        // server pre-render where JS interop is unavailable and every API call
+        // returns 401. Mirrors the pattern established by GdprDashboardPage.
+        await InitializeAuthorizationAsync();
         await LoadCandidatesAsync();
+        StateHasChanged();
+    }
+
+    private async Task InitializeAuthorizationAsync()
+    {
+        AuthenticationState authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        _ = authState.User;
     }
 
     #endregion

--- a/src/WebUI/WebUI.Client/Components/Pages/Gdpr/RetentionSettingsPage.razor.cs
+++ b/src/WebUI/WebUI.Client/Components/Pages/Gdpr/RetentionSettingsPage.razor.cs
@@ -7,6 +7,7 @@ using Core.Interfaces.Services;
 using Domain.Enums;
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
 
 namespace WebUI.Client.Components.Pages.Gdpr;
 
@@ -19,6 +20,8 @@ public partial class RetentionSettingsPage : ComponentBase
 
     [Inject]
     private IRetentionPolicyService RetentionPolicyService { get; set; } = default!;
+    [Inject]
+    private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
 
     #endregion
 
@@ -35,9 +38,27 @@ public partial class RetentionSettingsPage : ComponentBase
 
     #region Lifecycle
 
-    protected override async Task OnInitializedAsync()
+    /// <inheritdoc />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (!firstRender)
+        {
+            return;
+        }
+        // Ensure the WASM auth state has been materialised from localStorage before
+        // invoking API calls, so JwtAuthorizationMessageHandler can attach the
+        // Bearer token. OnInitializedAsync would run during InteractiveAuto's
+        // server pre-render where JS interop is unavailable and every API call
+        // returns 401. Mirrors the pattern established by GdprDashboardPage.
+        await InitializeAuthorizationAsync();
         await LoadPoliciesAsync();
+        StateHasChanged();
+    }
+
+    private async Task InitializeAuthorizationAsync()
+    {
+        AuthenticationState authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        _ = authState.User;
     }
 
     #endregion

--- a/src/WebUI/WebUI.Client/Components/Pages/Gdpr/SecurityIncidentsPage.razor.cs
+++ b/src/WebUI/WebUI.Client/Components/Pages/Gdpr/SecurityIncidentsPage.razor.cs
@@ -7,6 +7,7 @@ using Core.Interfaces.Services;
 using Domain.Enums;
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
 
 namespace WebUI.Client.Components.Pages.Gdpr;
 
@@ -22,6 +23,8 @@ public partial class SecurityIncidentsPage : ComponentBase
 
     [Inject]
     private ISecurityIncidentService SecurityIncidentService { get; set; } = default!;
+    [Inject]
+    private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
 
     #endregion
 
@@ -39,9 +42,27 @@ public partial class SecurityIncidentsPage : ComponentBase
 
     #region Lifecycle
 
-    protected override async Task OnInitializedAsync()
+    /// <inheritdoc />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (!firstRender)
+        {
+            return;
+        }
+        // Ensure the WASM auth state has been materialised from localStorage before
+        // invoking API calls, so JwtAuthorizationMessageHandler can attach the
+        // Bearer token. OnInitializedAsync would run during InteractiveAuto's
+        // server pre-render where JS interop is unavailable and every API call
+        // returns 401. Mirrors the pattern established by GdprDashboardPage.
+        await InitializeAuthorizationAsync();
         await LoadIncidentsAsync();
+        StateHasChanged();
+    }
+
+    private async Task InitializeAuthorizationAsync()
+    {
+        AuthenticationState authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        _ = authState.User;
     }
 
     #endregion


### PR DESCRIPTION


GdprDashboardPage already loads its data from OnAfterRenderAsync(firstRender) and primes the auth state via InitializeAuthorizationAsync (Jens Tirsvad Nielsen's pattern). The other three admin GDPR pages still used OnInitializedAsync, which runs during InteractiveAuto's server pre-render where JS interop and localStorage are unavailable. The Bearer token cannot be read, JwtAuthorizationMessageHandler attaches no Authorization header, and the API returns 401 — the pages then render empty for an admin who is in fact correctly logged in.

Align AnonymizationQueuePage, RetentionSettingsPage and SecurityIncidentsPage with the established Dashboard pattern:
  - Inject AuthenticationStateProvider.
  - Replace OnInitializedAsync with OnAfterRenderAsync(firstRender) guarded on the first interactive render only.
  - Call InitializeAuthorizationAsync() before the data load so the WASM auth state is materialised from localStorage in time for the request.
  - Call StateHasChanged() explicitly because OnAfterRenderAsync does not trigger a re-render itself.
  - Add `using Microsoft.AspNetCore.Components.Authorization;`.

No DTO, controller or migration changes are needed; this is purely the Blazor-side fix for the InteractiveAuto rendering quirk.