### PR TITLE
test: concurrency, edge-case and functionality unit tests for Core mappers

### DIFF
--- a/tests/Core.Tests/Mappers/PainKillerMapperTests.cs
+++ b/tests/Core.Tests/Mappers/PainKillerMapperTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+using Core.Mappers;
+
+using Domain.Entities;
+
+namespace Core.Tests.Mappers;
+
+public class PainKillerMapperTests
+{
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public void ToPainkillerStatusDto_WithRecords_MapsTypesAndMaxNextAllowed()
+    {
+        Guid residentId = Guid.NewGuid();
+        DateTime later = new(2026, 5, 1, 18, 0, 0, DateTimeKind.Utc);
+        PainkillerRecord[] records =
+        [
+            new() { Type = "Paracetamol", NextAllowedTime = new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc) },
+            new() { Type = "Ibuprofen", NextAllowedTime = later }
+        ];
+
+        PainkillerStatusDto dto = PainKillerMapper.ToPainkillerStatusDto(residentId, records);
+
+        Assert.Equal(residentId, dto.ResidentId);
+        Assert.Equal(2, dto.Types.Count());
+        Assert.Equal(later, dto.NextAllowedTime);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void ToPainkillerStatusDto_EmptyRecords_UsesNowAndEmptyTypes()
+    {
+        DateTime before = DateTime.UtcNow;
+
+        PainkillerStatusDto dto = PainKillerMapper.ToPainkillerStatusDto(Guid.NewGuid(), []);
+
+        Assert.Empty(dto.Types);
+        Assert.InRange(dto.NextAllowedTime, before.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void ToPainkillerStatusDto_NullRecords_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => PainKillerMapper.ToPainkillerStatusDto(Guid.NewGuid(), null!));
+
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public void ToPainkillerStatusDto_ParallelMapping_IsThreadSafe()
+    {
+        Guid residentId = Guid.NewGuid();
+        PainkillerRecord[] records = [new() { Type = "Paracetamol", NextAllowedTime = DateTime.UtcNow }];
+
+        PainkillerStatusDto[] results = Enumerable.Range(0, 200).AsParallel()
+            .Select(_ => PainKillerMapper.ToPainkillerStatusDto(residentId, records)).ToArray();
+
+        Assert.All(results, r => Assert.Equal(residentId, r.ResidentId));
+    }
+}

--- a/tests/Core.Tests/Mappers/PhoneAssignmentMapperTests.cs
+++ b/tests/Core.Tests/Mappers/PhoneAssignmentMapperTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+using Core.Mappers;
+
+using Domain.Entities;
+
+namespace Core.Tests.Mappers;
+
+public class PhoneAssignmentMapperTests
+{
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public void ToDto_MapsPhoneNumberAndShift()
+    {
+        PhoneAssignment entity = new() { PhoneNumber = "12345678", ShiftType = "Day" };
+
+        PhoneAssignmentDto dto = PhoneAssignmentMapper.ToDto(entity);
+
+        Assert.Equal("12345678", dto.PhoneNumber);
+        Assert.Equal("Day", dto.ShiftType);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public void ToDtos_MapsCollection()
+    {
+        PhoneAssignment[] entities =
+        [
+            new() { PhoneNumber = "111", ShiftType = "Day" },
+            new() { PhoneNumber = "222", ShiftType = "Night" }
+        ];
+
+        List<PhoneAssignmentDto> dtos = PhoneAssignmentMapper.ToDtos(entities).ToList();
+
+        Assert.Equal(2, dtos.Count);
+        Assert.Equal("222", dtos[1].PhoneNumber);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void ToDtos_Empty_ReturnsEmpty()
+    {
+        List<PhoneAssignmentDto> dtos = PhoneAssignmentMapper.ToDtos([]).ToList();
+
+        Assert.Empty(dtos);
+    }
+
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public void ToDto_ParallelMapping_IsThreadSafe()
+    {
+        PhoneAssignment entity = new() { PhoneNumber = "999", ShiftType = "Evening" };
+
+        PhoneAssignmentDto[] results = Enumerable.Range(0, 200).AsParallel().Select(_ => PhoneAssignmentMapper.ToDto(entity)).ToArray();
+
+        Assert.All(results, r => Assert.Equal("999", r.PhoneNumber));
+    }
+}

--- a/tests/Core.Tests/Mappers/ResidentNoteMapperTests.cs
+++ b/tests/Core.Tests/Mappers/ResidentNoteMapperTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs;
+using Core.Mappers;
+
+using Domain.Entities;
+
+namespace Core.Tests.Mappers;
+
+public class ResidentNoteMapperTests
+{
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public void ToDto_MapsFields()
+    {
+        DateTime edited = new(2026, 5, 9, 10, 0, 0, DateTimeKind.Utc);
+        ResidentNote entity = new() { Id = Guid.NewGuid(), Note = "obs", EditedAt = edited, ResidentId = Guid.NewGuid() };
+
+        ResidentNoteDto dto = ResidentNoteMapper.ToDto(entity);
+
+        Assert.Equal(entity.Id, dto.Id);
+        Assert.Equal("obs", dto.Note);
+        Assert.Equal(edited, dto.Timestamp);
+        Assert.Equal(string.Empty, dto.Initials);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void ToDto_NullEntity_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => ResidentNoteMapper.ToDto(null!));
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public void ToDtos_MapsCollection()
+    {
+        ResidentNote[] entities = [new() { Note = "a" }, new() { Note = "b" }];
+
+        List<ResidentNoteDto> dtos = ResidentNoteMapper.ToDtos(entities).ToList();
+
+        Assert.Equal(2, dtos.Count);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void ToDtos_Null_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => ResidentNoteMapper.ToDtos(null!).ToList());
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public void ToNewEntity_SetsFieldsAndGeneratesId()
+    {
+        Guid residentId = Guid.NewGuid();
+
+        ResidentNote entity = ResidentNoteMapper.ToNewEntity(residentId, "note");
+
+        Assert.NotEqual(Guid.Empty, entity.Id);
+        Assert.Equal(residentId, entity.ResidentId);
+        Assert.Equal("note", entity.Note);
+    }
+
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public void ToDto_ParallelMapping_IsThreadSafe()
+    {
+        ResidentNote entity = new() { Id = Guid.NewGuid(), Note = "x", EditedAt = DateTime.UtcNow };
+
+        ResidentNoteDto[] results = Enumerable.Range(0, 200).AsParallel().Select(_ => ResidentNoteMapper.ToDto(entity)).ToArray();
+
+        Assert.All(results, r => Assert.Equal(entity.Id, r.Id));
+    }
+}

--- a/tests/Core.Tests/Mappers/RetentionPolicyMapperTests.cs
+++ b/tests/Core.Tests/Mappers/RetentionPolicyMapperTests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Retention;
+using Core.Mappers;
+
+using Domain.Entities;
+using Domain.Enums;
+
+namespace Core.Tests.Mappers;
+
+public class RetentionPolicyMapperTests
+{
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public void ToDto_MapsFields()
+    {
+        RetentionPolicy entity = new()
+        {
+            Id = Guid.NewGuid(),
+            Category = RetentionDataCategory.MedicineLogs,
+            RetentionPeriod = TimeSpan.FromDays(365),
+            LegalMinimum = TimeSpan.FromDays(30),
+            EffectiveFrom = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        RetentionPolicyDto dto = RetentionPolicyMapper.ToDto(entity);
+
+        Assert.Equal(entity.Id, dto.Id);
+        Assert.Equal(RetentionDataCategory.MedicineLogs, dto.Category);
+        Assert.Equal(TimeSpan.FromDays(365), dto.RetentionPeriod);
+        Assert.Equal(TimeSpan.FromDays(30), dto.LegalMinimum);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public void ToAuditDto_MapsFields()
+    {
+        RetentionPolicyAudit entity = new()
+        {
+            Id = Guid.NewGuid(),
+            RetentionPolicyId = Guid.NewGuid(),
+            ChangedByEmployeeId = Guid.NewGuid(),
+            PreviousPeriod = TimeSpan.FromDays(30),
+            NewPeriod = TimeSpan.FromDays(60),
+            ChangedAt = DateTime.UtcNow,
+            Reason = "review"
+        };
+
+        RetentionPolicyAuditDto dto = RetentionPolicyMapper.ToAuditDto(entity);
+
+        Assert.Equal(entity.Id, dto.Id);
+        Assert.Equal(TimeSpan.FromDays(30), dto.PreviousPeriod);
+        Assert.Equal(TimeSpan.FromDays(60), dto.NewPeriod);
+        Assert.Equal("review", dto.Reason);
+    }
+
+    [Theory]
+    [Trait("Category", "EdgeCase")]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(3650)]
+    public void ToDto_AnyRetentionPeriod_RoundTrips(int days)
+    {
+        RetentionPolicy entity = new() { RetentionPeriod = TimeSpan.FromDays(days), Category = RetentionDataCategory.AuditLogs };
+
+        RetentionPolicyDto dto = RetentionPolicyMapper.ToDto(entity);
+
+        Assert.Equal(TimeSpan.FromDays(days), dto.RetentionPeriod);
+    }
+
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public void ToDto_ParallelMapping_IsThreadSafe()
+    {
+        RetentionPolicy entity = new() { Id = Guid.NewGuid(), Category = RetentionDataCategory.LoginLogs };
+
+        RetentionPolicyDto[] results = Enumerable.Range(0, 200).AsParallel().Select(_ => RetentionPolicyMapper.ToDto(entity)).ToArray();
+
+        Assert.All(results, r => Assert.Equal(entity.Id, r.Id));
+    }
+}

--- a/tests/Core.Tests/Mappers/SarExportMapperTests.cs
+++ b/tests/Core.Tests/Mappers/SarExportMapperTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Sar;
+using Core.Mappers;
+
+namespace Core.Tests.Mappers;
+
+public class SarExportMapperTests
+{
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public void ToPackageDto_ThreeArgs_MapsMetadata()
+    {
+        Guid id = Guid.NewGuid();
+        DateTime now = DateTime.UtcNow;
+
+        SarExportPackageDto dto = SarExportMapper.ToPackageDto(id, now, "f.json");
+
+        Assert.Equal(id, dto.ExportId);
+        Assert.Equal(now, dto.GeneratedAt);
+        Assert.Equal("f.json", dto.FileName);
+    }
+
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public void ToPackageDto_WithPayload_MapsPayload()
+    {
+        Guid id = Guid.NewGuid();
+
+        SarExportPackageDto dto = SarExportMapper.ToPackageDto(id, DateTime.UtcNow, "f.json", "{\"k\":1}");
+
+        Assert.Equal("{\"k\":1}", dto.Payload);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void ToPackageDto_EmptyFileName_Maps()
+    {
+        SarExportPackageDto dto = SarExportMapper.ToPackageDto(Guid.NewGuid(), DateTime.UtcNow, string.Empty);
+
+        Assert.Equal(string.Empty, dto.FileName);
+    }
+
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public void ToPackageDto_ParallelMapping_IsThreadSafe()
+    {
+        Guid id = Guid.NewGuid();
+
+        SarExportPackageDto[] results = Enumerable.Range(0, 200).AsParallel()
+            .Select(_ => SarExportMapper.ToPackageDto(id, DateTime.UtcNow, "f.json")).ToArray();
+
+        Assert.All(results, r => Assert.Equal(id, r.ExportId));
+    }
+}

--- a/tests/Core.Tests/Mappers/SecurityIncidentMapperTests.cs
+++ b/tests/Core.Tests/Mappers/SecurityIncidentMapperTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Core.DTOs.Security;
+using Core.Mappers;
+
+using Domain.Entities;
+
+namespace Core.Tests.Mappers;
+
+public class SecurityIncidentMapperTests
+{
+    [Fact]
+    [Trait("Category", "Functionality")]
+    public void ToDto_MapsFields()
+    {
+        SecurityIncident entity = new()
+        {
+            Id = Guid.NewGuid(),
+            DetectedAt = new DateTime(2026, 5, 1, 8, 0, 0, DateTimeKind.Utc),
+            Type = "BruteForce",
+            InvestigationNotes = "looking"
+        };
+
+        SecurityIncidentDto dto = SecurityIncidentMapper.ToDto(entity);
+
+        Assert.Equal(entity.Id, dto.Id);
+        Assert.Equal("BruteForce", dto.Type);
+        Assert.Equal("looking", dto.InvestigationNotes);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void ToDto_DeadlineIs72HoursAfterDetection()
+    {
+        DateTime detected = new(2026, 5, 1, 8, 0, 0, DateTimeKind.Utc);
+        SecurityIncident entity = new() { DetectedAt = detected, Type = "X" };
+
+        SecurityIncidentDto dto = SecurityIncidentMapper.ToDto(entity);
+
+        Assert.Equal(detected.AddHours(72), dto.BreachNotificationDeadlineUtc);
+    }
+
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public void ToDto_ParallelMapping_IsThreadSafe()
+    {
+        SecurityIncident entity = new() { Id = Guid.NewGuid(), DetectedAt = DateTime.UtcNow, Type = "X" };
+
+        SecurityIncidentDto[] results = Enumerable.Range(0, 200).AsParallel().Select(_ => SecurityIncidentMapper.ToDto(entity)).ToArray();
+
+        Assert.All(results, r => Assert.Equal(entity.Id, r.Id));
+    }
+}


### PR DESCRIPTION
Pure unit tests for 6 previously-untested Core mappers: ResidentNote, RetentionPolicy, SarExport, SecurityIncident, PainKiller, PhoneAssignment. Each covered via [Trait] across Functionality (field mapping), EdgeCase (null guards, empty collections, 72h breach deadline) and Concurrency (parallel mapping). Core.Tests 100 to 127, all green.