### PR TITLE
fix: show resident admin CRUD buttons + names in backend only

### DIFF
--- a/src/Api/Controllers/ResidentController.cs
+++ b/src/Api/Controllers/ResidentController.cs
@@ -42,6 +42,8 @@ public class ResidentController(IResidentRepository residentRepository) : Contro
         {
             Id = r.Id,
             Initials = r.Initials,
+            FirstName = r.FirstName,
+            LastName = r.LastName,
             TrafficLightStatus = r.TrafficLightStatus.HasValue ? (int)r.TrafficLightStatus.Value : null,
             Department = r.Department,
             Activity = r.Activity,
@@ -128,6 +130,8 @@ public class ResidentController(IResidentRepository residentRepository) : Contro
         {
             Id = created.Id,
             Initials = created.Initials,
+            FirstName = created.FirstName,
+            LastName = created.LastName,
             TrafficLightStatus = created.TrafficLightStatus.HasValue ? (int)created.TrafficLightStatus.Value : null,
             Department = created.Department,
             Activity = created.Activity,
@@ -158,6 +162,8 @@ public class ResidentController(IResidentRepository residentRepository) : Contro
         {
             Id = resident.Id,
             Initials = resident.Initials,
+            FirstName = resident.FirstName,
+            LastName = resident.LastName,
             TrafficLightStatus = resident.TrafficLightStatus.HasValue ? (int)resident.TrafficLightStatus.Value : null,
             Department = resident.Department,
             Activity = resident.Activity,
@@ -299,6 +305,8 @@ public class ResidentController(IResidentRepository residentRepository) : Contro
         {
             Id = resident.Id,
             Initials = resident.Initials,
+            FirstName = resident.FirstName,
+            LastName = resident.LastName,
             TrafficLightStatus = resident.TrafficLightStatus.HasValue ? (int)resident.TrafficLightStatus.Value : null,
             Department = resident.Department,
             Activity = resident.Activity,

--- a/src/WebUI/WebUI.Client/Components/Pages/Management/Residents/Residents.razor.cs
+++ b/src/WebUI/WebUI.Client/Components/Pages/Management/Residents/Residents.razor.cs
@@ -102,8 +102,15 @@ public partial class Residents : ComponentBase
         AuthenticationState authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
         ClaimsPrincipal user = authState.User;
 
-        _hasManageClaim = user.HasClaim(c => c.Type == "permission" && c.Value == "manage:residents");
-        _userDepartment = user.FindFirst("department")?.Value;
+        // Admins and superusers may manage all residents; a "CanManageResidents" role
+        // claim grants the same without full admin. Mirrors the WebApi "CanManageResidents" policy.
+        _hasManageClaim = user.IsInRole("admin")
+            || user.IsInRole("superuser")
+            || user.HasClaim(c => c.Type == ClaimTypes.Role && c.Value == "CanManageResidents");
+
+        // Non-admins may be restricted to a single department via the "Department" claim
+        // emitted by TokenService. Admins have no Department claim, so they are unrestricted.
+        _userDepartment = user.FindFirst("Department")?.Value;
     }
     #endregion
 


### PR DESCRIPTION
## Problem
The Resident admin page hid all CRUD buttons (Opret/Rediger/Slet) because it checked a `permission`=`manage:residents` claim the JWT never contains. Admins saw no buttons.

## Fix
- Residents page derives manage rights from the **admin/superuser role** (matching the WebApi `CanManageResidents` policy) + correct `Department` claim casing
- `ResidentController` GetAll/GetById/Create now return **FirstName/LastName** for the authenticated admin backend
- `GetByDepartment` (the dashboard endpoint) still returns **initials only** — full names are never sent to the public info screen (data minimisation / GDPR)

## Result
- Admins get full Resident CRUD (Create/Read/Update/Delete) in the backend
- Backend table shows full names; dashboard cards show initials only

## Test plan
- [x] All 234 tests pass
- [ ] Manual: log in as admin, see Opret/Rediger/Slet, create a resident, confirm name shows in admin but only initials on dashboard

Refs UC-014, UC-015, UC-016