### PR TITLE
test: round 3 - infrastructure manager unit tests

### DIFF
--- a/tests/Infrastructure.Tests/Managers/AnonymizationManagerTests.cs
+++ b/tests/Infrastructure.Tests/Managers/AnonymizationManagerTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+
+using Core.DTOs.Anonymization;
+
+using Infrastructure.Managers;
+
+namespace Infrastructure.Tests.Managers;
+
+public class AnonymizationManagerTests : HttpManagerTestBase
+{
+    private readonly AnonymizationManager _manager;
+
+    public AnonymizationManagerTests() => _manager = new AnonymizationManager(FactoryMock.Object);
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetCandidatesAsync_DeserialisesPayload()
+    {
+        AnonymizationCandidateDto[] payload = [new(), new(), new()];
+        Setup("anonymization/candidates", Json(HttpStatusCode.OK, payload));
+
+        IEnumerable<AnonymizationCandidateDto> result = await _manager.GetCandidatesAsync(CancellationToken.None);
+
+        Assert.Equal(3, result.Count());
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task ApproveAnonymizationAsync_PostsAndReturnsResult()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"anonymization/{id}/approve", RawJson(HttpStatusCode.OK, "{}"));
+
+        AnonymizationResultDto result = await _manager.ApproveAnonymizationAsync(id, CancellationToken.None);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task ApproveAnonymizationAsync_WhenError_Throws()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"anonymization/{id}/approve", Status(HttpStatusCode.BadRequest));
+
+        _ = await Assert.ThrowsAsync<HttpRequestException>(
+            () => _manager.ApproveAnonymizationAsync(id, CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task RejectAnonymizationAsync_WhenOk_ReturnsTrue()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"anonymization/{id}/reject", Status(HttpStatusCode.OK));
+
+        bool ok = await _manager.RejectAnonymizationAsync(id, "reason", CancellationToken.None);
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task RejectAnonymizationAsync_WhenError_ReturnsFalse()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"anonymization/{id}/reject", Status(HttpStatusCode.BadRequest));
+
+        bool ok = await _manager.RejectAnonymizationAsync(id, "reason", CancellationToken.None);
+
+        Assert.False(ok);
+    }
+}

--- a/tests/Infrastructure.Tests/Managers/EmployeeManagerTests.cs
+++ b/tests/Infrastructure.Tests/Managers/EmployeeManagerTests.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+
+using Core.DTOs;
+
+using Infrastructure.Managers;
+
+namespace Infrastructure.Tests.Managers;
+
+public class EmployeeManagerTests : HttpManagerTestBase
+{
+    private readonly EmployeeManager _manager;
+
+    public EmployeeManagerTests() => _manager = new EmployeeManager(FactoryMock.Object);
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetAllAsync_DeserialisesPayload()
+    {
+        EmployeeDto[] payload = [new(), new()];
+        Setup("employees", Json(HttpStatusCode.OK, payload));
+
+        IEnumerable<EmployeeDto> result = await _manager.GetAllAsync(CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+    }
+}

--- a/tests/Infrastructure.Tests/Managers/HttpManagerTestBase.cs
+++ b/tests/Infrastructure.Tests/Managers/HttpManagerTestBase.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+using Moq;
+using Moq.Protected;
+
+namespace Infrastructure.Tests.Managers;
+
+/// <summary>
+/// Shared scaffolding for HTTP-backed manager tests: a mocked <see cref="HttpMessageHandler"/>
+/// wired into a named "SlottetApi" client via a mocked <see cref="IHttpClientFactory"/>.
+/// </summary>
+public abstract class HttpManagerTestBase
+{
+    protected readonly Mock<HttpMessageHandler> HandlerMock;
+    protected readonly Mock<IHttpClientFactory> FactoryMock;
+    protected readonly HttpClient Client;
+
+    protected HttpManagerTestBase()
+    {
+        HandlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        Client = new HttpClient(HandlerMock.Object) { BaseAddress = new Uri("http://localhost/") };
+        FactoryMock = new Mock<IHttpClientFactory>();
+        _ = FactoryMock.Setup(f => f.CreateClient("SlottetApi")).Returns(Client);
+    }
+
+    protected static HttpResponseMessage Json<T>(HttpStatusCode status, T payload) =>
+        new(status) { Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json") };
+
+    protected static HttpResponseMessage RawJson(HttpStatusCode status, string json) =>
+        new(status) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    protected static HttpResponseMessage Status(HttpStatusCode status) => new(status);
+
+    protected void Setup(string urlContains, HttpResponseMessage response) =>
+        _ = HandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains(urlContains)),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(response);
+
+    protected void VerifySent(string urlContains, Times times) =>
+        HandlerMock.Protected().Verify(
+            "SendAsync",
+            times,
+            ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains(urlContains)),
+            ItExpr.IsAny<CancellationToken>());
+}

--- a/tests/Infrastructure.Tests/Managers/MedicineDeliveryManagerTests.cs
+++ b/tests/Infrastructure.Tests/Managers/MedicineDeliveryManagerTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+
+using Core.DTOs;
+
+using Infrastructure.Managers;
+
+using Moq;
+
+namespace Infrastructure.Tests.Managers;
+
+public class MedicineDeliveryManagerTests : HttpManagerTestBase
+{
+    private readonly MedicineDeliveryManager _manager;
+
+    public MedicineDeliveryManagerTests() => _manager = new MedicineDeliveryManager(FactoryMock.Object);
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetAllAsync_DeserialisesPayload()
+    {
+        MedicineDeliveryResponseDto[] payload = [new() { Id = Guid.NewGuid(), MedicineName = "Panodil" }];
+        Setup("medicinedelivery", Json(HttpStatusCode.OK, payload));
+
+        IEnumerable<MedicineDeliveryResponseDto> result = await _manager.GetAllAsync(CancellationToken.None);
+
+        _ = Assert.Single(result);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetByIdAsync_WhenOk_ReturnsDto()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"medicinedelivery/{id}", Json(HttpStatusCode.OK, new MedicineDeliveryResponseDto { Id = id }));
+
+        MedicineDeliveryResponseDto? result = await _manager.GetByIdAsync(id, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(id, result!.Id);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task GetByIdAsync_When404_ReturnsNull()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"medicinedelivery/{id}", Status(HttpStatusCode.NotFound));
+
+        MedicineDeliveryResponseDto? result = await _manager.GetByIdAsync(id, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task CreateAsync_PostsToEndpoint()
+    {
+        Setup("medicinedelivery", Status(HttpStatusCode.Created));
+
+        await _manager.CreateAsync(new MedicineDeliveryCreateRequestDto { MedicineName = "X" }, CancellationToken.None);
+
+        VerifySent("medicinedelivery", Times.Once());
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task CreateAsync_WhenError_Throws()
+    {
+        Setup("medicinedelivery", Status(HttpStatusCode.BadRequest));
+
+        _ = await Assert.ThrowsAsync<HttpRequestException>(
+            () => _manager.CreateAsync(new MedicineDeliveryCreateRequestDto(), CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task UpdateAsync_PutsToEndpoint()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"medicinedelivery/{id}", Status(HttpStatusCode.NoContent));
+
+        await _manager.UpdateAsync(id, new MedicineDeliveryUpdateRequestDto { MedicineName = "Y" }, CancellationToken.None);
+
+        VerifySent($"medicinedelivery/{id}", Times.Once());
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task UpdateAsync_WhenError_Throws()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"medicinedelivery/{id}", Status(HttpStatusCode.NotFound));
+
+        _ = await Assert.ThrowsAsync<HttpRequestException>(
+            () => _manager.UpdateAsync(id, new MedicineDeliveryUpdateRequestDto(), CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task DeleteAsync_DeletesEndpoint()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"medicinedelivery/{id}", Status(HttpStatusCode.NoContent));
+
+        await _manager.DeleteAsync(id, CancellationToken.None);
+
+        VerifySent($"medicinedelivery/{id}", Times.Once());
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task DeleteAsync_WhenError_Throws()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"medicinedelivery/{id}", Status(HttpStatusCode.InternalServerError));
+
+        _ = await Assert.ThrowsAsync<HttpRequestException>(() => _manager.DeleteAsync(id, CancellationToken.None));
+    }
+}

--- a/tests/Infrastructure.Tests/Managers/MedicineStatusManagerTests.cs
+++ b/tests/Infrastructure.Tests/Managers/MedicineStatusManagerTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+
+using Core.DTOs;
+
+using Infrastructure.Managers;
+
+namespace Infrastructure.Tests.Managers;
+
+public class MedicineStatusManagerTests : HttpManagerTestBase
+{
+    private readonly MedicineStatusManager _manager;
+
+    public MedicineStatusManagerTests() => _manager = new MedicineStatusManager(FactoryMock.Object);
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetMedicineStatusAsync_ReturnsDto()
+    {
+        Guid residentId = Guid.NewGuid();
+        Setup(residentId.ToString(), Json(HttpStatusCode.OK, new MedicineStatusDto()));
+
+        MedicineStatusDto? result = await _manager.GetMedicineStatusAsync(residentId, CancellationToken.None);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetPainkillerStatusAsync_ReturnsDto()
+    {
+        Guid residentId = Guid.NewGuid();
+        Setup(residentId.ToString(), Json(HttpStatusCode.OK, new PainkillerStatusDto()));
+
+        PainkillerStatusDto? result = await _manager.GetPainkillerStatusAsync(residentId, CancellationToken.None);
+
+        Assert.NotNull(result);
+    }
+}

--- a/tests/Infrastructure.Tests/Managers/PhoneAssignmentManagerTests.cs
+++ b/tests/Infrastructure.Tests/Managers/PhoneAssignmentManagerTests.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+
+using Core.DTOs;
+
+using Infrastructure.Managers;
+
+namespace Infrastructure.Tests.Managers;
+
+public class PhoneAssignmentManagerTests : HttpManagerTestBase
+{
+    private readonly PhoneAssignmentManager _manager;
+
+    public PhoneAssignmentManagerTests() => _manager = new PhoneAssignmentManager(FactoryMock.Object);
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetActiveShiftAsync_DeserialisesPayload()
+    {
+        PhoneAssignmentDto[] payload = [new()];
+        Setup("phoneassignments/active-shift", Json(HttpStatusCode.OK, payload));
+
+        IEnumerable<PhoneAssignmentDto> result = await _manager.GetCurrentPhoneAssignmentsForActiveShift(CancellationToken.None);
+
+        _ = Assert.Single(result);
+    }
+}

--- a/tests/Infrastructure.Tests/Managers/ResidentNoteManagerTests.cs
+++ b/tests/Infrastructure.Tests/Managers/ResidentNoteManagerTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+
+using Core.DTOs;
+
+using Infrastructure.Managers;
+
+namespace Infrastructure.Tests.Managers;
+
+public class ResidentNoteManagerTests : HttpManagerTestBase
+{
+    private readonly ResidentNoteManager _manager;
+
+    public ResidentNoteManagerTests() => _manager = new ResidentNoteManager(FactoryMock.Object);
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetAllByResidentIdAsync_DeserialisesPayload()
+    {
+        Guid residentId = Guid.NewGuid();
+        ResidentNoteDto[] payload = [new() { Note = "hello" }];
+        Setup($"residentnote/{residentId}", Json(HttpStatusCode.OK, payload));
+
+        IEnumerable<ResidentNoteDto> result = await _manager.GetAllByResidentIdAsync(residentId, CancellationToken.None);
+
+        _ = Assert.Single(result);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task AddAsync_WhenOk_ReturnsTrue()
+    {
+        Setup("residentnote", Status(HttpStatusCode.Created));
+
+        bool ok = await _manager.AddAsync(Guid.NewGuid(), "note", CancellationToken.None);
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task AddAsync_WhenError_ReturnsFalse()
+    {
+        Setup("residentnote", Status(HttpStatusCode.BadRequest));
+
+        bool ok = await _manager.AddAsync(Guid.NewGuid(), "note", CancellationToken.None);
+
+        Assert.False(ok);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task UpdateAsync_WhenOk_ReturnsTrue()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"residentnote/{id}", Status(HttpStatusCode.NoContent));
+
+        bool ok = await _manager.UpdateAsync(id, "new", CancellationToken.None);
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task DeleteAsync_WhenOk_ReturnsTrue()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"residentnote/{id}", Status(HttpStatusCode.NoContent));
+
+        bool ok = await _manager.DeleteAsync(id, CancellationToken.None);
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task DeleteAsync_WhenError_ReturnsFalse()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"residentnote/{id}", Status(HttpStatusCode.NotFound));
+
+        bool ok = await _manager.DeleteAsync(id, CancellationToken.None);
+
+        Assert.False(ok);
+    }
+}

--- a/tests/Infrastructure.Tests/Managers/RetentionPolicyManagerTests.cs
+++ b/tests/Infrastructure.Tests/Managers/RetentionPolicyManagerTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+
+using Core.DTOs.Retention;
+
+using Infrastructure.Managers;
+
+namespace Infrastructure.Tests.Managers;
+
+public class RetentionPolicyManagerTests : HttpManagerTestBase
+{
+    private readonly RetentionPolicyManager _manager;
+
+    public RetentionPolicyManagerTests() => _manager = new RetentionPolicyManager(FactoryMock.Object);
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetPoliciesAsync_DeserialisesPayload()
+    {
+        RetentionPolicyDto[] payload = [new(), new()];
+        Setup("retentionpolicy", Json(HttpStatusCode.OK, payload));
+
+        IEnumerable<RetentionPolicyDto> result = await _manager.GetPoliciesAsync(CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task UpdateRetentionPolicyAsync_PutsAndReturnsDto()
+    {
+        Setup("retentionpolicy", RawJson(HttpStatusCode.OK, "{}"));
+
+        RetentionPolicyDto result = await _manager.UpdateRetentionPolicyAsync(
+            new UpdateRetentionPolicyDto { Reason = "r", RetentionPeriod = TimeSpan.FromDays(30) },
+            Guid.NewGuid(),
+            CancellationToken.None);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task UpdateRetentionPolicyAsync_WhenError_Throws()
+    {
+        Setup("retentionpolicy", Status(HttpStatusCode.BadRequest));
+
+        _ = await Assert.ThrowsAsync<HttpRequestException>(
+            () => _manager.UpdateRetentionPolicyAsync(new UpdateRetentionPolicyDto(), Guid.NewGuid(), CancellationToken.None));
+    }
+}

--- a/tests/Infrastructure.Tests/Managers/SecurityIncidentManagerTests.cs
+++ b/tests/Infrastructure.Tests/Managers/SecurityIncidentManagerTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+
+using Core.DTOs.Security;
+
+using Infrastructure.Managers;
+
+namespace Infrastructure.Tests.Managers;
+
+public class SecurityIncidentManagerTests : HttpManagerTestBase
+{
+    private readonly SecurityIncidentManager _manager;
+
+    public SecurityIncidentManagerTests() => _manager = new SecurityIncidentManager(FactoryMock.Object);
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetIncidentsAsync_DeserialisesPayload()
+    {
+        SecurityIncidentDto[] payload = [new(), new()];
+        Setup("securityincident", Json(HttpStatusCode.OK, payload));
+
+        IEnumerable<SecurityIncidentDto> result = await _manager.GetIncidentsAsync(CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task EscalateIncidentAsync_PostsAndReturnsDto()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"securityincident/{id}/escalate", RawJson(HttpStatusCode.OK, "{}"));
+
+        SecurityIncidentDto result = await _manager.EscalateIncidentAsync(id, true, CancellationToken.None);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task EscalateIncidentAsync_WhenError_Throws()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"securityincident/{id}/escalate", Status(HttpStatusCode.BadRequest));
+
+        _ = await Assert.ThrowsAsync<HttpRequestException>(
+            () => _manager.EscalateIncidentAsync(id, false, CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task AddInvestigationNotesAsync_PostsAndReturnsDto()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"securityincident/{id}/notes", RawJson(HttpStatusCode.OK, "{}"));
+
+        SecurityIncidentDto result = await _manager.AddInvestigationNotesAsync(
+            new AddInvestigationNotesDto { IncidentId = id, Notes = "n" }, CancellationToken.None);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task CloseIncidentAsync_PostsAndReturnsDto()
+    {
+        Guid id = Guid.NewGuid();
+        Setup($"securityincident/{id}/close", RawJson(HttpStatusCode.OK, "{}"));
+
+        SecurityIncidentDto result = await _manager.CloseIncidentAsync(id, CancellationToken.None);
+
+        Assert.NotNull(result);
+    }
+}

--- a/tests/Infrastructure.Tests/Managers/StaffAssignmentManagerTests.cs
+++ b/tests/Infrastructure.Tests/Managers/StaffAssignmentManagerTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+using Core.Interfaces.Repositories;
+
+using Domain.Entities;
+using Domain.Enums;
+
+using Infrastructure.Managers;
+
+using Moq;
+
+namespace Infrastructure.Tests.Managers;
+
+public class StaffAssignmentManagerTests
+{
+    private readonly Mock<IStaffAssignmentRepository> _repo = new(MockBehavior.Strict);
+    private readonly StaffAssignmentManager _manager;
+
+    public StaffAssignmentManagerTests() => _manager = new StaffAssignmentManager(_repo.Object);
+
+    private static StaffAssignmentDto NewDto() => new()
+    {
+        ResidentId = Guid.NewGuid(),
+        EmployeeId = Guid.NewGuid(),
+        ShiftType = ShiftType.Day,
+        AssignmentDate = DateTime.UtcNow
+    };
+
+    private static StaffAssignment WithDetails(Guid id) => new()
+    {
+        Id = id,
+        ResidentId = Guid.NewGuid(),
+        EmployeeId = Guid.NewGuid(),
+        ShiftType = ShiftType.Day,
+        AssignmentDate = DateTime.UtcNow.Date,
+        Resident = new Resident { Initials = "AB" },
+        Employee = new Employee { FirstName = "Jane", LastName = "Doe" }
+    };
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task AssignAsync_WhenNoDuplicate_CreatesAndReturnsDto()
+    {
+        StaffAssignmentDto dto = NewDto();
+        Guid createdId = Guid.NewGuid();
+        _ = _repo.Setup(r => r.GetExistingAssignmentAsync(dto.ResidentId, dto.EmployeeId, dto.ShiftType, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StaffAssignment?)null);
+        _ = _repo.Setup(r => r.CreateAsync(It.IsAny<StaffAssignment>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StaffAssignment { Id = createdId });
+        _ = _repo.Setup(r => r.GetByIdWithDetailsAsync(createdId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WithDetails(createdId));
+
+        AssignmentOverviewDto result = await _manager.AssignAsync(dto, CancellationToken.None);
+
+        Assert.Equal("AB", result.ResidentInitials);
+        Assert.Equal("Jane Doe", result.EmployeeName);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task AssignAsync_WhenDuplicate_Throws()
+    {
+        StaffAssignmentDto dto = NewDto();
+        _ = _repo.Setup(r => r.GetExistingAssignmentAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<ShiftType>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StaffAssignment());
+
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() => _manager.AssignAsync(dto, CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task AssignAsync_WhenCreatedNotFound_Throws()
+    {
+        StaffAssignmentDto dto = NewDto();
+        Guid createdId = Guid.NewGuid();
+        _ = _repo.Setup(r => r.GetExistingAssignmentAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<ShiftType>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StaffAssignment?)null);
+        _ = _repo.Setup(r => r.CreateAsync(It.IsAny<StaffAssignment>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StaffAssignment { Id = createdId });
+        _ = _repo.Setup(r => r.GetByIdWithDetailsAsync(createdId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StaffAssignment?)null);
+
+        _ = await Assert.ThrowsAsync<KeyNotFoundException>(() => _manager.AssignAsync(dto, CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetAssignmentsByShiftAsync_ReturnsMappedDtos()
+    {
+        _ = _repo.Setup(r => r.GetByShiftAsync(ShiftType.Evening, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([WithDetails(Guid.NewGuid()), WithDetails(Guid.NewGuid())]);
+
+        IEnumerable<AssignmentOverviewDto> result =
+            await _manager.GetAssignmentsByShiftAsync(ShiftType.Evening, DateTime.UtcNow, CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task DeleteAssignmentAsync_WhenExists_Deletes()
+    {
+        Guid id = Guid.NewGuid();
+        StaffAssignment existing = new() { Id = id };
+        _ = _repo.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        _ = _repo.Setup(r => r.DeleteAsync(existing, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        await _manager.DeleteAssignmentAsync(id, CancellationToken.None);
+
+        _repo.Verify(r => r.DeleteAsync(existing, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task DeleteAssignmentAsync_WhenNotFound_Throws()
+    {
+        Guid id = Guid.NewGuid();
+        _ = _repo.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync((StaffAssignment?)null);
+
+        _ = await Assert.ThrowsAsync<KeyNotFoundException>(() => _manager.DeleteAssignmentAsync(id, CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task UpdateAssignmentAsync_WhenExists_UpdatesAndReturns()
+    {
+        Guid id = Guid.NewGuid();
+        StaffAssignmentDto dto = NewDto();
+        _ = _repo.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(new StaffAssignment { Id = id });
+        _ = _repo.Setup(r => r.UpdateAsync(It.IsAny<StaffAssignment>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        _ = _repo.Setup(r => r.GetByIdWithDetailsAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(WithDetails(id));
+
+        AssignmentOverviewDto result = await _manager.UpdateAssignmentAsync(id, dto, CancellationToken.None);
+
+        Assert.Equal("AB", result.ResidentInitials);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task UpdateAssignmentAsync_WhenNotFound_Throws()
+    {
+        Guid id = Guid.NewGuid();
+        _ = _repo.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync((StaffAssignment?)null);
+
+        _ = await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => _manager.UpdateAssignmentAsync(id, NewDto(), CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task UpdateAssignmentAsync_WhenUpdatedNotFound_Throws()
+    {
+        Guid id = Guid.NewGuid();
+        _ = _repo.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(new StaffAssignment { Id = id });
+        _ = _repo.Setup(r => r.UpdateAsync(It.IsAny<StaffAssignment>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        _ = _repo.Setup(r => r.GetByIdWithDetailsAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync((StaffAssignment?)null);
+
+        _ = await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => _manager.UpdateAssignmentAsync(id, NewDto(), CancellationToken.None));
+    }
+}

--- a/tests/Infrastructure.Tests/Managers/SubjectAccessRequestManagerTests.cs
+++ b/tests/Infrastructure.Tests/Managers/SubjectAccessRequestManagerTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+
+using Core.DTOs.Sar;
+
+using Infrastructure.Managers;
+
+namespace Infrastructure.Tests.Managers;
+
+public class SubjectAccessRequestManagerTests : HttpManagerTestBase
+{
+    private readonly SubjectAccessRequestManager _manager;
+
+    public SubjectAccessRequestManagerTests() => _manager = new SubjectAccessRequestManager(FactoryMock.Object);
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GenerateExportAsync_PostsAndReturnsPackage()
+    {
+        Setup("subjectaccessrequest/export", RawJson(HttpStatusCode.OK, "{}"));
+
+        SarExportPackageDto result = await _manager.GenerateExportAsync(
+            new SarExportRequestDto { ResidentId = Guid.NewGuid() }, CancellationToken.None);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task GenerateExportAsync_WhenError_Throws()
+    {
+        Setup("subjectaccessrequest/export", Status(HttpStatusCode.BadRequest));
+
+        _ = await Assert.ThrowsAsync<HttpRequestException>(
+            () => _manager.GenerateExportAsync(new SarExportRequestDto(), CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task MarkFulfilledAsync_WhenOk_ReturnsTrue()
+    {
+        Setup("subjectaccessrequest/fulfilled", Status(HttpStatusCode.OK));
+
+        bool ok = await _manager.MarkFulfilledAsync(
+            new SarFulfilledDto { SarId = Guid.NewGuid(), FulfilledAt = DateTime.UtcNow }, CancellationToken.None);
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task MarkFulfilledAsync_WhenError_ReturnsFalse()
+    {
+        Setup("subjectaccessrequest/fulfilled", Status(HttpStatusCode.BadRequest));
+
+        bool ok = await _manager.MarkFulfilledAsync(new SarFulfilledDto(), CancellationToken.None);
+
+        Assert.False(ok);
+    }
+}

--- a/tests/Infrastructure.Tests/Managers/TaskListManagerTests.cs
+++ b/tests/Infrastructure.Tests/Managers/TaskListManagerTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+
+using Core.DTOs;
+
+using Domain.Enums;
+
+using Infrastructure.Managers;
+
+namespace Infrastructure.Tests.Managers;
+
+public class TaskListManagerTests : HttpManagerTestBase
+{
+    private readonly TaskListManager _manager;
+
+    public TaskListManagerTests() => _manager = new TaskListManager(FactoryMock.Object);
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetDashboardTasksByDepartmentAsync_DeserialisesPayload()
+    {
+        TaskListDto[] payload = [new(), new()];
+        Setup("TaskList/dashboard/Slottet", Json(HttpStatusCode.OK, payload));
+
+        IEnumerable<TaskListDto> result =
+            await _manager.GetDashboardTasksByDepartmentAsync(Department.Slottet, CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+    }
+}


### PR DESCRIPTION
Round 3 of raising coverage. Adds 46 unit tests for previously-untested Infrastructure managers. HTTP managers (MedicineDelivery, SecurityIncident, ResidentNote, Anonymization, SubjectAccessRequest, RetentionPolicy, MedicineStatus, Employee, PhoneAssignment, TaskList) via mocked HttpMessageHandler; StaffAssignmentManager via mocked repository. Infrastructure.Tests 30 to 76, all green. Test plan: all tests pass via docker compose --profile test up --build.