### PR TITLE
test: Blazor bUnit page and component tests

### DIFF
--- a/tests/WebUI.Tests/Components/Nav/NavItemDashboardTests.cs
+++ b/tests/WebUI.Tests/Components/Nav/NavItemDashboardTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Bunit;
+using Bunit.TestDoubles;
+
+using Component = WebUI.Client.Components.NavItemDashboard;
+
+namespace WebUI.Tests.Components.Nav;
+
+public class NavItemDashboardTests : Bunit.TestContext
+{
+    [Fact]
+    public void Render_WhenAuthenticated_RendersWithoutError()
+    {
+        TestAuthorizationContext auth = this.AddTestAuthorization();
+        auth.SetAuthorized("admin@example.com");
+        auth.SetRoles("admin");
+
+        IRenderedComponent<Component> cut = RenderComponent<Component>();
+
+        Assert.NotNull(cut);
+    }
+
+    [Fact]
+    public void Render_WhenNotAuthenticated_RendersWithoutError()
+    {
+        TestAuthorizationContext auth = this.AddTestAuthorization();
+        auth.SetNotAuthorized();
+
+        IRenderedComponent<Component> cut = RenderComponent<Component>();
+
+        Assert.NotNull(cut);
+    }
+}

--- a/tests/WebUI.Tests/Components/Pages/Gdpr/AnonymizationQueuePageTests.cs
+++ b/tests/WebUI.Tests/Components/Pages/Gdpr/AnonymizationQueuePageTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Bunit;
+using Bunit.TestDoubles;
+
+using Core.Interfaces.Services;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+
+using Page = WebUI.Client.Components.Pages.Gdpr.AnonymizationQueuePage;
+
+namespace WebUI.Tests.Components.Pages.Gdpr;
+
+public class AnonymizationQueuePageTests : Bunit.TestContext
+{
+    private readonly Mock<IAnonymizationService> _service = new();
+
+    public AnonymizationQueuePageTests()
+    {
+        TestAuthorizationContext auth = this.AddTestAuthorization();
+        auth.SetAuthorized("admin@example.com");
+        auth.SetRoles("admin");
+        _ = _service.Setup(s => s.GetCandidatesAsync(It.IsAny<CancellationToken>())).ReturnsAsync([]);
+        _ = Services.AddScoped(_ => _service.Object);
+    }
+
+    [Fact]
+    public void Render_AsAdmin_ShowsHeading()
+    {
+        IRenderedComponent<Page> cut = RenderComponent<Page>();
+        cut.WaitForAssertion(() => Assert.Contains("Anonymization Queue", cut.Markup));
+    }
+
+    [Fact]
+    public void Render_AsAdmin_LoadsCandidates()
+    {
+        IRenderedComponent<Page> cut = RenderComponent<Page>();
+        cut.WaitForAssertion(() => _service.Verify(s => s.GetCandidatesAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce));
+    }
+}

--- a/tests/WebUI.Tests/Components/Pages/Gdpr/RetentionSettingsPageTests.cs
+++ b/tests/WebUI.Tests/Components/Pages/Gdpr/RetentionSettingsPageTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Bunit;
+using Bunit.TestDoubles;
+
+using Core.Interfaces.Services;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+
+using Page = WebUI.Client.Components.Pages.Gdpr.RetentionSettingsPage;
+
+namespace WebUI.Tests.Components.Pages.Gdpr;
+
+public class RetentionSettingsPageTests : Bunit.TestContext
+{
+    private readonly Mock<IRetentionPolicyService> _service = new();
+
+    public RetentionSettingsPageTests()
+    {
+        TestAuthorizationContext auth = this.AddTestAuthorization();
+        auth.SetAuthorized("admin@example.com");
+        auth.SetRoles("admin");
+        _ = _service.Setup(s => s.GetPoliciesAsync(It.IsAny<CancellationToken>())).ReturnsAsync([]);
+        _ = Services.AddScoped(_ => _service.Object);
+    }
+
+    [Fact]
+    public void Render_AsAdmin_ShowsHeading()
+    {
+        IRenderedComponent<Page> cut = RenderComponent<Page>();
+        cut.WaitForAssertion(() => Assert.Contains("Retention Settings", cut.Markup));
+    }
+
+    [Fact]
+    public void Render_AsAdmin_LoadsPolicies()
+    {
+        IRenderedComponent<Page> cut = RenderComponent<Page>();
+        cut.WaitForAssertion(() => _service.Verify(s => s.GetPoliciesAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce));
+    }
+}

--- a/tests/WebUI.Tests/Components/Pages/Gdpr/SubjectAccessRequestPageTests.cs
+++ b/tests/WebUI.Tests/Components/Pages/Gdpr/SubjectAccessRequestPageTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Bunit;
+using Bunit.TestDoubles;
+
+using Core.Interfaces.Services;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+
+using Page = WebUI.Client.Components.Pages.Gdpr.SubjectAccessRequestPage;
+
+namespace WebUI.Tests.Components.Pages.Gdpr;
+
+public class SubjectAccessRequestPageTests : Bunit.TestContext
+{
+    private readonly Mock<ISubjectAccessRequestService> _service = new();
+
+    public SubjectAccessRequestPageTests()
+    {
+        TestAuthorizationContext auth = this.AddTestAuthorization();
+        auth.SetAuthorized("admin@example.com");
+        auth.SetRoles("admin");
+        _ = Services.AddScoped(_ => _service.Object);
+    }
+
+    [Fact]
+    public void Render_AsAdmin_ShowsHeading()
+    {
+        IRenderedComponent<Page> cut = RenderComponent<Page>();
+        cut.WaitForAssertion(() => Assert.Contains("Subject Access Request", cut.Markup));
+    }
+}

--- a/tests/WebUI.Tests/Components/Pages/Management/ResidentsPageTests.cs
+++ b/tests/WebUI.Tests/Components/Pages/Management/ResidentsPageTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Bunit;
+using Bunit.TestDoubles;
+
+using Core.Interfaces.Services;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+
+using Page = WebUI.Client.Components.Pages.Management.Residents.Residents;
+
+namespace WebUI.Tests.Components.Pages.Management;
+
+public class ResidentsPageTests : Bunit.TestContext
+{
+    private readonly Mock<IResidentService> _service = new();
+
+    public ResidentsPageTests()
+    {
+        TestAuthorizationContext auth = this.AddTestAuthorization();
+        auth.SetAuthorized("admin@example.com");
+        auth.SetRoles("admin");
+        _ = _service.Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync([]);
+        _ = Services.AddScoped(_ => _service.Object);
+    }
+
+    [Fact]
+    public void Render_AsAdmin_ShowsHeading()
+    {
+        IRenderedComponent<Page> cut = RenderComponent<Page>();
+        cut.WaitForAssertion(() => Assert.Contains("Beboere", cut.Markup));
+    }
+
+    [Fact]
+    public void Render_AsAdmin_LoadsResidents()
+    {
+        IRenderedComponent<Page> cut = RenderComponent<Page>();
+        cut.WaitForAssertion(() => _service.Verify(s => s.GetAllAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce));
+    }
+}

--- a/tests/WebUI.Tests/Components/Pages/StaffAssignments/StaffAssignmentsPageTests.cs
+++ b/tests/WebUI.Tests/Components/Pages/StaffAssignments/StaffAssignmentsPageTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using System.Net;
+using System.Text;
+
+using Bunit;
+using Bunit.TestDoubles;
+
+using Core.Interfaces.Services;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+using Moq.Protected;
+
+using Page = WebUI.Client.Components.Pages.StaffAssignments.StaffAssignments;
+
+namespace WebUI.Tests.Components.Pages.StaffAssignments;
+
+public class StaffAssignmentsPageTests : Bunit.TestContext
+{
+    private readonly Mock<IResidentService> _residents = new();
+    private readonly Mock<IHttpClientFactory> _factory = new();
+
+    public StaffAssignmentsPageTests()
+    {
+        TestAuthorizationContext auth = this.AddTestAuthorization();
+        auth.SetAuthorized("admin@example.com");
+        auth.SetRoles("admin");
+
+        Mock<HttpMessageHandler> handler = new();
+        _ = handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]", Encoding.UTF8, "application/json")
+            });
+        HttpClient client = new(handler.Object) { BaseAddress = new Uri("http://localhost/") };
+        _ = _factory.Setup(f => f.CreateClient("SlottetApi")).Returns(client);
+        _ = _factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+        _ = _residents.Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync([]);
+
+        _ = Services.AddScoped(_ => _residents.Object);
+        _ = Services.AddScoped(_ => _factory.Object);
+    }
+
+    [Fact]
+    public void Render_ShowsHeading()
+    {
+        IRenderedComponent<Page> cut = RenderComponent<Page>();
+        cut.WaitForAssertion(() => Assert.Contains("Staff Assignments", cut.Markup));
+    }
+}

--- a/tests/WebUI.Tests/Components/Residents/PainkillerStatusTests.cs
+++ b/tests/WebUI.Tests/Components/Residents/PainkillerStatusTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Bunit;
+
+using Core.DTOs;
+
+using Component = WebUI.Client.Components.Residents.PainkillerStatus;
+
+namespace WebUI.Tests.Components.Residents;
+
+public class PainkillerStatusTests : Bunit.TestContext
+{
+    [Fact]
+    public void Render_WithStatus_RendersWithoutError()
+    {
+        PainkillerStatusDto status = new() { ResidentId = Guid.NewGuid(), Types = ["Paracetamol"], NextAllowedTime = DateTime.UtcNow.AddHours(2) };
+
+        IRenderedComponent<Component> cut = RenderComponent<Component>(p => p.Add(c => c.Status, status));
+
+        Assert.NotNull(cut);
+    }
+
+    [Fact]
+    public void Render_WithNullStatus_RendersWithoutError()
+    {
+        IRenderedComponent<Component> cut = RenderComponent<Component>(p => p.Add(c => c.Status, (PainkillerStatusDto?)null));
+
+        Assert.NotNull(cut);
+    }
+}

--- a/tests/WebUI.Tests/Components/Residents/ResidentCardExtraTests.cs
+++ b/tests/WebUI.Tests/Components/Residents/ResidentCardExtraTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Team6. All rights reserved.
+// No warranty, explicit or implicit, provided.
+
+using Bunit;
+using Bunit.TestDoubles;
+
+using Core.DTOs;
+using Core.Interfaces.Services;
+
+using Domain.Entities;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+
+using Component = WebUI.Client.Components.Residents.ResidentCard;
+
+namespace WebUI.Tests.Components.Residents;
+
+public class ResidentCardExtraTests : Bunit.TestContext
+{
+    private readonly Mock<IResidentNoteService> _notes = new();
+    private readonly Mock<IMedicineStatusService> _medicine = new();
+
+    public ResidentCardExtraTests()
+    {
+        TestAuthorizationContext auth = this.AddTestAuthorization();
+        auth.SetAuthorized("admin@example.com");
+        auth.SetRoles("admin");
+
+        _ = _notes.Setup(s => s.GetAllByResidentIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync([]);
+        _ = _medicine.Setup(s => s.GetMedicineStatusAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new MedicineStatusDto());
+        _ = _medicine.Setup(s => s.GetPainkillerStatusAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PainkillerStatusDto());
+
+        _ = Services.AddScoped(_ => _notes.Object);
+        _ = Services.AddScoped(_ => _medicine.Object);
+    }
+
+    [Fact]
+    public void Render_WithResident_ShowsInitials()
+    {
+        Resident resident = new() { Id = Guid.NewGuid(), Initials = "Q:WW" };
+
+        IRenderedComponent<Component> cut = RenderComponent<Component>(p => p.Add(c => c.Resident, resident));
+
+        cut.WaitForAssertion(() => Assert.Contains("Q:WW", cut.Markup));
+    }
+
+    [Fact]
+    public void Render_WithResident_LoadsMedicineStatus()
+    {
+        Resident resident = new() { Id = Guid.NewGuid(), Initials = "AB" };
+
+        IRenderedComponent<Component> cut = RenderComponent<Component>(p => p.Add(c => c.Resident, resident));
+
+        cut.WaitForAssertion(() =>
+            _medicine.Verify(s => s.GetMedicineStatusAsync(resident.Id, It.IsAny<CancellationToken>()), Times.AtLeastOnce));
+    }
+}


### PR DESCRIPTION
bUnit render/data-load tests for AnonymizationQueue, RetentionSettings, SubjectAccessRequest, Residents and StaffAssignments pages, plus NavItemDashboard, ResidentCard and PainkillerStatus components. AddTestAuthorization + mocked services. All green.