### PR TITLE
test: round 2 - controller integration tests

### DIFF
--- a/tests/WebApi.Tests/Controllers/Anonymization/AnonymizationControllerTests.cs
+++ b/tests/WebApi.Tests/Controllers/Anonymization/AnonymizationControllerTests.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+
+namespace WebApi.Tests.Controllers.Anonymization;
+
+/// <summary>
+/// Integration tests for AnonymizationController (UC-010 GDPR).
+/// </summary>
+public class AnonymizationControllerTests(CustomWebApplicationFactory<Api.Program> factory)
+    : IClassFixture<CustomWebApplicationFactory<Api.Program>>
+{
+    private readonly HttpClient _client = factory.CreateAuthenticatedClient();
+
+    [Fact]
+    public async Task GetCandidates_AsAdmin_ReturnsOk()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        HttpResponseMessage response = await _client.GetAsync("/anonymization/candidates", ct);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/tests/WebApi.Tests/Controllers/Employees/EmployeeControllerTests.cs
+++ b/tests/WebApi.Tests/Controllers/Employees/EmployeeControllerTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+using System.Net.Http.Json;
+
+using Core.DTOs;
+
+namespace WebApi.Tests.Controllers.Employees;
+
+/// <summary>
+/// Integration tests for EmployeeController.
+/// </summary>
+public class EmployeeControllerTests(CustomWebApplicationFactory<Api.Program> factory)
+    : IClassFixture<CustomWebApplicationFactory<Api.Program>>
+{
+    private readonly HttpClient _client = factory.CreateAuthenticatedClient();
+
+    [Fact]
+    public async Task GetAll_ReturnsOk()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        HttpResponseMessage response = await _client.GetAsync("/employees", ct);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsEmployeeList()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        IEnumerable<EmployeeDto>? result =
+            await _client.GetFromJsonAsync<IEnumerable<EmployeeDto>>("/employees", ct);
+
+        Assert.NotNull(result);
+    }
+}

--- a/tests/WebApi.Tests/Controllers/MedicineDelivery/MedicineDeliveryControllerTests.cs
+++ b/tests/WebApi.Tests/Controllers/MedicineDelivery/MedicineDeliveryControllerTests.cs
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+using System.Net.Http.Json;
+
+using Core.DTOs;
+
+namespace WebApi.Tests.Controllers.MedicineDelivery;
+
+/// <summary>
+/// Integration tests for MedicineDeliveryController (UC-020/021/022).
+/// Exercises the full admin CRUD surface over HTTP against the in-memory test database.
+/// </summary>
+public class MedicineDeliveryControllerTests(CustomWebApplicationFactory<Api.Program> factory)
+    : IClassFixture<CustomWebApplicationFactory<Api.Program>>
+{
+    private readonly HttpClient _client = factory.CreateAuthenticatedClient();
+
+    private static MedicineDeliveryCreateRequestDto NewCreateDto() => new()
+    {
+        ResidentId = Guid.NewGuid(),
+        MedicineName = "Panodil",
+        Timestamp = DateTime.UtcNow,
+        Given = true
+    };
+
+    private async Task<MedicineDeliveryResponseDto> CreateAsync(CancellationToken ct)
+    {
+        HttpResponseMessage response = await _client.PostAsJsonAsync("/medicinedelivery", NewCreateDto(), ct);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        MedicineDeliveryResponseDto? created = await response.Content.ReadFromJsonAsync<MedicineDeliveryResponseDto>(cancellationToken: ct);
+        Assert.NotNull(created);
+        return created!;
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsOk()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        HttpResponseMessage response = await _client.GetAsync("/medicinedelivery", ct);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsCreated_WithGeneratedId()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        MedicineDeliveryResponseDto created = await CreateAsync(ct);
+
+        Assert.NotEqual(Guid.Empty, created.Id);
+        Assert.Equal("Panodil", created.MedicineName);
+        Assert.True(created.Given);
+    }
+
+    [Fact]
+    public async Task GetById_AfterCreate_ReturnsOk()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        MedicineDeliveryResponseDto created = await CreateAsync(ct);
+
+        MedicineDeliveryResponseDto? fetched =
+            await _client.GetFromJsonAsync<MedicineDeliveryResponseDto>($"/medicinedelivery/{created.Id}", ct);
+
+        Assert.NotNull(fetched);
+        Assert.Equal(created.Id, fetched!.Id);
+    }
+
+    [Fact]
+    public async Task GetById_UnknownId_ReturnsNotFound()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        HttpResponseMessage response = await _client.GetAsync($"/medicinedelivery/{Guid.NewGuid()}", ct);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_AfterCreate_ContainsCreatedItem()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        MedicineDeliveryResponseDto created = await CreateAsync(ct);
+
+        IEnumerable<MedicineDeliveryResponseDto>? all =
+            await _client.GetFromJsonAsync<IEnumerable<MedicineDeliveryResponseDto>>("/medicinedelivery", ct);
+
+        Assert.NotNull(all);
+        Assert.Contains(all!, d => d.Id == created.Id);
+    }
+
+    [Fact]
+    public async Task Update_AfterCreate_ReturnsNoContent_AndPersists()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        MedicineDeliveryResponseDto created = await CreateAsync(ct);
+
+        MedicineDeliveryUpdateRequestDto update = new()
+        {
+            ResidentId = created.ResidentId,
+            MedicineName = "Ipren",
+            Timestamp = created.Timestamp,
+            Given = false
+        };
+
+        HttpResponseMessage response = await _client.PutAsJsonAsync($"/medicinedelivery/{created.Id}", update, ct);
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        MedicineDeliveryResponseDto? fetched =
+            await _client.GetFromJsonAsync<MedicineDeliveryResponseDto>($"/medicinedelivery/{created.Id}", ct);
+        Assert.NotNull(fetched);
+        Assert.Equal("Ipren", fetched!.MedicineName);
+        Assert.False(fetched.Given);
+    }
+
+    [Fact]
+    public async Task Update_UnknownId_ReturnsNotFound()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        MedicineDeliveryUpdateRequestDto update = new()
+        {
+            ResidentId = Guid.NewGuid(),
+            MedicineName = "X",
+            Timestamp = DateTime.UtcNow,
+            Given = false
+        };
+
+        HttpResponseMessage response = await _client.PutAsJsonAsync($"/medicinedelivery/{Guid.NewGuid()}", update, ct);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_AfterCreate_ReturnsNoContent_ThenGone()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        MedicineDeliveryResponseDto created = await CreateAsync(ct);
+
+        HttpResponseMessage delete = await _client.DeleteAsync($"/medicinedelivery/{created.Id}", ct);
+        Assert.Equal(HttpStatusCode.NoContent, delete.StatusCode);
+
+        HttpResponseMessage getAfter = await _client.GetAsync($"/medicinedelivery/{created.Id}", ct);
+        Assert.Equal(HttpStatusCode.NotFound, getAfter.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_UnknownId_ReturnsNotFound()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        HttpResponseMessage response = await _client.DeleteAsync($"/medicinedelivery/{Guid.NewGuid()}", ct);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}


### PR DESCRIPTION
Round 2 of raising coverage. Adds 12 integration tests via CustomWebApplicationFactory (authenticated admin client, in-memory DB) for previously-untested controllers: MedicineDeliveryController full CRUD (9), EmployeeController GET (2), AnonymizationController GET candidates (1). WebApi.Tests 49 to 61, all green. Test plan: all tests pass via docker compose --profile test up --build.