### PR TITLE
fix: implement resident delete + await create

### DIFF
--- a/src/Core/Services/ResidentService.cs
+++ b/src/Core/Services/ResidentService.cs
@@ -76,7 +76,7 @@ public class ResidentService(IResidentManager residentManager) : IResidentServic
         // Validation logic
         ArgumentNullException.ThrowIfNull(dto);
         _ = ResidentMapper.ToResident(dto);
-        _ = residentManager.CreateAsync(dto, ct);
+        await residentManager.CreateAsync(dto, ct);
         await Task.CompletedTask;
     }
 

--- a/src/Infrastructure/Managers/ResidentManager.cs
+++ b/src/Infrastructure/Managers/ResidentManager.cs
@@ -161,9 +161,13 @@ public class ResidentManager(IHttpClientFactory httpClientFactory) : HttpApiMana
     /// <exception cref="NotImplementedException">
     /// Always thrown as this method is not implemented.
     /// </exception>
-    public Task DeleteAsync(Guid id, CancellationToken ct = default)
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
     {
-        throw new NotImplementedException();
+        HttpResponseMessage response = await HttpClient.DeleteAsync($"residents/{id}", ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Failed to delete resident. Status code: {response.StatusCode}");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Makes the Resident admin CRUD work end-to-end (not just visually).

## Bugs fixed
- **Slet**: `ResidentManager.DeleteAsync` threw `NotImplementedException`. It now calls `DELETE residents/{id}` (the existing API endpoint), so delete works.
- **Opret**: `ResidentService.CreateAsync` used fire-and-forget `_ = residentManager.CreateAsync(...)` which discarded the Task — errors were swallowed and completion not guaranteed. Now awaited.

Update already worked.

## Test plan
- [x] All 234 tests pass
- [ ] Manual: as admin, create a resident (appears in list + dashboard), then delete it (disappears)

Refs UC-014, UC-016