### PR TITLE
test: round 4 - controller integration tests

### DIFF
--- a/tests/WebApi.Tests/Controllers/RetentionPolicy/RetentionPolicyControllerTests.cs
+++ b/tests/WebApi.Tests/Controllers/RetentionPolicy/RetentionPolicyControllerTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+using System.Net.Http.Json;
+
+using Core.DTOs.Retention;
+
+using Domain.Entities;
+using Domain.Enums;
+
+namespace WebApi.Tests.Controllers.RetentionPolicy;
+
+/// <summary>
+/// Integration tests for RetentionPolicyController (UC-010 retention governance).
+/// </summary>
+public class RetentionPolicyControllerTests(CustomWebApplicationFactory<Api.Program> factory)
+    : IClassFixture<CustomWebApplicationFactory<Api.Program>>
+{
+    private readonly CustomWebApplicationFactory<Api.Program> _factory = factory;
+    private readonly HttpClient _client = factory.CreateAuthenticatedClient();
+
+    [Fact]
+    public async Task GetAll_ReturnsOk()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        HttpResponseMessage response = await _client.GetAsync("/retentionpolicy", ct);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_BelowLegalMinimum_ReturnsBadRequest()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        _factory.Seed(db => db.RetentionPolicies.Add(new Domain.Entities.RetentionPolicy
+        {
+            Id = Guid.NewGuid(),
+            Category = RetentionDataCategory.LoginLogs,
+            RetentionPeriod = TimeSpan.FromDays(365),
+            LegalMinimum = TimeSpan.FromDays(100),
+            EffectiveFrom = DateTime.UtcNow
+        }));
+        UpdateRetentionPolicyDto dto = new()
+        {
+            Category = RetentionDataCategory.LoginLogs,
+            RetentionPeriod = TimeSpan.FromDays(1),
+            Reason = "too short"
+        };
+        HttpResponseMessage response = await _client.PutAsJsonAsync(
+            $"/retentionpolicy?changedByEmployeeId={Guid.NewGuid()}", dto, ct);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/tests/WebApi.Tests/Controllers/SecurityIncident/SecurityIncidentControllerTests.cs
+++ b/tests/WebApi.Tests/Controllers/SecurityIncident/SecurityIncidentControllerTests.cs
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+using System.Net.Http.Json;
+
+using Core.DTOs.Security;
+
+using Domain.Entities;
+
+namespace WebApi.Tests.Controllers.SecurityIncident;
+
+/// <summary>
+/// Integration tests for SecurityIncidentController (UC-011 security monitoring).
+/// </summary>
+public class SecurityIncidentControllerTests(CustomWebApplicationFactory<Api.Program> factory)
+    : IClassFixture<CustomWebApplicationFactory<Api.Program>>
+{
+    private readonly CustomWebApplicationFactory<Api.Program> _factory = factory;
+    private readonly HttpClient _client = factory.CreateAuthenticatedClient();
+
+    private Guid SeedIncident()
+    {
+        Guid id = Guid.NewGuid();
+        _factory.Seed(db => db.SecurityIncidents.Add(new Domain.Entities.SecurityIncident
+        {
+            Id = id,
+            DetectedAt = DateTime.UtcNow,
+            Type = "BruteForce"
+        }));
+        return id;
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsOk()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        HttpResponseMessage response = await _client.GetAsync("/securityincident", ct);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Escalate_UnknownId_ReturnsNotFound()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            $"/securityincident/{Guid.NewGuid()}/escalate", new EscalateIncidentDto { IsBreach = true }, ct);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Escalate_Seeded_ReturnsOk()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Guid id = SeedIncident();
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            $"/securityincident/{id}/escalate", new EscalateIncidentDto { IncidentId = id, IsBreach = true }, ct);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddNotes_EmptyNotes_ReturnsBadRequest()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Guid id = Guid.NewGuid();
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            $"/securityincident/{id}/notes", new AddInvestigationNotesDto { IncidentId = id, Notes = "" }, ct);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddNotes_Seeded_ReturnsOk()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Guid id = SeedIncident();
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            $"/securityincident/{id}/notes", new AddInvestigationNotesDto { IncidentId = id, Notes = "looked into it" }, ct);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Close_UnknownId_ReturnsNotFound()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            $"/securityincident/{Guid.NewGuid()}/close", new { }, ct);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Close_Seeded_ReturnsOk()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Guid id = SeedIncident();
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            $"/securityincident/{id}/close", new { }, ct);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/tests/WebApi.Tests/Controllers/SeedExtensions.cs
+++ b/tests/WebApi.Tests/Controllers/SeedExtensions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Infrastructure.Data.Persistent;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace WebApi.Tests.Controllers;
+
+/// <summary>
+/// Helpers for seeding the in-memory database backing the integration-test host.
+/// The factory exposes the host's service provider via <see cref="Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory{TEntryPoint}.Services"/>,
+/// which shares the same in-memory database instance used to serve HTTP requests.
+/// </summary>
+public static class SeedExtensions
+{
+    public static void Seed(this CustomWebApplicationFactory<Api.Program> factory, Action<AppDbContext> seed)
+    {
+        using IServiceScope scope = factory.Services.CreateScope();
+        AppDbContext db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        seed(db);
+        _ = db.SaveChanges();
+    }
+}

--- a/tests/WebApi.Tests/Controllers/StaffAssignment/StaffAssignmentControllerTests.cs
+++ b/tests/WebApi.Tests/Controllers/StaffAssignment/StaffAssignmentControllerTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+using System.Net.Http.Json;
+
+using Core.DTOs;
+
+namespace WebApi.Tests.Controllers.StaffAssignment;
+
+/// <summary>
+/// Integration tests for StaffAssignmentController.
+/// </summary>
+public class StaffAssignmentControllerTests(CustomWebApplicationFactory<Api.Program> factory)
+    : IClassFixture<CustomWebApplicationFactory<Api.Program>>
+{
+    private readonly HttpClient _client = factory.CreateAuthenticatedClient();
+
+    [Fact]
+    public async Task GetAssignments_ReturnsOk()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        HttpResponseMessage response = await _client.GetAsync(
+            "/staff-assignments/list?shiftType=0&assignmentDate=2026-05-24", ct);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteAssignment_UnknownId_ReturnsNotFound()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        HttpResponseMessage response = await _client.DeleteAsync($"/staff-assignments/{Guid.NewGuid()}", ct);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateAssignment_UnknownId_ReturnsNotFound()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        StaffAssignmentDto dto = new()
+        {
+            ResidentId = Guid.NewGuid(),
+            EmployeeId = Guid.NewGuid(),
+            ShiftType = Domain.Enums.ShiftType.Night,
+            AssignmentDate = DateTime.UtcNow
+        };
+        HttpResponseMessage response = await _client.PutAsJsonAsync($"/staff-assignments/{Guid.NewGuid()}", dto, ct);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/tests/WebApi.Tests/Controllers/SubjectAccessRequest/SubjectAccessRequestControllerTests.cs
+++ b/tests/WebApi.Tests/Controllers/SubjectAccessRequest/SubjectAccessRequestControllerTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+using System.Net.Http.Json;
+
+using Core.DTOs.Sar;
+
+using Domain.Entities;
+using Domain.Enums;
+
+namespace WebApi.Tests.Controllers.SubjectAccessRequest;
+
+/// <summary>
+/// Integration tests for SubjectAccessRequestController (UC-010 GDPR Article 15).
+/// </summary>
+public class SubjectAccessRequestControllerTests(CustomWebApplicationFactory<Api.Program> factory)
+    : IClassFixture<CustomWebApplicationFactory<Api.Program>>
+{
+    private readonly CustomWebApplicationFactory<Api.Program> _factory = factory;
+    private readonly HttpClient _client = factory.CreateAuthenticatedClient();
+
+    [Fact]
+    public async Task GenerateExport_EmptyResidentId_ReturnsBadRequest()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            "/subjectaccessrequest/export", new SarExportRequestDto { ResidentId = Guid.Empty }, ct);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GenerateExport_UnknownResident_ReturnsNotFound()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            "/subjectaccessrequest/export", new SarExportRequestDto { ResidentId = Guid.NewGuid() }, ct);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GenerateExport_WithSeededResident_ReturnsOk()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Guid residentId = Guid.NewGuid();
+        _factory.Seed(db => db.Residents.Add(new Resident
+        {
+            Id = residentId,
+            Initials = "SR",
+            TrafficLightStatus = TrafficLightStatus.Green,
+            Department = Department.Slottet
+        }));
+
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            "/subjectaccessrequest/export",
+            new SarExportRequestDto { ResidentId = residentId, ScopeOptions = ["notes", "medicine"] }, ct);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MarkFulfilled_EmptySarId_ReturnsBadRequest()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            "/subjectaccessrequest/fulfilled", new SarFulfilledDto { SarId = Guid.Empty }, ct);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MarkFulfilled_UnknownSar_ReturnsNotFound()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            "/subjectaccessrequest/fulfilled",
+            new SarFulfilledDto { SarId = Guid.NewGuid(), FulfilledAt = DateTime.UtcNow }, ct);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MarkFulfilled_WithSeededSar_ReturnsOk()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Guid sarId = Guid.NewGuid();
+        _factory.Seed(db => db.SubjectAccessRequests.Add(new Domain.Entities.SubjectAccessRequest
+        {
+            Id = sarId,
+            ResidentId = Guid.NewGuid(),
+            RequestedByEmployeeId = Guid.NewGuid(),
+            RequestedAt = DateTime.UtcNow,
+            ExportFileName = "f.json",
+            ExportGeneratedAt = DateTime.UtcNow
+        }));
+
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            "/subjectaccessrequest/fulfilled",
+            new SarFulfilledDto { SarId = sarId, FulfilledAt = DateTime.UtcNow }, ct);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/tests/WebApi.Tests/Controllers/TaskList/TaskListControllerTests.cs
+++ b/tests/WebApi.Tests/Controllers/TaskList/TaskListControllerTests.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+
+namespace WebApi.Tests.Controllers.TaskList;
+
+/// <summary>
+/// Integration tests for TaskListController (UC-002 dashboard task list).
+/// </summary>
+public class TaskListControllerTests(CustomWebApplicationFactory<Api.Program> factory)
+    : IClassFixture<CustomWebApplicationFactory<Api.Program>>
+{
+    private readonly HttpClient _client = factory.CreateAuthenticatedClient();
+
+    [Fact]
+    public async Task GetDashboardTasksByDepartment_ReturnsOk()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        HttpResponseMessage response = await _client.GetAsync("/TaskList/dashboard/Slottet", ct);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}


### PR DESCRIPTION
Round 4 of raising coverage. Adds integration tests for SubjectAccessRequest, SecurityIncident, RetentionPolicy, StaffAssignment and TaskList controllers via CustomWebApplicationFactory with DB seeding for happy paths. All green. Test plan: docker compose --profile test up --build.