### PR TITLE
test: round 1 - mapper + ResidentService unit tests

### DIFF
--- a/tests/Core.Tests/Mappers/MedicineDeliveryMapperTests.cs
+++ b/tests/Core.Tests/Mappers/MedicineDeliveryMapperTests.cs
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+using Core.Mappers;
+using Domain.Entities;
+using Xunit;
+
+namespace Core.Tests.Mappers;
+
+/// <summary>
+/// Unit tests for <see cref="MedicineDeliveryMapper"/> (UC-020/021/022).
+/// </summary>
+public class MedicineDeliveryMapperTests
+{
+    #region ToMedicineRecord (CreateRequestDto)
+
+    [Fact]
+    public void ToMedicineRecord_FromCreateDto_MapsAllFields()
+    {
+        Guid residentId = Guid.NewGuid();
+        DateTime timestamp = new(2026, 5, 23, 8, 0, 0, DateTimeKind.Utc);
+        MedicineDeliveryCreateRequestDto dto = new()
+        {
+            ResidentId = residentId,
+            MedicineName = "Panodil",
+            Timestamp = timestamp,
+            Given = true
+        };
+
+        MedicineRecord result = MedicineDeliveryMapper.ToMedicineRecord(dto);
+
+        Assert.Equal(residentId, result.ResidentId);
+        Assert.Equal("Panodil", result.MedicineName);
+        Assert.Equal(timestamp, result.Timestamp);
+        Assert.True(result.Given);
+    }
+
+    [Fact]
+    public void ToMedicineRecord_FromCreateDto_GeneratesNonEmptyId()
+    {
+        MedicineDeliveryCreateRequestDto dto = new()
+        {
+            ResidentId = Guid.NewGuid(),
+            MedicineName = "Ipren",
+            Timestamp = DateTime.UtcNow
+        };
+
+        MedicineRecord result = MedicineDeliveryMapper.ToMedicineRecord(dto);
+
+        Assert.NotEqual(Guid.Empty, result.Id);
+    }
+
+    [Fact]
+    public void ToMedicineRecord_FromCreateDto_TwoCalls_ProduceDifferentIds()
+    {
+        MedicineDeliveryCreateRequestDto dto = new()
+        {
+            ResidentId = Guid.NewGuid(),
+            MedicineName = "Ipren",
+            Timestamp = DateTime.UtcNow
+        };
+
+        MedicineRecord first = MedicineDeliveryMapper.ToMedicineRecord(dto);
+        MedicineRecord second = MedicineDeliveryMapper.ToMedicineRecord(dto);
+
+        Assert.NotEqual(first.Id, second.Id);
+    }
+
+    [Fact]
+    public void ToMedicineRecord_FromNullCreateDto_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            MedicineDeliveryMapper.ToMedicineRecord((MedicineDeliveryCreateRequestDto)null!));
+    }
+
+    #endregion
+
+    #region ToMedicineRecord (ResponseDto)
+
+    [Fact]
+    public void ToMedicineRecord_FromResponseDto_PreservesId()
+    {
+        Guid id = Guid.NewGuid();
+        MedicineDeliveryResponseDto dto = new()
+        {
+            Id = id,
+            ResidentId = Guid.NewGuid(),
+            MedicineName = "Panodil",
+            Timestamp = DateTime.UtcNow,
+            Given = false
+        };
+
+        MedicineRecord result = MedicineDeliveryMapper.ToMedicineRecord(dto);
+
+        Assert.Equal(id, result.Id);
+        Assert.Equal(dto.ResidentId, result.ResidentId);
+        Assert.Equal(dto.MedicineName, result.MedicineName);
+        Assert.False(result.Given);
+    }
+
+    [Fact]
+    public void ToMedicineRecord_FromNullResponseDto_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            MedicineDeliveryMapper.ToMedicineRecord((MedicineDeliveryResponseDto)null!));
+    }
+
+    #endregion
+
+    #region ApplyUpdate
+
+    [Fact]
+    public void ApplyUpdate_OverwritesMutableFields_KeepsId()
+    {
+        Guid originalId = Guid.NewGuid();
+        MedicineRecord record = new()
+        {
+            Id = originalId,
+            ResidentId = Guid.NewGuid(),
+            MedicineName = "Old",
+            Timestamp = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Given = false
+        };
+        Guid newResident = Guid.NewGuid();
+        DateTime newTime = new(2026, 5, 23, 9, 0, 0, DateTimeKind.Utc);
+        MedicineDeliveryUpdateRequestDto dto = new()
+        {
+            ResidentId = newResident,
+            MedicineName = "New",
+            Timestamp = newTime,
+            Given = true
+        };
+
+        MedicineDeliveryMapper.ApplyUpdate(record, dto);
+
+        Assert.Equal(originalId, record.Id);
+        Assert.Equal(newResident, record.ResidentId);
+        Assert.Equal("New", record.MedicineName);
+        Assert.Equal(newTime, record.Timestamp);
+        Assert.True(record.Given);
+    }
+
+    [Fact]
+    public void ApplyUpdate_NullRecord_Throws()
+    {
+        MedicineDeliveryUpdateRequestDto dto = new() { MedicineName = "x", Timestamp = DateTime.UtcNow };
+        Assert.Throws<ArgumentNullException>(() => MedicineDeliveryMapper.ApplyUpdate(null!, dto));
+    }
+
+    [Fact]
+    public void ApplyUpdate_NullDto_Throws()
+    {
+        MedicineRecord record = new() { MedicineName = "x", Timestamp = DateTime.UtcNow };
+        Assert.Throws<ArgumentNullException>(() => MedicineDeliveryMapper.ApplyUpdate(record, null!));
+    }
+
+    #endregion
+
+    #region ToResponseDto
+
+    [Fact]
+    public void ToResponseDto_MapsAllFields()
+    {
+        MedicineRecord record = new()
+        {
+            Id = Guid.NewGuid(),
+            ResidentId = Guid.NewGuid(),
+            MedicineName = "Panodil",
+            Timestamp = DateTime.UtcNow,
+            Given = true
+        };
+
+        MedicineDeliveryResponseDto dto = MedicineDeliveryMapper.ToResponseDto(record);
+
+        Assert.Equal(record.Id, dto.Id);
+        Assert.Equal(record.ResidentId, dto.ResidentId);
+        Assert.Equal(record.MedicineName, dto.MedicineName);
+        Assert.Equal(record.Timestamp, dto.Timestamp);
+        Assert.True(dto.Given);
+    }
+
+    [Fact]
+    public void ToResponseDto_NullRecord_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => MedicineDeliveryMapper.ToResponseDto(null!));
+    }
+
+    #endregion
+
+    #region Concurrency
+
+    [Fact]
+    public void ToResponseDto_UnderParallelLoad_IsThreadSafe()
+    {
+        MedicineRecord[] records = Enumerable.Range(0, 500)
+            .Select(i => new MedicineRecord
+            {
+                Id = Guid.NewGuid(),
+                ResidentId = Guid.NewGuid(),
+                MedicineName = $"med-{i}",
+                Timestamp = DateTime.UtcNow,
+                Given = i % 2 == 0
+            })
+            .ToArray();
+
+        MedicineDeliveryResponseDto[] results = new MedicineDeliveryResponseDto[records.Length];
+        Parallel.For(0, records.Length, i =>
+        {
+            results[i] = MedicineDeliveryMapper.ToResponseDto(records[i]);
+        });
+
+        for (int i = 0; i < records.Length; i++)
+        {
+            Assert.Equal(records[i].Id, results[i].Id);
+            Assert.Equal(records[i].MedicineName, results[i].MedicineName);
+        }
+    }
+
+    #endregion
+}

--- a/tests/Core.Tests/Mappers/MedicineMapperTests.cs
+++ b/tests/Core.Tests/Mappers/MedicineMapperTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+using Core.Mappers;
+using Domain.Entities;
+using Xunit;
+
+namespace Core.Tests.Mappers;
+
+/// <summary>
+/// Unit tests for <see cref="MedicineMapper"/> (UC-003).
+/// </summary>
+public class MedicineMapperTests
+{
+    [Fact]
+    public void ToMedicineStatusDto_SetsResidentId()
+    {
+        Guid residentId = Guid.NewGuid();
+
+        MedicineStatusDto dto = MedicineMapper.ToMedicineStatusDto(residentId, []);
+
+        Assert.Equal(residentId, dto.ResidentId);
+    }
+
+    [Fact]
+    public void ToMedicineStatusDto_EmptyRecords_ReturnsEmptyEntries()
+    {
+        MedicineStatusDto dto = MedicineMapper.ToMedicineStatusDto(Guid.NewGuid(), []);
+
+        Assert.Empty(dto.Entries);
+    }
+
+    [Fact]
+    public void ToMedicineStatusDto_MapsEntriesInOrder()
+    {
+        Guid residentId = Guid.NewGuid();
+        List<MedicineRecord> records =
+        [
+            new() { Id = Guid.NewGuid(), ResidentId = residentId, MedicineName = "Panodil", Timestamp = DateTime.UtcNow, Given = true },
+            new() { Id = Guid.NewGuid(), ResidentId = residentId, MedicineName = "Ipren", Timestamp = DateTime.UtcNow, Given = false }
+        ];
+
+        MedicineStatusDto dto = MedicineMapper.ToMedicineStatusDto(residentId, records);
+
+        Assert.Equal(2, dto.Entries.Count);
+        Assert.Equal("Panodil", dto.Entries[0].Name);
+        Assert.True(dto.Entries[0].Given);
+        Assert.Equal("Ipren", dto.Entries[1].Name);
+        Assert.False(dto.Entries[1].Given);
+    }
+
+    [Fact]
+    public void ToMedicineStatusDto_NullRecords_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            MedicineMapper.ToMedicineStatusDto(Guid.NewGuid(), null!));
+    }
+}

--- a/tests/Core.Tests/Mappers/ResidentMapperTests.cs
+++ b/tests/Core.Tests/Mappers/ResidentMapperTests.cs
@@ -1,0 +1,226 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+using Core.Mappers;
+using Domain.Entities;
+using Domain.Enums;
+using Xunit;
+
+namespace Core.Tests.Mappers;
+
+/// <summary>
+/// Unit tests for <see cref="ResidentMapper"/> (UC-001/014/015/024).
+/// </summary>
+public class ResidentMapperTests
+{
+    #region ToResident (ResponseDto)
+
+    [Fact]
+    public void ToResident_FromResponseDto_MapsAllFieldsIncludingExtended()
+    {
+        ResidentResponseDto dto = new()
+        {
+            Id = Guid.NewGuid(),
+            Initials = "AB",
+            FirstName = "Anders",
+            LastName = "Bjerg",
+            TrafficLightStatus = 1,
+            Department = Department.Skoven,
+            Activity = "Handle",
+            Companion = "KP",
+            Amount = "300kr",
+            Info = "Eget kort"
+        };
+
+        Resident result = ResidentMapper.ToResident(dto);
+
+        Assert.Equal(dto.Id, result.Id);
+        Assert.Equal("AB", result.Initials);
+        Assert.Equal("Anders", result.FirstName);
+        Assert.Equal("Bjerg", result.LastName);
+        Assert.Equal(TrafficLightStatus.Yellow, result.TrafficLightStatus);
+        Assert.Equal(Department.Skoven, result.Department);
+        Assert.Equal("Handle", result.Activity);
+        Assert.Equal("KP", result.Companion);
+        Assert.Equal("300kr", result.Amount);
+        Assert.Equal("Eget kort", result.Info);
+    }
+
+    [Theory]
+    [InlineData(0, TrafficLightStatus.Green)]
+    [InlineData(1, TrafficLightStatus.Yellow)]
+    [InlineData(2, TrafficLightStatus.Red)]
+    public void ToResident_FromResponseDto_MapsTrafficLightInt(int input, TrafficLightStatus expected)
+    {
+        ResidentResponseDto dto = new() { TrafficLightStatus = input };
+
+        Resident result = ResidentMapper.ToResident(dto);
+
+        Assert.Equal(expected, result.TrafficLightStatus);
+    }
+
+    [Fact]
+    public void ToResident_FromResponseDto_NullTrafficLight_MapsToNull()
+    {
+        ResidentResponseDto dto = new() { TrafficLightStatus = null };
+
+        Resident result = ResidentMapper.ToResident(dto);
+
+        Assert.Null(result.TrafficLightStatus);
+    }
+
+    #endregion
+
+    #region ToResidentResponseDto (entity)
+
+    [Fact]
+    public void ToResidentResponseDto_MapsTrafficLightEnumToInt()
+    {
+        Resident entity = new()
+        {
+            Id = Guid.NewGuid(),
+            Initials = "CC",
+            TrafficLightStatus = TrafficLightStatus.Red,
+            Department = Department.Slottet
+        };
+
+        ResidentResponseDto dto = ResidentMapper.ToResidentResponseDto(entity);
+
+        Assert.Equal(2, dto.TrafficLightStatus);
+        Assert.Equal("CC", dto.Initials);
+    }
+
+    [Fact]
+    public void ToResidentResponseDto_NullNotes_ReturnsEmptyList()
+    {
+        Resident entity = new()
+        {
+            Id = Guid.NewGuid(),
+            Initials = "DD",
+            Department = Department.Marken,
+            Notes = null!
+        };
+
+        ResidentResponseDto dto = ResidentMapper.ToResidentResponseDto(entity);
+
+        Assert.NotNull(dto.Notes);
+        Assert.Empty(dto.Notes);
+    }
+
+    [Fact]
+    public void ToResidentResponseDto_MapsNotes()
+    {
+        Resident entity = new()
+        {
+            Id = Guid.NewGuid(),
+            Initials = "EE",
+            Department = Department.Slottet,
+            Notes =
+            [
+                new ResidentNote { Id = Guid.NewGuid(), Note = "Spiste godt", EditedAt = DateTime.UtcNow }
+            ]
+        };
+
+        ResidentResponseDto dto = ResidentMapper.ToResidentResponseDto(entity);
+
+        Assert.Single(dto.Notes);
+        Assert.Equal("Spiste godt", dto.Notes[0].Note);
+    }
+
+    #endregion
+
+    #region ToResident (CreateRequestDto)
+
+    [Fact]
+    public void ToResident_FromCreateDto_GeneratesIdAndMapsFields()
+    {
+        ResidentCreateRequestDto dto = new()
+        {
+            Initials = "FF",
+            FirstName = "Frank",
+            LastName = "Frandsen",
+            TrafficLightStatus = TrafficLightStatus.Green,
+            Department = Department.Skoven,
+            Activity = "Spadseretur"
+        };
+
+        Resident result = ResidentMapper.ToResident(dto);
+
+        Assert.NotEqual(Guid.Empty, result.Id);
+        Assert.Equal("Frank", result.FirstName);
+        Assert.Equal(TrafficLightStatus.Green, result.TrafficLightStatus);
+        Assert.Equal("Spadseretur", result.Activity);
+    }
+
+    #endregion
+
+    #region ApplyUpdate
+
+    [Fact]
+    public void ApplyUpdate_OverwritesFields()
+    {
+        Resident entity = new()
+        {
+            Id = Guid.NewGuid(),
+            Initials = "GG",
+            FirstName = "Old",
+            Department = Department.Slottet
+        };
+        ResidentUpdateRequestDto dto = new()
+        {
+            Initials = "HH",
+            FirstName = "New",
+            LastName = "Name",
+            TrafficLightStatus = TrafficLightStatus.Red,
+            Department = Department.Marken,
+            Activity = "Hvile"
+        };
+
+        ResidentMapper.ApplyUpdate(entity, dto);
+
+        Assert.Equal("HH", entity.Initials);
+        Assert.Equal("New", entity.FirstName);
+        Assert.Equal(Department.Marken, entity.Department);
+        Assert.Equal(TrafficLightStatus.Red, entity.TrafficLightStatus);
+        Assert.Equal("Hvile", entity.Activity);
+    }
+
+    [Fact]
+    public void ApplyUpdate_NullEntity_Throws()
+    {
+        ResidentUpdateRequestDto dto = new() { Initials = "x", FirstName = "y", LastName = "z", TrafficLightStatus = null };
+        Assert.Throws<ArgumentNullException>(() => ResidentMapper.ApplyUpdate(null!, dto));
+    }
+
+    [Fact]
+    public void ApplyUpdate_NullDto_Throws()
+    {
+        Resident entity = new() { Initials = "x" };
+        Assert.Throws<ArgumentNullException>(() => ResidentMapper.ApplyUpdate(entity, null!));
+    }
+
+    #endregion
+
+    #region Note round-trip
+
+    [Fact]
+    public void ResidentNote_RoundTrip_PreservesValues()
+    {
+        ResidentNote note = new()
+        {
+            Id = Guid.NewGuid(),
+            Note = "Test note",
+            EditedAt = new DateTime(2026, 5, 23, 12, 0, 0, DateTimeKind.Utc)
+        };
+
+        ResidentNoteDto dto = ResidentMapper.ToResidentNoteDto(note);
+        ResidentNote back = ResidentMapper.ToResidentNote(dto);
+
+        Assert.Equal(note.Id, back.Id);
+        Assert.Equal(note.Note, back.Note);
+        Assert.Equal(note.EditedAt, back.EditedAt);
+    }
+
+    #endregion
+}

--- a/tests/Core.Tests/Mappers/TaskListMapperTests.cs
+++ b/tests/Core.Tests/Mappers/TaskListMapperTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+using Core.Mappers;
+using Domain.Entities;
+using Domain.Enums;
+using Xunit;
+
+namespace Core.Tests.Mappers;
+
+/// <summary>
+/// Unit tests for <see cref="TaskListMapper"/> (UC-002/006).
+/// </summary>
+public class TaskListMapperTests
+{
+    [Fact]
+    public void ToTaskListDto_MapsAllFields()
+    {
+        TaskList entity = new()
+        {
+            Id = Guid.NewGuid(),
+            Title = "Aftensmad",
+            Description = "Lav aftensmad",
+            TaskStatus = TaskListStatus.InProgress,
+            DueTime = new DateTime(2026, 5, 23, 18, 0, 0, DateTimeKind.Utc),
+            Department = Department.Slottet
+        };
+
+        TaskListDto dto = entity.ToTaskListDto();
+
+        Assert.Equal(entity.Id, dto.Id);
+        Assert.Equal("Aftensmad", dto.Title);
+        Assert.Equal("Lav aftensmad", dto.Description);
+        Assert.Equal(TaskListStatus.InProgress, dto.TaskListStatus);
+        Assert.Equal(entity.DueTime, dto.DueTime);
+        Assert.Equal(Department.Slottet, dto.Department);
+    }
+
+    [Theory]
+    [InlineData(TaskListStatus.Success)]
+    [InlineData(TaskListStatus.InProgress)]
+    public void ToTaskListDto_PreservesStatus(TaskListStatus status)
+    {
+        TaskList entity = new() { Id = Guid.NewGuid(), Title = "t", Description = "d", TaskStatus = status };
+
+        TaskListDto dto = entity.ToTaskListDto();
+
+        Assert.Equal(status, dto.TaskListStatus);
+    }
+}

--- a/tests/Core.Tests/Services/ResidentServiceTests.cs
+++ b/tests/Core.Tests/Services/ResidentServiceTests.cs
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+using Core.Interfaces.Managers;
+using Core.Services;
+using Domain.Entities;
+using Domain.Enums;
+using Moq;
+using Xunit;
+
+namespace Core.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ResidentService"/> (UC-001/014/015/016).
+/// Verifies orchestration between the service and <see cref="IResidentManager"/>.
+/// </summary>
+public class ResidentServiceTests
+{
+    private readonly Mock<IResidentManager> _managerMock;
+    private readonly ResidentService _sut;
+
+    public ResidentServiceTests()
+    {
+        _managerMock = new Mock<IResidentManager>();
+        _sut = new ResidentService(_managerMock.Object);
+    }
+
+    #region GetByIdAsync
+
+    [Fact]
+    public async Task GetByIdAsync_EmptyId_ThrowsArgumentException()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _sut.GetByIdAsync(Guid.Empty, ct));
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ManagerReturnsNull_ReturnsNull()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        _managerMock.Setup(m => m.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ResidentResponseDto?)null);
+
+        Resident? result = await _sut.GetByIdAsync(Guid.NewGuid(), ct);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_Found_ReturnsMappedResident()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Guid id = Guid.NewGuid();
+        _managerMock.Setup(m => m.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ResidentResponseDto { Id = id, Initials = "AB", Department = Department.Slottet });
+
+        Resident? result = await _sut.GetByIdAsync(id, ct);
+
+        Assert.NotNull(result);
+        Assert.Equal(id, result!.Id);
+        Assert.Equal("AB", result.Initials);
+    }
+
+    #endregion
+
+    #region GetAllAsync / GetByDepartmentsAsync
+
+    [Fact]
+    public async Task GetAllAsync_MapsManagerDtosToEntities()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        _managerMock.Setup(m => m.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new ResidentResponseDto { Id = Guid.NewGuid(), Initials = "AA", Department = Department.Slottet },
+                new ResidentResponseDto { Id = Guid.NewGuid(), Initials = "BB", Department = Department.Skoven }
+            ]);
+
+        List<Resident> result = (await _sut.GetAllAsync(ct)).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, r => r.Initials == "AA");
+        Assert.Contains(result, r => r.Initials == "BB");
+    }
+
+    [Fact]
+    public async Task GetByDepartmentsAsync_DelegatesToManager()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        List<Department> departments = [Department.Skoven];
+        _managerMock.Setup(m => m.GetByDepartmentsAsync(departments, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ResidentResponseDto { Id = Guid.NewGuid(), Initials = "SK", Department = Department.Skoven }]);
+
+        List<Resident> result = (await _sut.GetByDepartmentsAsync(departments, ct)).ToList();
+
+        Assert.Single(result);
+        _managerMock.Verify(m => m.GetByDepartmentsAsync(departments, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region CreateAsync
+
+    [Fact]
+    public async Task CreateAsync_NullDto_Throws()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.CreateAsync(null!, ct));
+    }
+
+    [Fact]
+    public async Task CreateAsync_ValidDto_CallsManager()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        ResidentCreateRequestDto dto = new()
+        {
+            Initials = "AB",
+            FirstName = "Anders",
+            LastName = "Bjerg",
+            Department = Department.Slottet
+        };
+        _managerMock.Setup(m => m.CreateAsync(dto, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        await _sut.CreateAsync(dto, ct);
+
+        _managerMock.Verify(m => m.CreateAsync(dto, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region UpdateAsync
+
+    [Fact]
+    public async Task UpdateAsync_DelegatesToManager()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Guid id = Guid.NewGuid();
+        ResidentUpdateRequestDto dto = new()
+        {
+            Initials = "AB",
+            FirstName = "Anders",
+            LastName = "Bjerg",
+            TrafficLightStatus = TrafficLightStatus.Green,
+            Department = Department.Slottet
+        };
+        _managerMock.Setup(m => m.UpdateAsync(id, dto, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        await _sut.UpdateAsync(id, dto, ct);
+
+        _managerMock.Verify(m => m.UpdateAsync(id, dto, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region DeleteAsync
+
+    [Fact]
+    public async Task DeleteAsync_EmptyId_ThrowsArgumentException()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _sut.DeleteAsync(Guid.Empty, ct));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenResidentNotFound_DoesNotCallManagerDelete()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        _managerMock.Setup(m => m.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ResidentResponseDto?)null);
+
+        await _sut.DeleteAsync(Guid.NewGuid(), ct);
+
+        _managerMock.Verify(m => m.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenResidentExists_CallsManagerDelete()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Guid id = Guid.NewGuid();
+        _managerMock.Setup(m => m.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ResidentResponseDto { Id = id, Initials = "AB", Department = Department.Slottet });
+        _managerMock.Setup(m => m.DeleteAsync(id, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        await _sut.DeleteAsync(id, ct);
+
+        _managerMock.Verify(m => m.DeleteAsync(id, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Concurrency
+
+    [Fact]
+    public async Task GetAllAsync_ConcurrentCalls_AllSucceed()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        _managerMock.Setup(m => m.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ResidentResponseDto { Id = Guid.NewGuid(), Initials = "AA", Department = Department.Slottet }]);
+
+        IEnumerable<Task<IEnumerable<Resident>>> tasks =
+            Enumerable.Range(0, 50).Select(_ => _sut.GetAllAsync(ct));
+        IEnumerable<Resident>[] results = await Task.WhenAll(tasks);
+
+        Assert.All(results, r => Assert.Single(r));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Round 1 of raising test coverage. Adds 44 unit tests for previously-untested Core classes (Core.Tests 56 to 100, all green).

Covered: MedicineDeliveryMapper, ResidentMapper, TaskListMapper, MedicineMapper (functionality, null-guards, enum/int mapping, parallel thread-safety) and ResidentService via mocked IResidentManager (validation, not-found, CRUD delegation, concurrent reads).

Test plan: all 278 tests pass via docker compose --profile test up --build.