### PR TITLE
test: concurrency, edge-case and functionality unit tests for Core services

### DIFF
--- a/tests/Core.Tests/Services/AnonymizationServiceTests.cs
+++ b/tests/Core.Tests/Services/AnonymizationServiceTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Anonymization;
+using Core.Interfaces.Managers;
+using Core.Services;
+
+using Moq;
+
+namespace Core.Tests.Services;
+
+public class AnonymizationServiceTests
+{
+    private readonly Mock<IAnonymizationManager> _manager = new();
+    private readonly AnonymizationService _service;
+
+    public AnonymizationServiceTests() => _service = new AnonymizationService(_manager.Object);
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Constructor_NullManager_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new AnonymizationService(null!));
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetCandidatesAsync_DelegatesAndReturns()
+    {
+        AnonymizationCandidateDto[] expected = [new(), new()];
+        _ = _manager.Setup(m => m.GetCandidatesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(expected);
+
+        IEnumerable<AnonymizationCandidateDto> result = await _service.GetCandidatesAsync(CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+        _manager.Verify(m => m.GetCandidatesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task ApproveAnonymizationAsync_DelegatesWithId()
+    {
+        Guid id = Guid.NewGuid();
+        _ = _manager.Setup(m => m.ApproveAnonymizationAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(new AnonymizationResultDto());
+
+        AnonymizationResultDto result = await _service.ApproveAnonymizationAsync(id, CancellationToken.None);
+
+        Assert.NotNull(result);
+        _manager.Verify(m => m.ApproveAnonymizationAsync(id, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task RejectAnonymizationAsync_PassesReason()
+    {
+        Guid id = Guid.NewGuid();
+        _ = _manager.Setup(m => m.RejectAnonymizationAsync(id, "dup", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        bool ok = await _service.RejectAnonymizationAsync(id, "dup", CancellationToken.None);
+
+        Assert.True(ok);
+        _manager.Verify(m => m.RejectAnonymizationAsync(id, "dup", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task GetCandidatesAsync_WhenManagerThrows_Propagates()
+    {
+        _ = _manager.Setup(m => m.GetCandidatesAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new HttpRequestException("down"));
+
+        _ = await Assert.ThrowsAsync<HttpRequestException>(() => _service.GetCandidatesAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public async Task GetCandidatesAsync_ManyParallelCalls_AllSucceed()
+    {
+        _ = _manager.Setup(m => m.GetCandidatesAsync(It.IsAny<CancellationToken>())).ReturnsAsync([]);
+
+        IEnumerable<AnonymizationCandidateDto>[] results = await Task.WhenAll(
+            Enumerable.Range(0, 100).Select(_ => _service.GetCandidatesAsync(CancellationToken.None)));
+
+        Assert.All(results, Assert.NotNull);
+        _manager.Verify(m => m.GetCandidatesAsync(It.IsAny<CancellationToken>()), Times.Exactly(100));
+    }
+}

--- a/tests/Core.Tests/Services/MedicineStatusServiceTests.cs
+++ b/tests/Core.Tests/Services/MedicineStatusServiceTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+using Core.Interfaces.Managers;
+using Core.Services;
+
+using Moq;
+
+namespace Core.Tests.Services;
+
+public class MedicineStatusServiceTests
+{
+    private readonly Mock<IMedicineStatusManager> _manager = new();
+    private readonly MedicineStatusService _service;
+
+    public MedicineStatusServiceTests() => _service = new MedicineStatusService(_manager.Object);
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetMedicineStatusAsync_DelegatesWithResidentId()
+    {
+        Guid residentId = Guid.NewGuid();
+        _ = _manager.Setup(m => m.GetMedicineStatusAsync(residentId, It.IsAny<CancellationToken>())).ReturnsAsync(new MedicineStatusDto());
+
+        MedicineStatusDto? result = await _service.GetMedicineStatusAsync(residentId, CancellationToken.None);
+
+        Assert.NotNull(result);
+        _manager.Verify(m => m.GetMedicineStatusAsync(residentId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetPainkillerStatusAsync_DelegatesWithResidentId()
+    {
+        Guid residentId = Guid.NewGuid();
+        _ = _manager.Setup(m => m.GetPainkillerStatusAsync(residentId, It.IsAny<CancellationToken>())).ReturnsAsync(new PainkillerStatusDto());
+
+        PainkillerStatusDto? result = await _service.GetPainkillerStatusAsync(residentId, CancellationToken.None);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task GetMedicineStatusAsync_WhenManagerReturnsNull_ReturnsNull()
+    {
+        _ = _manager.Setup(m => m.GetMedicineStatusAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync((MedicineStatusDto?)null);
+
+        MedicineStatusDto? result = await _service.GetMedicineStatusAsync(Guid.NewGuid(), CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task GetPainkillerStatusAsync_WhenManagerThrows_Propagates()
+    {
+        _ = _manager.Setup(m => m.GetPainkillerStatusAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ThrowsAsync(new HttpRequestException());
+
+        _ = await Assert.ThrowsAsync<HttpRequestException>(() => _service.GetPainkillerStatusAsync(Guid.NewGuid(), CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public async Task GetMedicineStatusAsync_ManyParallelCalls_AllSucceed()
+    {
+        _ = _manager.Setup(m => m.GetMedicineStatusAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new MedicineStatusDto());
+
+        MedicineStatusDto?[] results = await Task.WhenAll(
+            Enumerable.Range(0, 100).Select(_ => _service.GetMedicineStatusAsync(Guid.NewGuid(), CancellationToken.None)));
+
+        Assert.All(results, Assert.NotNull);
+        _manager.Verify(m => m.GetMedicineStatusAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Exactly(100));
+    }
+}

--- a/tests/Core.Tests/Services/RetentionPolicyServiceTests.cs
+++ b/tests/Core.Tests/Services/RetentionPolicyServiceTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Retention;
+using Core.Interfaces.Managers;
+using Core.Services;
+
+using Moq;
+
+namespace Core.Tests.Services;
+
+public class RetentionPolicyServiceTests
+{
+    private readonly Mock<IRetentionPolicyManager> _manager = new();
+    private readonly RetentionPolicyService _service;
+
+    public RetentionPolicyServiceTests() => _service = new RetentionPolicyService(_manager.Object);
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Constructor_NullManager_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new RetentionPolicyService(null!));
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetPoliciesAsync_DelegatesAndReturns()
+    {
+        RetentionPolicyDto[] expected = [new(), new()];
+        _ = _manager.Setup(m => m.GetPoliciesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(expected);
+
+        IEnumerable<RetentionPolicyDto> result = await _service.GetPoliciesAsync(CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task UpdateRetentionPolicyAsync_PassesEmployeeId()
+    {
+        Guid employeeId = Guid.NewGuid();
+        UpdateRetentionPolicyDto dto = new() { Reason = "r", RetentionPeriod = TimeSpan.FromDays(30) };
+        _ = _manager.Setup(m => m.UpdateRetentionPolicyAsync(dto, employeeId, It.IsAny<CancellationToken>())).ReturnsAsync(new RetentionPolicyDto());
+
+        _ = await _service.UpdateRetentionPolicyAsync(dto, employeeId, CancellationToken.None);
+
+        _manager.Verify(m => m.UpdateRetentionPolicyAsync(dto, employeeId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task UpdateRetentionPolicyAsync_WhenManagerThrows_Propagates()
+    {
+        _ = _manager.Setup(m => m.UpdateRetentionPolicyAsync(It.IsAny<UpdateRetentionPolicyDto>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException());
+
+        _ = await Assert.ThrowsAsync<HttpRequestException>(
+            () => _service.UpdateRetentionPolicyAsync(new UpdateRetentionPolicyDto(), Guid.NewGuid(), CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public async Task GetPoliciesAsync_ManyParallelCalls_AllSucceed()
+    {
+        _ = _manager.Setup(m => m.GetPoliciesAsync(It.IsAny<CancellationToken>())).ReturnsAsync([]);
+
+        IEnumerable<RetentionPolicyDto>[] results = await Task.WhenAll(
+            Enumerable.Range(0, 100).Select(_ => _service.GetPoliciesAsync(CancellationToken.None)));
+
+        Assert.All(results, Assert.NotNull);
+        _manager.Verify(m => m.GetPoliciesAsync(It.IsAny<CancellationToken>()), Times.Exactly(100));
+    }
+}

--- a/tests/Core.Tests/Services/SecurityIncidentServiceTests.cs
+++ b/tests/Core.Tests/Services/SecurityIncidentServiceTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Security;
+using Core.Interfaces.Managers;
+using Core.Interfaces.Services;
+using Core.Services;
+
+using Moq;
+
+namespace Core.Tests.Services;
+
+public class SecurityIncidentServiceTests
+{
+    private readonly Mock<ISecurityIncidentManager> _manager = new();
+    private readonly Mock<IArt33NotificationService> _art33 = new();
+    private readonly SecurityIncidentService _service;
+
+    public SecurityIncidentServiceTests() => _service = new SecurityIncidentService(_manager.Object, _art33.Object);
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Constructor_NullManager_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new SecurityIncidentService(null!, _art33.Object));
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Constructor_NullArt33_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new SecurityIncidentService(_manager.Object, null!));
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetIncidentsAsync_DelegatesAndReturns()
+    {
+        SecurityIncidentDto[] expected = [new(), new(), new()];
+        _ = _manager.Setup(m => m.GetIncidentsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(expected);
+
+        IEnumerable<SecurityIncidentDto> result = await _service.GetIncidentsAsync(CancellationToken.None);
+
+        Assert.Equal(3, result.Count());
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task EscalateIncidentAsync_PassesBreachFlag()
+    {
+        Guid id = Guid.NewGuid();
+        _ = _manager.Setup(m => m.EscalateIncidentAsync(id, true, It.IsAny<CancellationToken>())).ReturnsAsync(new SecurityIncidentDto());
+
+        _ = await _service.EscalateIncidentAsync(id, true, CancellationToken.None);
+
+        _manager.Verify(m => m.EscalateIncidentAsync(id, true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task CloseIncidentAsync_DelegatesWithId()
+    {
+        Guid id = Guid.NewGuid();
+        _ = _manager.Setup(m => m.CloseIncidentAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(new SecurityIncidentDto());
+
+        _ = await _service.CloseIncidentAsync(id, CancellationToken.None);
+
+        _manager.Verify(m => m.CloseIncidentAsync(id, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task AddInvestigationNotesAsync_WhenManagerThrows_Propagates()
+    {
+        _ = _manager.Setup(m => m.AddInvestigationNotesAsync(It.IsAny<AddInvestigationNotesDto>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException());
+
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.AddInvestigationNotesAsync(new AddInvestigationNotesDto(), CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public async Task EscalateIncidentAsync_ManyParallelCalls_AllDelegate()
+    {
+        _ = _manager.Setup(m => m.EscalateIncidentAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SecurityIncidentDto());
+
+        SecurityIncidentDto[] results = await Task.WhenAll(
+            Enumerable.Range(0, 100).Select(_ => _service.EscalateIncidentAsync(Guid.NewGuid(), false, CancellationToken.None)));
+
+        Assert.All(results, Assert.NotNull);
+        _manager.Verify(m => m.EscalateIncidentAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Exactly(100));
+    }
+}

--- a/tests/Core.Tests/Services/SubjectAccessRequestServiceTests.cs
+++ b/tests/Core.Tests/Services/SubjectAccessRequestServiceTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Sar;
+using Core.Interfaces.Managers;
+using Core.Services;
+
+using Moq;
+
+namespace Core.Tests.Services;
+
+public class SubjectAccessRequestServiceTests
+{
+    private readonly Mock<ISubjectAccessRequestManager> _manager = new();
+    private readonly SubjectAccessRequestService _service;
+
+    public SubjectAccessRequestServiceTests() => _service = new SubjectAccessRequestService(_manager.Object);
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Constructor_NullManager_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new SubjectAccessRequestService(null!));
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GenerateExportAsync_DelegatesAndReturns()
+    {
+        SarExportRequestDto dto = new() { ResidentId = Guid.NewGuid() };
+        _ = _manager.Setup(m => m.GenerateExportAsync(dto, It.IsAny<CancellationToken>())).ReturnsAsync(new SarExportPackageDto());
+
+        SarExportPackageDto result = await _service.GenerateExportAsync(dto, CancellationToken.None);
+
+        Assert.NotNull(result);
+        _manager.Verify(m => m.GenerateExportAsync(dto, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task MarkFulfilledAsync_DelegatesAndReturns()
+    {
+        SarFulfilledDto dto = new() { SarId = Guid.NewGuid(), FulfilledAt = DateTime.UtcNow };
+        _ = _manager.Setup(m => m.MarkFulfilledAsync(dto, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        bool ok = await _service.MarkFulfilledAsync(dto, CancellationToken.None);
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task GenerateExportAsync_WhenManagerThrows_Propagates()
+    {
+        _ = _manager.Setup(m => m.GenerateExportAsync(It.IsAny<SarExportRequestDto>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException());
+
+        _ = await Assert.ThrowsAsync<HttpRequestException>(
+            () => _service.GenerateExportAsync(new SarExportRequestDto(), CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public async Task MarkFulfilledAsync_ManyParallelCalls_AllDelegate()
+    {
+        _ = _manager.Setup(m => m.MarkFulfilledAsync(It.IsAny<SarFulfilledDto>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        bool[] results = await Task.WhenAll(
+            Enumerable.Range(0, 100).Select(_ => _service.MarkFulfilledAsync(new SarFulfilledDto(), CancellationToken.None)));
+
+        Assert.All(results, Assert.True);
+        _manager.Verify(m => m.MarkFulfilledAsync(It.IsAny<SarFulfilledDto>(), It.IsAny<CancellationToken>()), Times.Exactly(100));
+    }
+}

--- a/tests/Core.Tests/Services/TaskListServiceTests.cs
+++ b/tests/Core.Tests/Services/TaskListServiceTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+using Core.Interfaces.Managers;
+using Core.Services;
+
+using Domain.Enums;
+
+using Moq;
+
+namespace Core.Tests.Services;
+
+public class TaskListServiceTests
+{
+    private readonly Mock<ITaskListManager> _manager = new();
+    private readonly TaskListService _service;
+
+    public TaskListServiceTests() => _service = new TaskListService(_manager.Object);
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public async Task GetAvailableTasksByDepartmentAsync_DelegatesWithDepartment()
+    {
+        TaskListDto[] expected = [new(), new()];
+        _ = _manager.Setup(m => m.GetDashboardTasksByDepartmentAsync(Department.Slottet, It.IsAny<CancellationToken>())).ReturnsAsync(expected);
+
+        IEnumerable<TaskListDto> result = await _service.GetAvailableTasksByDepartmentAsync(Department.Slottet, CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+        _manager.Verify(m => m.GetDashboardTasksByDepartmentAsync(Department.Slottet, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [Trait("Category", "EdgeCase")]
+    [InlineData(Department.Slottet)]
+    [InlineData(Department.Skoven)]
+    [InlineData(Department.Marken)]
+    public async Task GetAvailableTasksByDepartmentAsync_AnyDepartment_ReturnsEmptyWhenNone(Department department)
+    {
+        _ = _manager.Setup(m => m.GetDashboardTasksByDepartmentAsync(department, It.IsAny<CancellationToken>())).ReturnsAsync([]);
+
+        IEnumerable<TaskListDto> result = await _service.GetAvailableTasksByDepartmentAsync(department, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public async Task GetAvailableTasksByDepartmentAsync_WhenManagerThrows_Propagates()
+    {
+        _ = _manager.Setup(m => m.GetDashboardTasksByDepartmentAsync(It.IsAny<Department>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException());
+
+        _ = await Assert.ThrowsAsync<HttpRequestException>(
+            () => _service.GetAvailableTasksByDepartmentAsync(Department.Slottet, CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public async Task GetAvailableTasksByDepartmentAsync_ManyParallelCalls_AllSucceed()
+    {
+        _ = _manager.Setup(m => m.GetDashboardTasksByDepartmentAsync(It.IsAny<Department>(), It.IsAny<CancellationToken>())).ReturnsAsync([]);
+
+        IEnumerable<TaskListDto>[] results = await Task.WhenAll(
+            Enumerable.Range(0, 100).Select(_ => _service.GetAvailableTasksByDepartmentAsync(Department.Marken, CancellationToken.None)));
+
+        Assert.All(results, Assert.NotNull);
+        _manager.Verify(m => m.GetDashboardTasksByDepartmentAsync(It.IsAny<Department>(), It.IsAny<CancellationToken>()), Times.Exactly(100));
+    }
+}

--- a/tests/WebUI.Tests/Components/Pages/Gdpr/GdprDashboardPageTests.cs
+++ b/tests/WebUI.Tests/Components/Pages/Gdpr/GdprDashboardPageTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Bunit;
+using Bunit.TestDoubles;
+
+using Core.DTOs.Anonymization;
+using Core.Interfaces.Services;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+
+using GdprDashboard = WebUI.Client.Components.Pages.Gdpr.GdprDashboardPage;
+
+namespace WebUI.Tests.Components.Pages.Gdpr;
+
+/// <summary>
+/// bUnit tests for the GDPR dashboard landing page (UC-010).
+/// </summary>
+public class GdprDashboardPageTests : Bunit.TestContext
+{
+    private readonly Mock<IAnonymizationService> _anonymization = new();
+    private readonly Mock<ISecurityIncidentService> _incidents = new();
+
+    public GdprDashboardPageTests()
+    {
+        TestAuthorizationContext auth = this.AddTestAuthorization();
+        auth.SetAuthorized("admin@example.com");
+        auth.SetRoles("admin");
+
+        _ = _anonymization.Setup(s => s.GetCandidatesAsync(It.IsAny<CancellationToken>())).ReturnsAsync([]);
+        _ = _incidents.Setup(s => s.GetIncidentsAsync(It.IsAny<CancellationToken>())).ReturnsAsync([]);
+
+        _ = Services.AddScoped(_ => _anonymization.Object);
+        _ = Services.AddScoped(_ => _incidents.Object);
+    }
+
+    [Fact]
+    public void Render_AsAdmin_ShowsDashboardHeading()
+    {
+        IRenderedComponent<GdprDashboard> cut = RenderComponent<GdprDashboard>();
+
+        cut.WaitForAssertion(() => Assert.Contains("GDPR Compliance Dashboard", cut.Markup));
+    }
+
+    [Fact]
+    public void Render_AsAdmin_ShowsAllCards()
+    {
+        IRenderedComponent<GdprDashboard> cut = RenderComponent<GdprDashboard>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Retention Settings", cut.Markup);
+            Assert.Contains("Anonymization Queue", cut.Markup);
+            Assert.Contains("Security Incidents", cut.Markup);
+            Assert.Contains("Subject Access Request", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public void Render_WithPendingCandidates_LoadsCountersFromService()
+    {
+        AnonymizationCandidateDto[] candidates =
+        [
+            new() { Status = Domain.Enums.AnonymizationStatus.Pending },
+            new() { Status = Domain.Enums.AnonymizationStatus.Pending }
+        ];
+        _ = _anonymization.Setup(s => s.GetCandidatesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(candidates);
+
+        IRenderedComponent<GdprDashboard> cut = RenderComponent<GdprDashboard>();
+
+        cut.WaitForAssertion(() =>
+            _anonymization.Verify(s => s.GetCandidatesAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce));
+    }
+}

--- a/tests/WebUI.Tests/Components/Pages/Gdpr/SecurityIncidentsPageTests.cs
+++ b/tests/WebUI.Tests/Components/Pages/Gdpr/SecurityIncidentsPageTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Bunit;
+using Bunit.TestDoubles;
+
+using Core.DTOs.Security;
+using Core.Interfaces.Services;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+
+using SecurityIncidentsPageComponent = WebUI.Client.Components.Pages.Gdpr.SecurityIncidentsPage;
+
+namespace WebUI.Tests.Components.Pages.Gdpr;
+
+/// <summary>
+/// bUnit tests for the Security Incidents admin page (UC-011).
+/// </summary>
+public class SecurityIncidentsPageTests : Bunit.TestContext
+{
+    private readonly Mock<ISecurityIncidentService> _service = new();
+
+    public SecurityIncidentsPageTests()
+    {
+        TestAuthorizationContext auth = this.AddTestAuthorization();
+        auth.SetAuthorized("admin@example.com");
+        auth.SetRoles("admin");
+
+        _ = _service.Setup(s => s.GetIncidentsAsync(It.IsAny<CancellationToken>())).ReturnsAsync([]);
+
+        _ = Services.AddScoped(_ => _service.Object);
+    }
+
+    [Fact]
+    public void Render_AsAdmin_ShowsHeading()
+    {
+        IRenderedComponent<SecurityIncidentsPageComponent> cut = RenderComponent<SecurityIncidentsPageComponent>();
+
+        cut.WaitForAssertion(() => Assert.Contains("Security Incidents", cut.Markup));
+    }
+
+    [Fact]
+    public void Render_AsAdmin_LoadsIncidentsFromService()
+    {
+        IRenderedComponent<SecurityIncidentsPageComponent> cut = RenderComponent<SecurityIncidentsPageComponent>();
+
+        cut.WaitForAssertion(() =>
+            _service.Verify(s => s.GetIncidentsAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce));
+    }
+
+    [Fact]
+    public void Render_WithIncident_ShowsIncidentType()
+    {
+        SecurityIncidentDto[] incidents = [new() { Id = Guid.NewGuid(), Type = "BruteForce" }];
+        _ = _service.Setup(s => s.GetIncidentsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(incidents);
+
+        IRenderedComponent<SecurityIncidentsPageComponent> cut = RenderComponent<SecurityIncidentsPageComponent>();
+
+        cut.WaitForAssertion(() => Assert.Contains("BruteForce", cut.Markup));
+    }
+}

--- a/tests/WebUI.Tests/Components/Pages/MedicineDeliveries/MedicineDeliveriesPageTests.cs
+++ b/tests/WebUI.Tests/Components/Pages/MedicineDeliveries/MedicineDeliveriesPageTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Bunit;
+using Bunit.TestDoubles;
+
+using Core.Interfaces.Services;
+
+using Domain.Entities;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+
+using MedicineDeliveriesPage = WebUI.Client.Components.Pages.Management.MedicineDeliveries.MedicineDeliveries;
+
+namespace WebUI.Tests.Components.Pages.MedicineDeliveries;
+
+/// <summary>
+/// bUnit tests for the Medicine Deliveries admin page (UC-020/021/022).
+/// </summary>
+public class MedicineDeliveriesPageTests : Bunit.TestContext
+{
+    private readonly Mock<IMedicineDeliveryService> _service = new();
+
+    public MedicineDeliveriesPageTests()
+    {
+        TestAuthorizationContext auth = this.AddTestAuthorization();
+        auth.SetAuthorized("admin@example.com");
+        auth.SetRoles("admin");
+
+        _ = _service.Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync([]);
+
+        _ = Services.AddScoped(_ => _service.Object);
+    }
+
+    [Fact]
+    public void Render_AsAdmin_ShowsHeading()
+    {
+        IRenderedComponent<MedicineDeliveriesPage> cut = RenderComponent<MedicineDeliveriesPage>();
+
+        cut.WaitForAssertion(() => Assert.Contains("Medicin leveringer", cut.Markup));
+    }
+
+    [Fact]
+    public void Render_AsAdmin_LoadsDeliveriesFromService()
+    {
+        IRenderedComponent<MedicineDeliveriesPage> cut = RenderComponent<MedicineDeliveriesPage>();
+
+        cut.WaitForAssertion(() =>
+            _service.Verify(s => s.GetAllAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce));
+    }
+
+    [Fact]
+    public void Render_WithDelivery_ShowsMedicineName()
+    {
+        MedicineRecord[] records =
+        [
+            new() { Id = Guid.NewGuid(), ResidentId = Guid.NewGuid(), MedicineName = "Panodil", Timestamp = DateTime.UtcNow, Given = true }
+        ];
+        _ = _service.Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(records);
+
+        IRenderedComponent<MedicineDeliveriesPage> cut = RenderComponent<MedicineDeliveriesPage>();
+
+        cut.WaitForAssertion(() => Assert.Contains("Panodil", cut.Markup));
+    }
+}


### PR DESCRIPTION
Pure unit tests (no integration, no DB, no UI) for 6 previously-untested Core services. Each covered via [Trait] across Functionality, EdgeCase (null ctor args, manager exceptions, null/empty results) and Concurrency (100 parallel Task.WhenAll calls). Core.Tests 100 to 134, all green.